### PR TITLE
More regsync templates, bugfixes, and cleanup

### DIFF
--- a/cmd/regctl/template.go
+++ b/cmd/regctl/template.go
@@ -4,12 +4,32 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
+	"io/ioutil"
+	"os"
+	"reflect"
 	"strings"
 	"text/template"
 	"time"
 )
 
 var tmplFuncs = template.FuncMap{
+	"default": func(def, orig interface{}) interface{} {
+		if orig == nil || orig == reflect.Zero(reflect.TypeOf(orig)).Interface() {
+			return def
+		}
+		return orig
+	},
+	"env": func(key string) string {
+		return os.Getenv(key)
+	},
+	"file": func(filename string) string {
+		b, err := ioutil.ReadFile(filename)
+		if err != nil {
+			return ""
+		}
+		return strings.TrimSpace(string(b))
+	},
+	"join": strings.Join,
 	"json": func(v interface{}) string {
 		buf := &bytes.Buffer{}
 		enc := json.NewEncoder(buf)
@@ -25,12 +45,11 @@ var tmplFuncs = template.FuncMap{
 		enc.Encode(v)
 		return buf.String()
 	},
-	"split": strings.Split,
-	"join":  strings.Join,
-	"title": strings.Title,
 	"lower": strings.ToLower,
-	"upper": strings.ToUpper,
+	"split": strings.Split,
 	"time":  TimeFunc,
+	"title": strings.Title,
+	"upper": strings.ToUpper,
 }
 
 func templateRun(out io.Writer, tmpl string, data interface{}) error {

--- a/cmd/regsync/template.go
+++ b/cmd/regsync/template.go
@@ -5,11 +5,31 @@ import (
 	"encoding/json"
 	"html/template"
 	"io"
+	"io/ioutil"
+	"os"
+	"reflect"
 	"strings"
 	"time"
 )
 
 var tmplFuncs = template.FuncMap{
+	"default": func(def, orig interface{}) interface{} {
+		if orig == nil || orig == reflect.Zero(reflect.TypeOf(orig)).Interface() {
+			return def
+		}
+		return orig
+	},
+	"env": func(key string) string {
+		return os.Getenv(key)
+	},
+	"file": func(filename string) string {
+		b, err := ioutil.ReadFile(filename)
+		if err != nil {
+			return ""
+		}
+		return strings.TrimSpace(string(b))
+	},
+	"join": strings.Join,
 	"json": func(v interface{}) string {
 		buf := &bytes.Buffer{}
 		enc := json.NewEncoder(buf)
@@ -25,12 +45,11 @@ var tmplFuncs = template.FuncMap{
 		enc.Encode(v)
 		return buf.String()
 	},
-	"split": strings.Split,
-	"join":  strings.Join,
-	"title": strings.Title,
 	"lower": strings.ToLower,
-	"upper": strings.ToUpper,
+	"split": strings.Split,
 	"time":  TimeFunc,
+	"title": strings.Title,
+	"upper": strings.ToUpper,
 }
 
 func templateWritter(out io.Writer, tmpl string, data interface{}) error {

--- a/regclient/regclient.go
+++ b/regclient/regclient.go
@@ -272,7 +272,7 @@ func WithConfigHosts(configHosts []ConfigHost) Opt {
 					configHost.RegCert = orig.RegCert
 				}
 				if configHost.Scheme == "" {
-					configHost.RegCert = orig.RegCert
+					configHost.Scheme = orig.Scheme
 				}
 				if configHost.TLS == TLSUndefined {
 					configHost.TLS = orig.TLS
@@ -280,6 +280,12 @@ func WithConfigHosts(configHosts []ConfigHost) Opt {
 				if len(configHost.DNS) == 0 {
 					configHost.DNS = orig.DNS
 				}
+			}
+			if configHost.Scheme == "" {
+				configHost.Scheme = "https"
+			}
+			if configHost.TLS == TLSUndefined {
+				configHost.TLS = TLSEnabled
 			}
 			if len(configHost.DNS) == 0 {
 				configHost.DNS = []string{configHost.Name}


### PR DESCRIPTION
- regsync config: allow default backup value, expand templates on
  user/pass and source/target fields
- regsync: cleanup logging and error handling
- templates: adding templates for default, env, and file
- regclient: Bug fix with empty scheme on host