### PR TITLE
Various concurrency fixes

### DIFF
--- a/cmd/regctl/template.go
+++ b/cmd/regctl/template.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"strings"
 	"text/template"
+	"time"
 )
 
 var tmplFuncs = template.FuncMap{
@@ -29,6 +30,7 @@ var tmplFuncs = template.FuncMap{
 	"title": strings.Title,
 	"lower": strings.ToLower,
 	"upper": strings.ToUpper,
+	"time":  TimeFunc,
 }
 
 func templateRun(out io.Writer, tmpl string, data interface{}) error {
@@ -37,4 +39,22 @@ func templateRun(out io.Writer, tmpl string, data interface{}) error {
 		return err
 	}
 	return t.Execute(out, data)
+}
+
+// TimeFunc provides the "time" template, returning a struct with methods
+func TimeFunc() *TimeFuncs {
+	return &TimeFuncs{}
+}
+
+// TimeFuncs wraps all time based templates
+type TimeFuncs struct{}
+
+// Now returns current time
+func (t *TimeFuncs) Now() time.Time {
+	return time.Now()
+}
+
+// Parse parses the current time according to layout
+func (t *TimeFuncs) Parse(layout string, value string) (time.Time, error) {
+	return time.Parse(layout, value)
 }

--- a/pkg/auth/error.go
+++ b/pkg/auth/error.go
@@ -3,6 +3,8 @@ package auth
 import "errors"
 
 var (
+	// ErrEmptyChallenge indicates an issue with the received challenge in the WWW-Authenticate header
+	ErrEmptyChallenge = errors.New("Empty challenge header")
 	// ErrInvalidChallenge indicates an issue with the received challenge in the WWW-Authenticate header
 	ErrInvalidChallenge = errors.New("Invalid challenge header")
 	// ErrNoNewChallenge indicates a challenge update did not result in any change

--- a/regclient/image.go
+++ b/regclient/image.go
@@ -25,6 +25,7 @@ func (rc *regClient) ImageCopy(ctx context.Context, refSrc Ref, refTgt Ref) erro
 		rc.log.WithFields(logrus.Fields{
 			"source": refSrc.Reference,
 			"target": refTgt.Reference,
+			"digest": msh.GetDigest().String(),
 		}).Info("Copy not needed, target already up to date")
 		return nil
 	}
@@ -79,6 +80,8 @@ func (rc *regClient) ImageCopy(ctx context.Context, refSrc Ref, refTgt Ref) erro
 			return err
 		}
 		rc.log.WithFields(logrus.Fields{
+			"source": refSrc.Reference,
+			"target": refTgt.Reference,
 			"digest": cd.String(),
 		}).Info("Copy config")
 		if err := rc.BlobCopy(ctx, refSrc, refTgt, cd.String()); err != nil {
@@ -98,7 +101,9 @@ func (rc *regClient) ImageCopy(ctx context.Context, refSrc Ref, refTgt Ref) erro
 		}
 		for _, layerSrc := range l {
 			rc.log.WithFields(logrus.Fields{
-				"layer": layerSrc.Digest.String(),
+				"source": refSrc.Reference,
+				"target": refTgt.Reference,
+				"layer":  layerSrc.Digest.String(),
 			}).Info("Copy layer")
 			if err := rc.BlobCopy(ctx, refSrc, refTgt, layerSrc.Digest.String()); err != nil {
 				rc.log.WithFields(logrus.Fields{


### PR DESCRIPTION
- Template adds time functions
- Auth handles a race condition where two requests both see auth request
and second request would fail thinking auth already attempted.
- Retryable passes context to http request to allow cancel.
- Retryable checkResp is cleaned up for better logging.
- Image copy shows source and target in debug logs.
- regclient checks for docker.io in hostname.
- regclient locks before modifying hash of shared objects