### PR TITLE
Add prompt for user/pass on registry login

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ IMAGE_TAGS=regctl
 IMAGES=$(addprefix docker-,$(IMAGE_TAGS))
 GO_BUILD_FLAGS=
 
-.PHONY: all binaries docker test .FORCE
+.PHONY: all binaries vendor docker test .FORCE
 
 .FORCE:
 
@@ -13,10 +13,13 @@ all: test binaries
 test:
 	go test ./...
 
-binaries: $(BINARIES)
+binaries: vendor $(BINARIES)
 
 bin/regctl: .FORCE
 	go build ${GO_BUILD_FLAGS} -o bin/regctl ./cmd/regctl
+
+vendor:
+	go mod vendor
 
 docker: $(IMAGES)
 

--- a/cmd/regctl/error.go
+++ b/cmd/regctl/error.go
@@ -5,6 +5,8 @@ import "errors"
 var (
 	// ErrCredsNotFound returned when creds needed and cannot be found
 	ErrCredsNotFound = errors.New("Auth creds not found")
+	// ErrMissingInput indicates a required field is missing
+	ErrMissingInput = errors.New("Required input missing")
 	// ErrNotImplemented returned when method has not been implemented yet
 	// TODO: Delete when all methods are implemented
 	ErrNotImplemented = errors.New("Not implemented")

--- a/cmd/regctl/main.go
+++ b/cmd/regctl/main.go
@@ -6,5 +6,6 @@ import (
 
 func main() {
 	regclient.ConfigDir = ".regctl"
+	regclient.ConfigEnv = "REGCLI_CONFIG"
 	Execute()
 }

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/sirupsen/logrus v1.6.0
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5 // indirect
+	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 	golang.org/x/net v0.0.0-20200707034311-ab3426394381 // indirect
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208 // indirect
 	golang.org/x/sys v0.0.0-20200915084602-288bc346aa39 // indirect

--- a/go.sum
+++ b/go.sum
@@ -191,6 +191,7 @@ go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 golang.org/x/crypto v0.0.0-20171113213409-9f005a07e0d3/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/regclient/config.go
+++ b/regclient/config.go
@@ -17,6 +17,8 @@ var (
 	ConfigFilename = "config.json"
 	// ConfigDir is the default directory within the user's home directory to read/write configuration
 	ConfigDir = ".regclient"
+	// ConfigEnv is the environment variable to override the config filename
+	ConfigEnv = "REGCLIENT_CONFIG"
 )
 
 type tlsConf int
@@ -99,7 +101,7 @@ type ConfigHost struct {
 
 // getConfigFilename returns the filename based on environment variables and defaults
 func getConfigFilename() string {
-	cf := os.Getenv("REGCLI_CONFIG")
+	cf := os.Getenv(ConfigEnv)
 	if cf == "" {
 		return filepath.Join(getHomeDir(), ConfigDir, ConfigFilename)
 	}


### PR DESCRIPTION
This adds a prompt for the password without echoing out to the screen (tested in Linux). Also included:

- Makefile now includes a `go mod vendor` since I ran into issues adding another dependency.
- Environment variable in regclient is no longer regctl specific and can be configured.
- Username can be blank/unset and the previous username will be reused.