### PR TITLE
Adding manifest HEAD request support

### DIFF
--- a/regclient/error.go
+++ b/regclient/error.go
@@ -17,6 +17,8 @@ var (
 	ErrNotImplemented = errors.New("Not implemented")
 	// ErrParsingFailed when a string cannot be parsed
 	ErrParsingFailed = errors.New("Parsing failed")
+	// ErrUnavailable when a requested value is not available
+	ErrUnavailable = errors.New("Unavailable")
 	// ErrUnsupportedMediaType returned when media type is unknown or unsupported
 	ErrUnsupportedMediaType = errors.New("Unsupported media type")
 )

--- a/regclient/regclient.go
+++ b/regclient/regclient.go
@@ -19,7 +19,6 @@ import (
 	dockerManifestList "github.com/docker/distribution/manifest/manifestlist"
 	dockerSchema2 "github.com/docker/distribution/manifest/schema2"
 	"github.com/docker/distribution/reference"
-	digest "github.com/opencontainers/go-digest"
 	ociv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/regclient/regclient/pkg/auth"
 	"github.com/regclient/regclient/pkg/retryable"
@@ -60,8 +59,9 @@ type RegClient interface {
 	ImageExport(ctx context.Context, ref Ref, outStream io.Writer) error
 	ImageGetConfig(ctx context.Context, ref Ref, d string) (ociv1.Image, error)
 	ManifestDelete(ctx context.Context, ref Ref) error
-	ManifestDigest(ctx context.Context, ref Ref) (digest.Digest, error)
+	// ManifestDigest(ctx context.Context, ref Ref) (digest.Digest, error)
 	ManifestGet(ctx context.Context, ref Ref) (Manifest, error)
+	ManifestHead(ctx context.Context, ref Ref) (Manifest, error)
 	TagDelete(ctx context.Context, ref Ref) error
 	TagsList(ctx context.Context, ref Ref) (TagList, error)
 }

--- a/regclient/tag.go
+++ b/regclient/tag.go
@@ -81,6 +81,7 @@ func (rc *regClient) TagDelete(ctx context.Context, ref Ref) error {
 	m := manifest{
 		digest:   manfDigest,
 		dockerM:  manf,
+		manifSet: true,
 		mt:       MediaTypeDocker2Manifest,
 		origByte: manfB,
 	}


### PR DESCRIPTION
Adding support for HEAD requests when pulling the manifest digest avoids hitting the rate limited APIs on Docker Hub.