### PR TITLE
Adding docker CLI plugin wrapper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ IMAGE_TAGS=regctl
 IMAGES=$(addprefix docker-,$(IMAGE_TAGS))
 GO_BUILD_FLAGS=
 
-.PHONY: all binaries vendor docker test .FORCE
+.PHONY: all binaries vendor docker test plugin-user plugin-host .FORCE
 
 .FORCE:
 
@@ -25,3 +25,10 @@ docker: $(IMAGES)
 
 docker-regctl:
 	docker build -t regclient/regctl -f build/Dockerfile.regctl .
+
+plugin-user:
+	mkdir -p ${HOME}/.docker/cli-plugins/
+	cp docker-plugin/docker-regclient ${HOME}/.docker/cli-plugins/docker-regctl
+
+plugin-host:
+	sudo cp docker-plugin/docker-regclient /usr/libexec/docker/cli-plugins/docker-regctl

--- a/README.md
+++ b/README.md
@@ -86,6 +86,35 @@ chmod 755 regctl
 ./regctl --help
 ```
 
+## Installing as a Docker CLI Plugin
+
+To install this as a docker CLI plugin:
+
+```shell
+make plugin-user # install for the current user
+make plugin-host # install for all users on the host (requires sudo)
+```
+
+Once installed as a plugin, you can access it from the docker CLI:
+
+```shell
+$ docker regctl --help
+Utility for accessing docker registries
+More details at https://github.com/regclient/regclient
+
+Usage:
+  regctl <cmd> [flags]
+  regctl [command]
+
+Available Commands:
+  help        Help about any command
+  image       manage images
+  layer       manage image layers/blobs
+  registry    manage registries
+  tag         manage tags
+...
+```
+
 ## Usage
 
 See the [project documentation](docs/README.md).

--- a/docker-plugin/docker-regclient
+++ b/docker-plugin/docker-regclient
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+docker_cli_plugin_metadata() {
+  vendor="regclient"
+  version="0.1"
+  url="https://github.com/regclient/regclient"
+  description="Manage docker registries"
+  cat <<-EOF
+  {"SchemaVersion":"0.1.0","Vendor":"${vendor}","Version":"${version}","ShortDescription":"${description}","URL":"${url}"}
+EOF
+}
+
+case "$1" in
+  docker-cli-plugin-metadata)
+    docker_cli_plugin_metadata
+    ;;
+
+  regctl|*)
+    shift # remove command name from first arg
+    if [ -x "$(command -v regctl)" ]; then
+      regctl "$@"
+    else
+      docker container run -it --rm --net host \
+        -u "$(id -u):$(id -g)" -e HOME -v $HOME:$HOME \
+        -v /etc/docker/certs.d:/etc/docker/certs.d:ro \
+        regclient/regctl:latest "$@"
+    fi
+    ;;
+esac


### PR DESCRIPTION
This adds a small wrapper script so regctl can be called as a docker CLI plugin.