### PR TITLE
Adding regbot

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,6 +19,7 @@ jobs:
       run: |
         REGCTL_IMAGE=regclient/regctl
         REGSYNC_IMAGE=regclient/regsync
+        REGBOT_IMAGE=regclient/regbot
         VERSION=noop
         if [ "${{ github.event_name }}" = "schedule" ]; then
           VERSION=nightly
@@ -36,6 +37,8 @@ jobs:
         REGCTL_TAGS_ALPINE="${REGCTL_IMAGE}:${VERSION}-alpine"
         REGSYNC_TAGS_SCRATCH="${REGSYNC_IMAGE}:${VERSION}"
         REGSYNC_TAGS_ALPINE="${REGSYNC_IMAGE}:${VERSION}-alpine"
+        REGBOT_TAGS_SCRATCH="${REGBOT_IMAGE}:${VERSION}"
+        REGBOT_TAGS_ALPINE="${REGBOT_IMAGE}:${VERSION}-alpine"
         if [[ $VERSION =~ ^v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
           MINOR=${VERSION%.*}
           MAJOR=${MINOR%.*}
@@ -43,12 +46,16 @@ jobs:
           REGCTL_TAGS_ALPINE="${REGCTL_TAGS_ALPINE},${REGCTL_IMAGE}:${MINOR}-alpine,${REGCTL_IMAGE}:${MAJOR}-alpine,${REGCTL_IMAGE}:alpine"
           REGSYNC_TAGS_SCRATCH="${REGSYNC_TAGS_SCRATCH},${REGSYNC_IMAGE}:${MINOR},${REGSYNC_IMAGE}:${MAJOR},${REGSYNC_IMAGE}:latest"
           REGSYNC_TAGS_ALPINE="${REGSYNC_TAGS_ALPINE},${REGSYNC_IMAGE}:${MINOR}-alpine,${REGSYNC_IMAGE}:${MAJOR}-alpine,${REGSYNC_IMAGE}:alpine"
+          REGBOT_TAGS_SCRATCH="${REGBOT_TAGS_SCRATCH},${REGBOT_IMAGE}:${MINOR},${REGBOT_IMAGE}:${MAJOR},${REGBOT_IMAGE}:latest"
+          REGBOT_TAGS_ALPINE="${REGBOT_TAGS_ALPINE},${REGBOT_IMAGE}:${MINOR}-alpine,${REGBOT_IMAGE}:${MAJOR}-alpine,${REGBOT_IMAGE}:alpine"
         fi
         echo ::set-output name=version::${VERSION}
         echo ::set-output name=regctl_tags_scratch::${REGCTL_TAGS_SCRATCH}
         echo ::set-output name=regctl_tags_alpine::${REGCTL_TAGS_ALPINE}
         echo ::set-output name=regsync_tags_scratch::${REGSYNC_TAGS_SCRATCH}
         echo ::set-output name=regsync_tags_alpine::${REGSYNC_TAGS_ALPINE}
+        echo ::set-output name=regbot_tags_scratch::${REGBOT_TAGS_SCRATCH}
+        echo ::set-output name=regbot_tags_alpine::${REGBOT_TAGS_ALPINE}
         echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
 
     - name: Check out code
@@ -140,6 +147,44 @@ jobs:
         tags: ${{ steps.prep.outputs.regsync_tags_alpine }}
         cache-from: type=local,src=/tmp/.buildx-regsync-cache
         cache-to: type=local,dest=/tmp/.buildx-regsync-cache
+        build-args: |
+          LD_FLAGS=-X github.com/regclient/regclient/regclient.VCSRef=${{ github.sha }}
+        labels: |
+          org.opencontainers.image.created=${{ steps.prep.outputs.created }}
+          org.opencontainers.image.source=${{ github.repositoryUrl }}
+          org.opencontainers.image.version=${{ steps.prep.outputs.version }}
+          org.opencontainers.image.revision=${{ github.sha }}
+
+    - name: Build and push regbot scratch
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: ./build/Dockerfile.regbot.buildkit
+        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/ppc64le,linux/s390x
+        push: ${{ github.event_name != 'pull_request' }}
+        target: release-scratch
+        tags: ${{ steps.prep.outputs.regbot_tags_scratch }}
+        cache-from: type=local,src=/tmp/.buildx-regbot-cache
+        cache-to: type=local,dest=/tmp/.buildx-regbot-cache
+        build-args: |
+          LD_FLAGS=-X github.com/regclient/regclient/regclient.VCSRef=${{ github.sha }}
+        labels: |
+          org.opencontainers.image.created=${{ steps.prep.outputs.created }}
+          org.opencontainers.image.source=${{ github.repositoryUrl }}
+          org.opencontainers.image.version=${{ steps.prep.outputs.version }}
+          org.opencontainers.image.revision=${{ github.sha }}
+
+    - name: Build and push regbot alpine
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: ./build/Dockerfile.regbot.buildkit
+        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/ppc64le,linux/s390x
+        push: ${{ github.event_name != 'pull_request' }}
+        target: release-alpine
+        tags: ${{ steps.prep.outputs.regbot_tags_alpine }}
+        cache-from: type=local,src=/tmp/.buildx-regbot-cache
+        cache-to: type=local,dest=/tmp/.buildx-regbot-cache
         build-args: |
           LD_FLAGS=-X github.com/regclient/regclient/regclient.VCSRef=${{ github.sha }}
         labels: |

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -138,3 +138,27 @@ jobs:
         asset_path: ./artifacts/regsync-linux-arm64
         asset_name: regsync-linux-arm64
         asset_content_type: application/octet-stream
+
+    - name: Upload Release Asset - regbot-linux-amd64
+      if: steps.release_details.outputs.valid == 'true'
+      id: release_assets_regbot_linux_amd64
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.release_create.outputs.upload_url }}
+        asset_path: ./artifacts/regbot-linux-amd64
+        asset_name: regbot-linux-amd64
+        asset_content_type: application/octet-stream
+
+    - name: Upload Release Asset - regbot-linux-arm64
+      if: steps.release_details.outputs.valid == 'true'
+      id: release_assets_regbot_linux_arm64
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.release_create.outputs.upload_url }}
+        asset_path: ./artifacts/regbot-linux-arm64
+        asset_name: regbot-linux-arm64
+        asset_content_type: application/octet-stream

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-COMMANDS=regctl regsync
+COMMANDS=regctl regsync regbot
 BINARIES=$(addprefix bin/,$(COMMANDS))
-IMAGE_TAGS=regctl regsync
+IMAGE_TAGS=regctl regsync regbot
 IMAGES=$(addprefix docker-,$(IMAGE_TAGS))
 VCS_REF=$(shell git rev-list -1 HEAD)
 LD_FLAGS=-X \"github.com/regclient/regclient/regclient.VCSRef=$(VCS_REF)\"
@@ -24,6 +24,9 @@ bin/regctl: .FORCE
 bin/regsync: .FORCE
 	go build ${GO_BUILD_FLAGS} -o bin/regsync ./cmd/regsync
 
+bin/regbot: .FORCE
+	go build ${GO_BUILD_FLAGS} -o bin/regbot ./cmd/regbot
+
 vendor:
 	go mod vendor
 
@@ -36,6 +39,10 @@ docker-regctl:
 docker-regsync:
 	docker build -t regclient/regsync -f build/Dockerfile.regsync $(DOCKER_ARGS) .
 	docker build -t regclient/regsync:alpine -f build/Dockerfile.regsync --target release-alpine $(DOCKER_ARGS) .
+
+docker-regbot:
+	docker build -t regclient/regbot -f build/Dockerfile.regbot $(DOCKER_ARGS) .
+	docker build -t regclient/regbot:alpine -f build/Dockerfile.regbot --target release-alpine $(DOCKER_ARGS) .
 
 plugin-user:
 	mkdir -p ${HOME}/.docker/cli-plugins/

--- a/README.md
+++ b/README.md
@@ -29,6 +29,22 @@ This includes `regctl` for a command line interface to manage registries.
 - Ability to postpone mirror step when rate limit is below a threshold.
 - Ability to mirror multiple images concurrently.
 
+## regbot features
+
+- Runs user provided scripts based on a yaml configuration.
+- Scripts are written in Lua and executed directly in Go.
+- Can run on a cron schedule or a one time execution.
+- Dry-run option can be used for testing.
+- Built-in functions include:
+  - Repository list
+  - Tag list
+  - Image manifest (either head or get, and optional resolving multi-platform reference)
+  - Image config (this includes the creation time, labels, and other details shown in a `docker image inspect`)
+  - Image ratelimit and a wait function to delay the script when ratelimit remaining is below a threshold
+  - Image copy
+  - Manifest delete
+  - Tag delete
+
 ## Development Status
 
 This project is in active development, a few features are not complete.
@@ -64,7 +80,9 @@ chmod 755 regctl
 
 ## Running as a Container
 
-You can run `regctl` and `regsync` in a container. For regctl:
+You can run `regctl`, `regsync`, and `regbot` in a container.
+
+For `regctl`:
 
 ```shell
 docker container run -it --rm --net host \
@@ -72,12 +90,20 @@ docker container run -it --rm --net host \
   regclient/regctl:latest --help
 ```
 
-And for `regsync`:
+For `regsync`:
 
 ```shell
 docker container run -it --rm --net host \
   -v "$(pwd)/regsync.yml:/home/appuser/regsync.yml" \
   regclient/regsync:latest -c /home/appuser/regsync.yml check
+```
+
+For `regbot`:
+
+```shell
+docker container run -it --rm --net host \
+  -v "$(pwd)/regbot.yml:/home/appuser/regbot.yml" \
+  regclient/regbot:latest -c /home/appuser/regbot.yml once --dry-run
 ```
 
 Or on Linux and Mac environments, you can run `regctl` as your own user and save

--- a/build/Dockerfile.regbot
+++ b/build/Dockerfile.regbot
@@ -1,0 +1,61 @@
+FROM golang:1.14-alpine as dev
+RUN apk add --no-cache git ca-certificates
+RUN adduser -D appuser \
+ && mkdir -p /home/appuser/.docker \
+ && chown -R appuser /home/appuser
+WORKDIR /src
+COPY . /src/
+CMD CGO_ENABLED=0 go build -ldflags '-s -w -extldflags -static' -o regctl ./cmd/regbot/ && ./regbot
+
+FROM dev as build
+ARG LD_FLAGS
+RUN CGO_ENABLED=0 \
+    go build -ldflags "-s -w -extldflags -static ${LD_FLAGS}" -o regbot ./cmd/regbot/
+USER appuser
+CMD [ "./regbot" ]
+
+FROM alpine as release-alpine
+COPY --from=build /etc/passwd /etc/group /etc/
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=build --chown=appuser /home/appuser /home/appuser
+COPY --from=build /src/regbot /usr/local/bin/regbot
+USER appuser
+CMD [ "regbot", "--help" ]
+
+ARG BUILD_DATE
+ARG VCS_REF
+LABEL maintainer="" \
+      org.opencontainers.image.created=$BUILD_DATE \
+      org.opencontainers.image.authors="Regclient contributors" \
+      org.opencontainers.image.url="https://github.com/regclient/regclient" \
+      org.opencontainers.image.documentation="https://github.com/regclient/regclient" \
+      org.opencontainers.image.source="https://github.com/regclient/regclient" \
+      org.opencontainers.image.version="latest" \
+      org.opencontainers.image.revision=$VCS_REF \
+      org.opencontainers.image.vendor="" \
+      org.opencontainers.image.licenses="Apache 2.0" \
+      org.opencontainers.image.title="regbot" \
+      org.opencontainers.image.description=""
+
+FROM scratch as release-scratch
+COPY --from=build /etc/passwd /etc/group /etc/
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=build --chown=appuser /home/appuser /home/appuser
+COPY --from=build /src/regbot /regbot
+USER appuser
+ENTRYPOINT [ "/regbot" ]
+
+ARG BUILD_DATE
+ARG VCS_REF
+LABEL maintainer="" \
+      org.opencontainers.image.created=$BUILD_DATE \
+      org.opencontainers.image.authors="Regclient contributors" \
+      org.opencontainers.image.url="https://github.com/regclient/regclient" \
+      org.opencontainers.image.documentation="https://github.com/regclient/regclient" \
+      org.opencontainers.image.source="https://github.com/regclient/regclient" \
+      org.opencontainers.image.version="latest" \
+      org.opencontainers.image.revision=$VCS_REF \
+      org.opencontainers.image.vendor="" \
+      org.opencontainers.image.licenses="Apache 2.0" \
+      org.opencontainers.image.title="regbot" \
+      org.opencontainers.image.description=""

--- a/build/Dockerfile.regbot.buildkit
+++ b/build/Dockerfile.regbot.buildkit
@@ -1,0 +1,70 @@
+# syntax=docker/dockerfile:experimental
+
+FROM --platform=$BUILDPLATFORM golang:1.14-alpine as dev
+RUN apk add --no-cache git ca-certificates
+RUN adduser -D appuser \
+ && mkdir -p /home/appuser/.docker \
+ && chown -R appuser /home/appuser
+WORKDIR /src
+COPY . /src/
+CMD CGO_ENABLED=0 go build -ldflags '-s -w -extldflags -static' -o regbot ./cmd/regbot/ && ./regbot
+
+FROM --platform=$BUILDPLATFORM dev as build
+ARG TARGETOS
+ARG TARGETARCH
+ARG LD_FLAGS
+RUN --mount=type=cache,id=gomod,target=/go/pkg/mod/cache \
+    --mount=type=cache,id=goroot,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+    go build -ldflags "-s -w -extldflags -static ${LD_FLAGS}" -o regbot ./cmd/regbot/
+USER appuser
+CMD [ "./regbot" ]
+
+FROM scratch as artifact
+COPY --from=build /src/regbot /regbot
+
+FROM alpine as release-alpine
+COPY --from=build /etc/passwd /etc/group /etc/
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=build --chown=appuser /home/appuser /home/appuser
+COPY --from=build /src/regbot /usr/local/bin/regbot
+USER appuser
+CMD [ "regbot", "--help" ]
+
+ARG BUILD_DATE
+ARG VCS_REF
+LABEL maintainer="" \
+      org.opencontainers.image.created=$BUILD_DATE \
+      org.opencontainers.image.authors="Regclient contributors" \
+      org.opencontainers.image.url="https://github.com/regclient/regclient" \
+      org.opencontainers.image.documentation="https://github.com/regclient/regclient" \
+      org.opencontainers.image.source="https://github.com/regclient/regclient" \
+      org.opencontainers.image.version="latest" \
+      org.opencontainers.image.revision=$VCS_REF \
+      org.opencontainers.image.vendor="" \
+      org.opencontainers.image.licenses="Apache 2.0" \
+      org.opencontainers.image.title="regbot" \
+      org.opencontainers.image.description=""
+
+FROM scratch as release-scratch
+COPY --from=build /etc/passwd /etc/group /etc/
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=build --chown=appuser /home/appuser /home/appuser
+COPY --from=build /src/regbot /regbot
+USER appuser
+ENTRYPOINT [ "/regbot" ]
+
+ARG BUILD_DATE
+ARG VCS_REF
+LABEL maintainer="" \
+      org.opencontainers.image.created=$BUILD_DATE \
+      org.opencontainers.image.authors="Regclient contributors" \
+      org.opencontainers.image.url="https://github.com/regclient/regclient" \
+      org.opencontainers.image.documentation="https://github.com/regclient/regclient" \
+      org.opencontainers.image.source="https://github.com/regclient/regclient" \
+      org.opencontainers.image.version="latest" \
+      org.opencontainers.image.revision=$VCS_REF \
+      org.opencontainers.image.vendor="" \
+      org.opencontainers.image.licenses="Apache 2.0" \
+      org.opencontainers.image.title="regbot" \
+      org.opencontainers.image.description=""

--- a/build/build-artifacts.sh
+++ b/build/build-artifacts.sh
@@ -27,3 +27,11 @@ for target in $targets; do
   echo "Building regsync-${GOOS}-${GOARCH}"
   go build -o "artifacts/regsync-${GOOS}-${GOARCH}" -ldflags "$LD_FLAGS" ${GO_BUILD_FLAGS} ./cmd/regsync/
 done
+
+for target in $targets; do
+  GOOS="${target%%/*}"
+  GOARCH="${target#*/}"
+  export GOOS GOARCH
+  echo "Building regbot-${GOOS}-${GOARCH}"
+  go build -o "artifacts/regbot-${GOOS}-${GOARCH}" -ldflags "$LD_FLAGS" ${GO_BUILD_FLAGS} ./cmd/regbot/
+done

--- a/cmd/regbot/config.go
+++ b/cmd/regbot/config.go
@@ -43,6 +43,7 @@ type ConfigDefaults struct {
 	RateLimit      ConfigRateLimit `json:"ratelimit"`
 	Parallel       int             `json:"parallel"`
 	SkipDockerConf bool            `json:"skipDockerConfig`
+	Timeout        time.Duration   `json:"timeout"`
 }
 
 // ConfigRateLimit is for rate limit settings
@@ -58,6 +59,7 @@ type ConfigScript struct {
 	Interval  time.Duration   `json:"interval"`
 	Schedule  string          `json:"schedule"`
 	RateLimit ConfigRateLimit `json:"ratelimit"`
+	Timeout   time.Duration   `json:"timeout"`
 }
 
 // ConfigNew creates an empty configuration
@@ -159,5 +161,8 @@ func scriptSetDefaults(s *ConfigScript, d ConfigDefaults) {
 		s.RateLimit.Retry = d.RateLimit.Retry
 	} else if s.RateLimit.Retry < rateLimitRetryMin {
 		s.RateLimit.Retry = rateLimitRetryMin
+	}
+	if s.Timeout == 0 && d.Timeout != 0 {
+		s.Timeout = d.Timeout
 	}
 }

--- a/cmd/regbot/config.go
+++ b/cmd/regbot/config.go
@@ -11,13 +11,6 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-// delay checking for at least 5 minutes when rate limit is exceeded
-var rateLimitRetryMin time.Duration
-
-func init() {
-	rateLimitRetryMin, _ = time.ParseDuration("5m")
-}
-
 // Config is parsed configuration file for regsync
 type Config struct {
 	Version  int            `json:"version"`
@@ -38,28 +31,20 @@ type ConfigCreds struct {
 
 // ConfigDefaults is uses for general options and defaults for ConfigScript entries
 type ConfigDefaults struct {
-	Interval       time.Duration   `json:"interval"`
-	Schedule       string          `json:"schedule"`
-	RateLimit      ConfigRateLimit `json:"ratelimit"`
-	Parallel       int             `json:"parallel"`
-	SkipDockerConf bool            `json:"skipDockerConfig`
-	Timeout        time.Duration   `json:"timeout"`
-}
-
-// ConfigRateLimit is for rate limit settings
-type ConfigRateLimit struct {
-	Min   int           `json:"min"`
-	Retry time.Duration `json:"retry"`
+	Interval       time.Duration `json:"interval"`
+	Schedule       string        `json:"schedule"`
+	Parallel       int           `json:"parallel"`
+	SkipDockerConf bool          `json:"skipDockerConfig`
+	Timeout        time.Duration `json:"timeout"`
 }
 
 // ConfigScript defines a source/target repository to sync
 type ConfigScript struct {
-	Name      string          `json:"name"`
-	Script    string          `json:"script"`
-	Interval  time.Duration   `json:"interval"`
-	Schedule  string          `json:"schedule"`
-	RateLimit ConfigRateLimit `json:"ratelimit"`
-	Timeout   time.Duration   `json:"timeout"`
+	Name     string        `json:"name"`
+	Script   string        `json:"script"`
+	Interval time.Duration `json:"interval"`
+	Schedule string        `json:"schedule"`
+	Timeout  time.Duration `json:"timeout"`
 }
 
 // ConfigNew creates an empty configuration
@@ -84,9 +69,6 @@ func ConfigLoadReader(r io.Reader) (*Config, error) {
 	// apply top level defaults
 	if c.Defaults.Parallel <= 0 {
 		c.Defaults.Parallel = 1
-	}
-	if c.Defaults.RateLimit.Retry < rateLimitRetryMin {
-		c.Defaults.RateLimit.Retry = rateLimitRetryMin
 	}
 	// apply defaults to each step
 	for i := range c.Scripts {
@@ -153,14 +135,6 @@ func scriptSetDefaults(s *ConfigScript, d ConfigDefaults) {
 	}
 	if s.Interval == 0 && s.Schedule == "" && d.Interval != 0 {
 		s.Interval = d.Interval
-	}
-	if s.RateLimit.Min == 0 && d.RateLimit.Min != 0 {
-		s.RateLimit.Min = d.RateLimit.Min
-	}
-	if s.RateLimit.Retry == 0 {
-		s.RateLimit.Retry = d.RateLimit.Retry
-	} else if s.RateLimit.Retry < rateLimitRetryMin {
-		s.RateLimit.Retry = rateLimitRetryMin
 	}
 	if s.Timeout == 0 && d.Timeout != 0 {
 		s.Timeout = d.Timeout

--- a/cmd/regbot/config.go
+++ b/cmd/regbot/config.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"errors"
+	"io"
+	"os"
+	"time"
+
+	"github.com/regclient/regclient/pkg/template"
+	"github.com/regclient/regclient/regclient"
+	"gopkg.in/yaml.v2"
+)
+
+// delay checking for at least 5 minutes when rate limit is exceeded
+var rateLimitRetryMin time.Duration
+
+func init() {
+	rateLimitRetryMin, _ = time.ParseDuration("5m")
+}
+
+// Config is parsed configuration file for regsync
+type Config struct {
+	Version  int            `json:"version"`
+	Creds    []ConfigCreds  `json:"creds"`
+	Defaults ConfigDefaults `json:"defaults"`
+	Scripts  []ConfigScript `json:"scripts"`
+}
+
+// ConfigCreds allows the registry login to be passed in the config rather than from Docker
+type ConfigCreds struct {
+	Registry string            `json:"registry"`
+	User     string            `json:"user"`
+	Pass     string            `json:"pass"`
+	TLS      regclient.TLSConf `json:"tls"`
+	Scheme   string            `json:"scheme"`
+	RegCert  string            `json:"regcert"`
+}
+
+// ConfigDefaults is uses for general options and defaults for ConfigScript entries
+type ConfigDefaults struct {
+	Interval       time.Duration   `json:"interval"`
+	Schedule       string          `json:"schedule"`
+	RateLimit      ConfigRateLimit `json:"ratelimit"`
+	Parallel       int             `json:"parallel"`
+	SkipDockerConf bool            `json:"skipDockerConfig`
+}
+
+// ConfigRateLimit is for rate limit settings
+type ConfigRateLimit struct {
+	Min   int           `json:"min"`
+	Retry time.Duration `json:"retry"`
+}
+
+// ConfigScript defines a source/target repository to sync
+type ConfigScript struct {
+	Name      string          `json:"name"`
+	Script    string          `json:"script"`
+	Interval  time.Duration   `json:"interval"`
+	Schedule  string          `json:"schedule"`
+	RateLimit ConfigRateLimit `json:"ratelimit"`
+}
+
+// ConfigNew creates an empty configuration
+func ConfigNew() *Config {
+	c := Config{
+		Creds:   []ConfigCreds{},
+		Scripts: []ConfigScript{},
+	}
+	return &c
+}
+
+// ConfigLoadReader reads the config from an io.Reader
+func ConfigLoadReader(r io.Reader) (*Config, error) {
+	c := ConfigNew()
+	if err := yaml.NewDecoder(r).Decode(c); err != nil && !errors.Is(err, io.EOF) {
+		return nil, err
+	}
+	// verify loaded version is not higher than supported version
+	if c.Version > 1 {
+		return c, ErrUnsupportedConfigVersion
+	}
+	// apply top level defaults
+	if c.Defaults.Parallel <= 0 {
+		c.Defaults.Parallel = 1
+	}
+	if c.Defaults.RateLimit.Retry < rateLimitRetryMin {
+		c.Defaults.RateLimit.Retry = rateLimitRetryMin
+	}
+	// apply defaults to each step
+	for i := range c.Scripts {
+		scriptSetDefaults(&c.Scripts[i], c.Defaults)
+	}
+	err := configExpandTemplates(c)
+	if err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+// ConfigLoadFile loads the config from a specified filename
+func ConfigLoadFile(filename string) (*Config, error) {
+	_, err := os.Stat(filename)
+	if err == nil {
+		file, err := os.Open(filename)
+		if err != nil {
+			return nil, err
+		}
+		defer file.Close()
+		c, err := ConfigLoadReader(file)
+		if err != nil {
+			return nil, err
+		}
+		return c, nil
+	}
+	return nil, err
+}
+
+// expand templates in various parts of the config
+func configExpandTemplates(c *Config) error {
+	for i := range c.Creds {
+		val, err := template.String(c.Creds[i].User, nil)
+		if err != nil {
+			return err
+		}
+		c.Creds[i].User = val
+		val, err = template.String(c.Creds[i].Pass, nil)
+		if err != nil {
+			return err
+		}
+		c.Creds[i].Pass = val
+		val, err = template.String(c.Creds[i].RegCert, nil)
+		if err != nil {
+			return err
+		}
+		c.Creds[i].RegCert = val
+	}
+	// for i := range c.Scripts {
+	// 	val, err := template.String(c.Scripts[i].Script, nil)
+	// 	if err != nil {
+	// 		return err
+	// 	}
+	// 	c.Scripts[i].Script = val
+	// }
+	return nil
+}
+
+// updates script entry with defaults
+func scriptSetDefaults(s *ConfigScript, d ConfigDefaults) {
+	if s.Schedule == "" && d.Schedule != "" {
+		s.Schedule = d.Schedule
+	}
+	if s.Interval == 0 && s.Schedule == "" && d.Interval != 0 {
+		s.Interval = d.Interval
+	}
+	if s.RateLimit.Min == 0 && d.RateLimit.Min != 0 {
+		s.RateLimit.Min = d.RateLimit.Min
+	}
+	if s.RateLimit.Retry == 0 {
+		s.RateLimit.Retry = d.RateLimit.Retry
+	} else if s.RateLimit.Retry < rateLimitRetryMin {
+		s.RateLimit.Retry = rateLimitRetryMin
+	}
+}

--- a/cmd/regbot/error.go
+++ b/cmd/regbot/error.go
@@ -1,0 +1,20 @@
+package main
+
+import "errors"
+
+var (
+	// ErrCanceled is used when context is canceled before task completes
+	ErrCanceled = errors.New("Task was canceled")
+	// ErrInvalidInput indicates a required field is invalid
+	ErrInvalidInput = errors.New("Invalid input")
+	// ErrMissingInput indicates a required field is missing
+	ErrMissingInput = errors.New("Required input missing")
+	// ErrNotImplemented returned when method has not been implemented yet
+	ErrNotImplemented = errors.New("Not implemented")
+	// ErrNotFound when anything else isn't found
+	ErrNotFound = errors.New("Not found")
+	// ErrScriptFailed when the script fails to run
+	ErrScriptFailed = errors.New("Failure in user script")
+	// ErrUnsupportedConfigVersion happens when config file version is greater than this command supports
+	ErrUnsupportedConfigVersion = errors.New("Unsupported config version")
+)

--- a/cmd/regbot/main.go
+++ b/cmd/regbot/main.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	// regclient.ConfigDir = ".regsync"
+	// regclient.ConfigEnv = "REGSYNC_CONFIG"
+
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	os.Exit(0)
+}

--- a/cmd/regbot/root.go
+++ b/cmd/regbot/root.go
@@ -239,7 +239,7 @@ func (s ConfigScript) process(ctx context.Context) error {
 		log.WithFields(logrus.Fields{
 			"script": s.Name,
 			"error":  err,
-		}).Debug("Error running script")
+		}).Warn("Error running script")
 		return ErrScriptFailed
 	}
 	log.WithFields(logrus.Fields{

--- a/cmd/regbot/root.go
+++ b/cmd/regbot/root.go
@@ -1,0 +1,266 @@
+package main
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+
+	"github.com/regclient/regclient/cmd/regbot/sandbox"
+	"github.com/regclient/regclient/regclient"
+	"github.com/robfig/cron/v3"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"golang.org/x/sync/semaphore"
+)
+
+const usageDesc = `Utility for mirroring docker repositories
+More details at https://github.com/regclient/regclient`
+
+var rootOpts struct {
+	confFile  string
+	verbosity string
+	logopts   []string
+}
+
+var config *Config
+var log *logrus.Logger
+var rc regclient.RegClient
+var sem *semaphore.Weighted
+
+var rootCmd = &cobra.Command{
+	Use:   "regbot <cmd>",
+	Short: "Utility for automating repository actions",
+	Long:  usageDesc,
+	// Run: func(cmd *cobra.Command, args []string) {
+	// 	// Do Stuff Here
+	// },
+	// RunE: runServer,
+}
+var serverCmd = &cobra.Command{
+	Use:   "server",
+	Short: "run the regbot server",
+	Long:  `Runs the various scripts according to their schedule.`,
+	Args:  cobra.RangeArgs(0, 0),
+	RunE:  runServer,
+}
+var checkCmd = &cobra.Command{
+	Use:   "check",
+	Short: "runs each script once in a dry-run mode",
+	Long: `Each script is executed once, and commands that would take external
+action are only logged rather than executed. The command returns after the last
+script completes.`,
+	Args: cobra.RangeArgs(0, 0),
+	RunE: runCheck,
+}
+var onceCmd = &cobra.Command{
+	Use:   "once",
+	Short: "runs each script once",
+	Long: `Each script is executed once ignoring any scheduling. The command
+returns after the last script completes.`,
+	Args: cobra.RangeArgs(0, 0),
+	RunE: runOnce,
+}
+
+func init() {
+	log = &logrus.Logger{
+		Out:       os.Stderr,
+		Formatter: new(logrus.TextFormatter),
+		Hooks:     make(logrus.LevelHooks),
+		Level:     logrus.InfoLevel,
+	}
+	rootCmd.PersistentFlags().StringVarP(&rootOpts.confFile, "config", "c", "", "Config file")
+	rootCmd.PersistentFlags().StringVarP(&rootOpts.verbosity, "verbosity", "v", logrus.InfoLevel.String(), "Log level (debug, info, warn, error, fatal, panic)")
+	rootCmd.PersistentFlags().StringArrayVar(&rootOpts.logopts, "logopt", []string{}, "Log options")
+	rootCmd.MarkPersistentFlagFilename("config")
+	rootCmd.MarkPersistentFlagRequired("config")
+
+	rootCmd.AddCommand(serverCmd)
+	rootCmd.AddCommand(checkCmd)
+	rootCmd.AddCommand(onceCmd)
+	rootCmd.PersistentPreRunE = rootPreRun
+}
+
+func rootPreRun(cmd *cobra.Command, args []string) error {
+	lvl, err := logrus.ParseLevel(rootOpts.verbosity)
+	if err != nil {
+		return err
+	}
+	log.SetLevel(lvl)
+	log.Formatter = &logrus.TextFormatter{FullTimestamp: true}
+	for _, opt := range rootOpts.logopts {
+		if opt == "json" {
+			log.Formatter = new(logrus.JSONFormatter)
+		}
+	}
+	if rootOpts.confFile == "-" {
+		config, err = ConfigLoadReader(os.Stdin)
+		if err != nil {
+			return err
+		}
+	} else {
+		r, err := os.Open(rootOpts.confFile)
+		if err != nil {
+			return err
+		}
+		defer r.Close()
+		config, err = ConfigLoadReader(r)
+		if err != nil {
+			return err
+		}
+	}
+	// use a semaphore to control parallelism
+	log.WithFields(logrus.Fields{
+		"parallel": config.Defaults.Parallel,
+	}).Debug("Configuring parallel settings")
+	sem = semaphore.NewWeighted(int64(config.Defaults.Parallel))
+	// set the regclient, loading docker creds unless disabled, and inject logins from config file
+	rcOpts := []regclient.Opt{regclient.WithLog(log)}
+	if !config.Defaults.SkipDockerConf {
+		rcOpts = append(rcOpts, regclient.WithDockerCreds(), regclient.WithDockerCerts())
+	}
+	rcHosts := []regclient.ConfigHost{}
+	for _, host := range config.Creds {
+		rcHosts = append(rcHosts, regclient.ConfigHost{
+			Name:    host.Registry,
+			User:    host.User,
+			Pass:    host.Pass,
+			TLS:     host.TLS,
+			Scheme:  host.Scheme,
+			RegCert: host.RegCert,
+		})
+	}
+	if len(rcHosts) > 0 {
+		rcOpts = append(rcOpts, regclient.WithConfigHosts(rcHosts))
+	}
+	rc = regclient.NewRegClient(rcOpts...)
+	return nil
+}
+
+// runOnce processes the file in one pass, ignoring cron
+func runOnce(cmd *cobra.Command, args []string) error {
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	var mainErr error
+	for _, s := range config.Scripts {
+		s := s
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := s.process(ctx)
+			if err != nil {
+				if mainErr == nil {
+					mainErr = err
+				}
+				return
+			}
+		}()
+	}
+	// wait on interrupt signal
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-sig
+		log.WithFields(logrus.Fields{}).Debug("Interrupt received, stopping")
+		// clean shutdown
+		cancel()
+	}()
+	wg.Wait()
+	return mainErr
+}
+
+// runServer stays running with cron scheduled tasks
+func runServer(cmd *cobra.Command, args []string) error {
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	var mainErr error
+	c := cron.New(cron.WithChain(
+		cron.SkipIfStillRunning(cron.DefaultLogger),
+	))
+	for _, s := range config.Scripts {
+		s := s
+		sched := s.Schedule
+		if sched == "" && s.Interval != 0 {
+			sched = "@every " + s.Interval.String()
+		}
+		if sched != "" {
+			log.WithFields(logrus.Fields{
+				"name":  s.Name,
+				"sched": sched,
+			}).Debug("Scheduled task")
+			c.AddFunc(sched, func() {
+				log.WithFields(logrus.Fields{
+					"name": s.Name,
+				}).Debug("Running task")
+				wg.Add(1)
+				defer wg.Done()
+				err := s.process(ctx)
+				if mainErr == nil {
+					mainErr = err
+				}
+			})
+		} else {
+			log.WithFields(logrus.Fields{
+				"name": s.Name,
+			}).Error("No schedule or interval found, ignoring")
+		}
+	}
+	c.Start()
+	// wait on interrupt signal
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, os.Interrupt, syscall.SIGTERM)
+	<-sig
+	log.WithFields(logrus.Fields{}).Debug("Interrupt received, stopping")
+	// clean shutdown
+	c.Stop()
+	cancel()
+	log.WithFields(logrus.Fields{}).Debug("Waiting on running tasks")
+	wg.Wait()
+	return mainErr
+}
+
+// run check is used for a dry-run
+func runCheck(cmd *cobra.Command, args []string) error {
+	var mainErr error
+	ctx := context.Background()
+	for _, s := range config.Scripts {
+		err := s.process(ctx)
+		if err != nil {
+			if mainErr == nil {
+				mainErr = err
+			}
+		}
+	}
+	return mainErr
+}
+
+// process a sync step
+func (s ConfigScript) process(ctx context.Context) error {
+	log.WithFields(logrus.Fields{
+		"name": s.Name,
+	}).Debug("Starting script")
+	sb := sandbox.New(ctx, rc, log)
+	defer sb.Close()
+	defer func() {
+		if r := recover(); r != nil {
+			log.WithFields(logrus.Fields{
+				"name":  s.Name,
+				"error": r,
+			}).Error("Runtime error from script")
+		}
+	}()
+	err := sb.RunScript(s.Script)
+	if err != nil {
+		log.WithFields(logrus.Fields{
+			"name":  s.Name,
+			"error": err,
+		}).Debug("Error running script")
+		return ErrScriptFailed
+	}
+	log.WithFields(logrus.Fields{
+		"name": s.Name,
+	}).Debug("Finished script")
+
+	return nil
+}

--- a/cmd/regbot/sandbox/error.go
+++ b/cmd/regbot/sandbox/error.go
@@ -11,4 +11,6 @@ var (
 	ErrMissingInput = errors.New("Required input missing")
 	// ErrNotImplemented returned when method has not been implemented yet
 	ErrNotImplemented = errors.New("Not implemented")
+	// ErrScriptFailed when the script fails to run
+	ErrScriptFailed = errors.New("Failure in user script")
 )

--- a/cmd/regbot/sandbox/error.go
+++ b/cmd/regbot/sandbox/error.go
@@ -1,0 +1,14 @@
+package sandbox
+
+import "errors"
+
+var (
+	// ErrInvalidInput indicates a required field is invalid
+	ErrInvalidInput = errors.New("Invalid input")
+	// ErrInvalidWrappedValue indicates the wrapped value did not expand to a table
+	ErrInvalidWrappedValue = errors.New("Wrapped value must map to a lua table")
+	// ErrMissingInput indicates a required field is missing
+	ErrMissingInput = errors.New("Required input missing")
+	// ErrNotImplemented returned when method has not been implemented yet
+	ErrNotImplemented = errors.New("Not implemented")
+)

--- a/cmd/regbot/sandbox/image.go
+++ b/cmd/regbot/sandbox/image.go
@@ -1,0 +1,132 @@
+package sandbox
+
+import (
+	"encoding/json"
+
+	"github.com/containerd/containerd/platforms"
+	ociv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/regclient/regclient/regclient"
+	"github.com/sirupsen/logrus"
+	lua "github.com/yuin/gopher-lua"
+)
+
+type manifest struct {
+	m regclient.Manifest
+}
+
+func setupImage(s *Sandbox) {
+	s.setupMod(
+		luaManifestName,
+		map[string]lua.LGFunction{
+			"__tostring": s.imageManifestJSON,
+		},
+		map[string]map[string]lua.LGFunction{
+			"__index": {},
+		},
+	)
+	s.setupMod(
+		luaImageName,
+		map[string]lua.LGFunction{
+			"manifest": s.imageManifest,
+		},
+		map[string]map[string]lua.LGFunction{
+			"__index": {
+				// "inspect": s.imageInspect,
+			},
+		},
+	)
+}
+
+func (s *Sandbox) checkManifest(L *lua.LState, i int, list bool) *manifest {
+	var m *manifest
+	switch L.Get(i).Type() {
+	case lua.LTString:
+		ref, err := regclient.NewRef(L.CheckString(1))
+		if err != nil {
+			L.RaiseError("reference parsing failed: %v", err)
+		}
+		rcM, err := s.getManifest(ref, list, "")
+		if err != nil {
+			L.RaiseError("manifest pull failed: %v", err)
+		}
+		m = &manifest{m: rcM}
+	case lua.LTUserData:
+		ud := L.CheckUserData(i)
+		udM, ok := ud.Value.(*manifest)
+		if !ok {
+			L.ArgError(i, "manifest expected")
+		}
+		m = udM
+	}
+	return m
+}
+
+func (s *Sandbox) getManifest(ref regclient.Ref, list bool, platform string) (regclient.Manifest, error) {
+	m, err := s.RC.ManifestGet(s.Ctx, ref)
+	if err != nil {
+		return m, err
+	}
+
+	if m.IsList() && !list {
+		var plat ociv1.Platform
+		if platform != "" {
+			plat, err = platforms.Parse(platform)
+			if err != nil {
+				s.log.WithFields(logrus.Fields{
+					"platform": platform,
+					"err":      err,
+				}).Warn("Could not parse platform")
+			}
+		}
+		if plat.OS == "" {
+			plat = platforms.DefaultSpec()
+		}
+		desc, err := m.GetPlatformDesc(&plat)
+		if err != nil {
+			return m, err
+		}
+		ref.Digest = desc.Digest.String()
+		m, err = s.RC.ManifestGet(s.Ctx, ref)
+		if err != nil {
+			return m, err
+		}
+	}
+
+	return m, nil
+}
+
+func (s *Sandbox) imageManifest(L *lua.LState) int {
+	return s.imageManifestWithOpts(L, false)
+}
+
+func (s *Sandbox) imageManifestList(L *lua.LState) int {
+	return s.imageManifestWithOpts(L, true)
+}
+
+func (s *Sandbox) imageManifestWithOpts(L *lua.LState, list bool) int {
+	ref := checkReference(L, 1)
+	plat := ""
+	if !list && L.GetTop() == 2 {
+		plat = L.CheckString(2)
+	}
+	m, err := s.getManifest(ref.Ref, list, plat)
+	if err != nil {
+		L.RaiseError("Failed retrieving \"%s\" manifest: %v", ref.Ref.CommonName(), err)
+	}
+
+	ud := L.NewUserData()
+	ud.Value = &manifest{m: m}
+	L.SetMetatable(ud, L.GetTypeMetatable(luaManifestName))
+	L.Push(ud)
+	return 1
+}
+
+func (s *Sandbox) imageManifestJSON(L *lua.LState) int {
+	m := s.checkManifest(L, 1, false)
+	mJSON, err := json.MarshalIndent(m.m, "", "  ")
+	if err != nil {
+		L.RaiseError("Failed outputing manifest: %v", err)
+	}
+	L.Push(lua.LString(string(mJSON)))
+	return 1
+}

--- a/cmd/regbot/sandbox/image.go
+++ b/cmd/regbot/sandbox/image.go
@@ -5,13 +5,21 @@ import (
 
 	"github.com/containerd/containerd/platforms"
 	ociv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/regclient/regclient/pkg/go2lua"
 	"github.com/regclient/regclient/regclient"
 	"github.com/sirupsen/logrus"
 	lua "github.com/yuin/gopher-lua"
 )
 
+type config struct {
+	m    regclient.Manifest
+	ref  regclient.Ref
+	conf *ociv1.Image
+}
+
 type manifest struct {
-	m regclient.Manifest
+	m   regclient.Manifest
+	ref regclient.Ref
 }
 
 func setupImage(s *Sandbox) {
@@ -21,18 +29,33 @@ func setupImage(s *Sandbox) {
 			"__tostring": s.imageManifestJSON,
 		},
 		map[string]map[string]lua.LGFunction{
-			"__index": {},
+			"__index": {
+				"config":    s.imageConfig,
+				"ratelimit": s.imageRateLimit,
+			},
 		},
 	)
 	s.setupMod(
 		luaImageName,
 		map[string]lua.LGFunction{
-			"manifest": s.imageManifest,
+			"config":       s.imageConfig,
+			"manifest":     s.imageManifest,
+			"manifestHead": s.imageManifestHead,
+			"manifestList": s.imageManifestList,
 		},
 		map[string]map[string]lua.LGFunction{
 			"__index": {
 				// "inspect": s.imageInspect,
 			},
+		},
+	)
+	s.setupMod(
+		luaImageConfigName,
+		map[string]lua.LGFunction{
+			"__tostring": s.imageConfigJSON,
+		},
+		map[string]map[string]lua.LGFunction{
+			"__index": {},
 		},
 	)
 }
@@ -49,7 +72,7 @@ func (s *Sandbox) checkManifest(L *lua.LState, i int, list bool) *manifest {
 		if err != nil {
 			L.RaiseError("manifest pull failed: %v", err)
 		}
-		m = &manifest{m: rcM}
+		m = &manifest{m: rcM, ref: ref}
 	case lua.LTUserData:
 		ud := L.CheckUserData(i)
 		udM, ok := ud.Value.(*manifest)
@@ -95,6 +118,25 @@ func (s *Sandbox) getManifest(ref regclient.Ref, list bool, platform string) (re
 	return m, nil
 }
 
+func (s *Sandbox) imageConfig(L *lua.LState) int {
+	m := s.checkManifest(L, 1, false)
+	confDigest, err := m.m.GetConfigDigest()
+	if err != nil {
+		L.RaiseError("Failed looking up \"%s\" config digest: %v", m.ref.CommonName(), err)
+	}
+
+	conf, err := s.RC.ImageGetConfig(s.Ctx, m.ref, confDigest.String())
+	if err != nil {
+		L.RaiseError("Failed retrieving \"%s\" config: %v", m.ref.CommonName(), err)
+	}
+	ud, err := wrapUserData(L, &config{conf: &conf, m: m.m, ref: m.ref}, conf, luaImageConfigName)
+	if err != nil {
+		L.RaiseError("Failed packaging \"%s\" config: %v", m.ref.CommonName(), err)
+	}
+	L.Push(ud)
+	return 1
+}
+
 func (s *Sandbox) imageManifest(L *lua.LState) int {
 	return s.imageManifestWithOpts(L, false)
 }
@@ -114,10 +156,37 @@ func (s *Sandbox) imageManifestWithOpts(L *lua.LState, list bool) int {
 		L.RaiseError("Failed retrieving \"%s\" manifest: %v", ref.Ref.CommonName(), err)
 	}
 
-	ud := L.NewUserData()
-	ud.Value = &manifest{m: m}
-	L.SetMetatable(ud, L.GetTypeMetatable(luaManifestName))
+	ud, err := wrapUserData(L, &manifest{m: m, ref: ref.Ref}, m.GetOrigManifest(), luaManifestName)
+	if err != nil {
+		L.RaiseError("Failed packaging \"%s\" manifest: %v", ref.Ref.CommonName(), err)
+	}
 	L.Push(ud)
+	return 1
+}
+
+func (s *Sandbox) imageManifestHead(L *lua.LState) int {
+	ref := checkReference(L, 1)
+
+	m, err := s.RC.ManifestHead(s.Ctx, ref.Ref)
+	if err != nil {
+		L.RaiseError("Failed retrieving \"%s\" manifest: %v", ref.Ref.CommonName(), err)
+	}
+
+	ud, err := wrapUserData(L, &manifest{m: m, ref: ref.Ref}, m, luaManifestName)
+	if err != nil {
+		L.RaiseError("Failed packaging \"%s\" manifest: %v", ref.Ref.CommonName(), err)
+	}
+	L.Push(ud)
+	return 1
+}
+
+func (s *Sandbox) imageConfigJSON(L *lua.LState) int {
+	c := checkConfig(L, 1)
+	cJSON, err := json.MarshalIndent(c.conf, "", "  ")
+	if err != nil {
+		L.RaiseError("Failed outputing config: %v", err)
+	}
+	L.Push(lua.LString(string(cJSON)))
 	return 1
 }
 
@@ -130,3 +199,53 @@ func (s *Sandbox) imageManifestJSON(L *lua.LState) int {
 	L.Push(lua.LString(string(mJSON)))
 	return 1
 }
+
+func (s *Sandbox) imageRateLimit(L *lua.LState) int {
+	m := s.checkManifest(L, 1, false)
+	rl := go2lua.Convert(L, m.m.GetRateLimit())
+	L.Push(rl)
+	return 1
+}
+
+func checkConfig(L *lua.LState, i int) *config {
+	var c *config
+	switch L.Get(i).Type() {
+	case lua.LTUserData:
+		ud := L.CheckUserData(i)
+		udc, ok := ud.Value.(*config)
+		if !ok {
+			L.ArgError(i, "config expected")
+		}
+		c = udc
+	default:
+		L.ArgError(i, "config expected")
+	}
+	return c
+}
+
+/* func checkManifest(L *lua.LState, i int) *manifest {
+	var man *manifest
+	switch L.Get(i).Type() {
+	case lua.LTUserData:
+		ud := L.CheckUserData(i)
+		m, ok := ud.Value.(*manifest)
+		if !ok {
+			L.ArgError(i, "manifest expected")
+		}
+		man = m
+	default:
+		L.ArgError(i, "manifest expected")
+	}
+	return man
+} */
+
+/* func isManifest(L *lua.LState, i int) bool {
+	if L.Get(i).Type() != lua.LTUserData {
+		return false
+	}
+	ud := L.CheckUserData(i)
+	if _, ok := ud.Value.(*manifest); ok {
+		return true
+	}
+	return false
+} */

--- a/cmd/regbot/sandbox/image.go
+++ b/cmd/regbot/sandbox/image.go
@@ -1,7 +1,9 @@
 package sandbox
 
 import (
+	"context"
 	"encoding/json"
+	"time"
 
 	"github.com/containerd/containerd/platforms"
 	ociv1 "github.com/opencontainers/image-spec/specs-go/v1"
@@ -28,26 +30,29 @@ func setupImage(s *Sandbox) {
 		map[string]lua.LGFunction{
 			"__tostring": s.manifestJSON,
 			"get":        s.manifestGet,
+			"getList":    s.manifestGetList,
 			"head":       s.manifestHead,
 		},
 		map[string]map[string]lua.LGFunction{
 			"__index": {
-				"config": s.configGet,
-				"delete": s.manifestDelete,
-				"get":    s.manifestGet,
-				// "head":      s.manifestHead,
-				"ratelimit": s.imageRateLimit,
+				"config":        s.configGet,
+				"delete":        s.manifestDelete,
+				"get":           s.manifestGet,
+				"head":          s.manifestHead,
+				"ratelimit":     s.imageRateLimit,
+				"ratelimitWait": s.imageRateLimitWait,
 			},
 		},
 	)
 	s.setupMod(
 		luaImageName,
 		map[string]lua.LGFunction{
-			"config":       s.configGet,
-			"copy":         s.imageCopy,
-			"manifest":     s.manifestGet,
-			"manifestHead": s.manifestHead,
-			"manifestList": s.manifestGetList,
+			"config":        s.configGet,
+			"copy":          s.imageCopy,
+			"manifest":      s.manifestGet,
+			"manifestHead":  s.manifestHead,
+			"manifestList":  s.manifestGetList,
+			"ratelimitWait": s.imageRateLimitWait,
 		},
 		map[string]map[string]lua.LGFunction{
 			"__index": {
@@ -82,7 +87,7 @@ func (s *Sandbox) checkConfig(ls *lua.LState, i int) *config {
 	return c
 }
 
-func (s *Sandbox) checkManifest(ls *lua.LState, i int, list bool) *manifest {
+func (s *Sandbox) checkManifest(ls *lua.LState, i int, list bool, head bool) *manifest {
 	var m *manifest
 	switch ls.Get(i).Type() {
 	case lua.LTString:
@@ -90,11 +95,19 @@ func (s *Sandbox) checkManifest(ls *lua.LState, i int, list bool) *manifest {
 		if err != nil {
 			ls.RaiseError("reference parsing failed: %v", err)
 		}
-		rcM, err := s.rcManifestGet(ref, list, "")
-		if err != nil {
-			ls.RaiseError("manifest pull failed: %v", err)
+		if head {
+			rcM, err := s.rc.ManifestHead(s.ctx, ref)
+			if err != nil {
+				ls.RaiseError("Failed retrieving \"%s\" manifest: %v", ref.CommonName(), err)
+			}
+			m = &manifest{m: rcM, ref: ref}
+		} else {
+			rcM, err := s.rcManifestGet(ref, list, "")
+			if err != nil {
+				ls.RaiseError("manifest pull failed: %v", err)
+			}
+			m = &manifest{m: rcM, ref: ref}
 		}
-		m = &manifest{m: rcM, ref: ref}
 	case lua.LTUserData:
 		ud := ls.CheckUserData(i)
 		switch ud.Value.(type) {
@@ -103,6 +116,21 @@ func (s *Sandbox) checkManifest(ls *lua.LState, i int, list bool) *manifest {
 		case *config:
 			c := ud.Value.(*config)
 			m = &manifest{ref: c.ref, m: c.m}
+		case *reference:
+			r := ud.Value.(*reference)
+			if head {
+				rcM, err := s.rc.ManifestHead(s.ctx, r.ref)
+				if err != nil {
+					ls.RaiseError("Failed retrieving \"%s\" manifest: %v", r.ref.CommonName(), err)
+				}
+				m = &manifest{m: rcM, ref: r.ref}
+			} else {
+				rcM, err := s.rcManifestGet(r.ref, list, "")
+				if err != nil {
+					ls.RaiseError("manifest pull failed: %v", err)
+				}
+				m = &manifest{m: rcM, ref: r.ref}
+			}
 		default:
 			ls.ArgError(i, "manifest expected")
 		}
@@ -113,7 +141,15 @@ func (s *Sandbox) checkManifest(ls *lua.LState, i int, list bool) *manifest {
 }
 
 func (s *Sandbox) configGet(ls *lua.LState) int {
-	m := s.checkManifest(ls, 1, false)
+	m := s.checkManifest(ls, 1, false, false)
+	if s.sem != nil {
+		s.sem.Acquire(s.ctx, 1)
+		defer s.sem.Release(1)
+	}
+	s.log.WithFields(logrus.Fields{
+		"script": s.name,
+		"image":  m.ref.CommonName(),
+	}).Debug("Retrieve image config")
 	confDigest, err := m.m.GetConfigDigest()
 	if err != nil {
 		ls.RaiseError("Failed looking up \"%s\" config digest: %v", m.ref.CommonName(), err)
@@ -144,9 +180,22 @@ func (s *Sandbox) configJSON(ls *lua.LState) int {
 func (s *Sandbox) imageCopy(ls *lua.LState) int {
 	src := s.checkReference(ls, 1)
 	tgt := s.checkReference(ls, 2)
-	err := s.rc.ImageCopy(s.ctx, src.Ref, tgt.Ref)
+	if s.sem != nil {
+		s.sem.Acquire(s.ctx, 1)
+		defer s.sem.Release(1)
+	}
+	s.log.WithFields(logrus.Fields{
+		"script":  s.name,
+		"source":  src.ref.CommonName(),
+		"target":  tgt.ref.CommonName(),
+		"dry-run": s.dryRun,
+	}).Info("Copy image")
+	if s.dryRun {
+		return 0
+	}
+	err := s.rc.ImageCopy(s.ctx, src.ref, tgt.ref)
 	if err != nil {
-		ls.RaiseError("Failed copying \"%s\" to \"%s\": %v", src.Ref.CommonName(), tgt.Ref.CommonName(), err)
+		ls.RaiseError("Failed copying \"%s\" to \"%s\": %v", src.ref.CommonName(), tgt.ref.CommonName(), err)
 	}
 	return 0
 }
@@ -165,14 +214,20 @@ func (s *Sandbox) manifestGetWithOpts(ls *lua.LState, list bool) int {
 	if !list && ls.GetTop() == 2 {
 		plat = ls.CheckString(2)
 	}
-	m, err := s.rcManifestGet(ref.Ref, list, plat)
+	s.log.WithFields(logrus.Fields{
+		"script":   s.name,
+		"image":    ref.ref.CommonName(),
+		"list":     list,
+		"platform": plat,
+	}).Debug("Retrieve manifest")
+	m, err := s.rcManifestGet(ref.ref, list, plat)
 	if err != nil {
-		ls.RaiseError("Failed retrieving \"%s\" manifest: %v", ref.Ref.CommonName(), err)
+		ls.RaiseError("Failed retrieving \"%s\" manifest: %v", ref.ref.CommonName(), err)
 	}
 
-	ud, err := wrapUserData(ls, &manifest{m: m, ref: ref.Ref}, m.GetOrigManifest(), luaManifestName)
+	ud, err := wrapUserData(ls, &manifest{m: m, ref: ref.ref}, m.GetOrigManifest(), luaManifestName)
 	if err != nil {
-		ls.RaiseError("Failed packaging \"%s\" manifest: %v", ref.Ref.CommonName(), err)
+		ls.RaiseError("Failed packaging \"%s\" manifest: %v", ref.ref.CommonName(), err)
 	}
 	ls.Push(ud)
 	return 1
@@ -181,32 +236,107 @@ func (s *Sandbox) manifestGetWithOpts(ls *lua.LState, list bool) int {
 func (s *Sandbox) manifestHead(ls *lua.LState) int {
 	ref := s.checkReference(ls, 1)
 
-	m, err := s.rc.ManifestHead(s.ctx, ref.Ref)
+	s.log.WithFields(logrus.Fields{
+		"script": s.name,
+		"image":  ref.ref.CommonName(),
+	}).Debug("Retrieve manifest with head")
+
+	m, err := s.rc.ManifestHead(s.ctx, ref.ref)
 	if err != nil {
-		ls.RaiseError("Failed retrieving \"%s\" manifest: %v", ref.Ref.CommonName(), err)
+		ls.RaiseError("Failed retrieving \"%s\" manifest: %v", ref.ref.CommonName(), err)
 	}
 
-	ud, err := wrapUserData(ls, &manifest{m: m, ref: ref.Ref}, m, luaManifestName)
+	ud, err := wrapUserData(ls, &manifest{m: m, ref: ref.ref}, m, luaManifestName)
 	if err != nil {
-		ls.RaiseError("Failed packaging \"%s\" manifest: %v", ref.Ref.CommonName(), err)
+		ls.RaiseError("Failed packaging \"%s\" manifest: %v", ref.ref.CommonName(), err)
 	}
 	ls.Push(ud)
 	return 1
 }
 
 func (s *Sandbox) imageRateLimit(ls *lua.LState) int {
-	m := s.checkManifest(ls, 1, false)
+	m := s.checkManifest(ls, 1, false, true)
 	rl := go2lua.Convert(ls, m.m.GetRateLimit())
 	ls.Push(rl)
 	return 1
 }
 
+// imageRateLimitWait takes a ref, limit, poll freq, timeout, returns a bool for success
+func (s *Sandbox) imageRateLimitWait(ls *lua.LState) int {
+	ref := s.checkReference(ls, 1)
+	limit := ls.CheckInt(2)
+	top := ls.GetTop()
+	var freq time.Duration
+	if top >= 3 {
+		freqStr := ls.CheckString(3)
+		freqParsed, err := time.ParseDuration(freqStr)
+		if err != nil {
+			ls.RaiseError("Failed parsing rate limit frequency %s: %v", freqStr, err)
+			return 0
+		}
+		freq = freqParsed
+	} else {
+		freq, _ = time.ParseDuration("5m")
+	}
+	var timeout time.Duration
+	if top >= 4 {
+		timeoutStr := ls.CheckString(4)
+		timeoutParsed, err := time.ParseDuration(timeoutStr)
+		if err != nil {
+			ls.RaiseError("Failed parsing timeout %s: %v", timeoutStr, err)
+			return 0
+		}
+		timeout = timeoutParsed
+	} else {
+		timeout, _ = time.ParseDuration("6h")
+	}
+	ctx, _ := context.WithTimeout(s.ctx, timeout)
+	for {
+		// check the current manifest head
+		mh, err := s.rc.ManifestHead(ctx, ref.ref)
+		if err != nil {
+			ls.RaiseError("Failed checking \"%s\" manifest: %v", ref.ref.CommonName(), err)
+			return 0
+		}
+		// success if rate limit not set or remaining is above our limit
+		rl := mh.GetRateLimit()
+		if !rl.Set || rl.Remain >= limit {
+			ls.Push(lua.LBool(true))
+			return 1
+		}
+		// delay for freq (until timeout reached), and then retry
+		s.log.WithFields(logrus.Fields{
+			"script":  s.name,
+			"image":   ref.ref.CommonName(),
+			"current": rl.Remain,
+			"target":  limit,
+			"delay":   freq.String(),
+		}).Info("Delaying for ratelimit")
+		select {
+		case <-ctx.Done():
+			ls.Push(lua.LBool(false))
+			return 1
+		case <-time.After(freq):
+		}
+	}
+	ls.Push(lua.LBool(false))
+	return 1
+}
+
 func (s *Sandbox) manifestDelete(ls *lua.LState) int {
-	m := s.checkManifest(ls, 1, true)
+	m := s.checkManifest(ls, 1, true, true)
 	ref := m.ref
 	if ref.Digest == "" {
 		d := m.m.GetDigest()
 		ref.Digest = d.String()
+	}
+	s.log.WithFields(logrus.Fields{
+		"script":  s.name,
+		"image":   ref.CommonName(),
+		"dry-run": s.dryRun,
+	}).Info("Delete manifest")
+	if s.dryRun {
+		return 0
 	}
 	err := s.rc.ManifestDelete(s.ctx, ref)
 	if err != nil {
@@ -216,7 +346,7 @@ func (s *Sandbox) manifestDelete(ls *lua.LState) int {
 }
 
 func (s *Sandbox) manifestJSON(ls *lua.LState) int {
-	m := s.checkManifest(ls, 1, false)
+	m := s.checkManifest(ls, 1, false, false)
 	mJSON, err := json.MarshalIndent(m.m, "", "  ")
 	if err != nil {
 		ls.RaiseError("Failed outputing manifest: %v", err)

--- a/cmd/regbot/sandbox/reference.go
+++ b/cmd/regbot/sandbox/reference.go
@@ -1,0 +1,88 @@
+package sandbox
+
+import (
+	"github.com/regclient/regclient/regclient"
+	lua "github.com/yuin/gopher-lua"
+)
+
+func setupReference(s *Sandbox) {
+	s.setupMod(
+		luaReferenceName,
+		map[string]lua.LGFunction{
+			"new":        s.newReference,
+			"__tostring": s.referenceString,
+		},
+		map[string]map[string]lua.LGFunction{
+			"__index": {
+				"tag": s.referenceGetSetTag,
+			},
+		},
+	)
+}
+
+// reference refers to a repository or image name
+type reference struct {
+	Ref regclient.Ref
+}
+
+// newReference creates a reference
+func (s *Sandbox) newReference(L *lua.LState) int {
+	ref, err := regclient.NewRef(L.CheckString(1))
+	if err != nil {
+		L.ArgError(1, "reference parsing failed: "+err.Error())
+	}
+	reference := &reference{Ref: ref}
+	ud := L.NewUserData()
+	ud.Value = reference
+	L.SetMetatable(ud, L.GetTypeMetatable(luaReferenceName))
+	L.Push(ud)
+	return 1
+}
+
+// referenceString converts a reference back to a common name
+func (s *Sandbox) referenceString(L *lua.LState) int {
+	r := checkReference(L, 1)
+	L.Push(lua.LString(r.Ref.CommonName()))
+	return 1
+}
+
+func (s *Sandbox) referenceGetSetTag(L *lua.LState) int {
+	r := checkReference(L, 1)
+	if L.GetTop() == 2 {
+		r.Ref.Tag = L.CheckString(2)
+		return 0
+	}
+	L.Push(lua.LString(r.Ref.Tag))
+	return 1
+}
+
+func checkReference(L *lua.LState, i int) *reference {
+	var ref *reference
+	switch L.Get(i).Type() {
+	case lua.LTString:
+		nr, err := regclient.NewRef(L.CheckString(1))
+		if err != nil {
+			L.ArgError(i, "reference parsing failed: "+err.Error())
+		}
+		ref = &reference{Ref: nr}
+	case lua.LTUserData:
+		ud := L.CheckUserData(i)
+		r, ok := ud.Value.(*reference)
+		if !ok {
+			L.ArgError(i, "reference expected")
+		}
+		ref = r
+	}
+	return ref
+}
+
+func isReference(L *lua.LState, i int) bool {
+	if L.Get(i).Type() != lua.LTUserData {
+		return false
+	}
+	ud := L.CheckUserData(i)
+	if _, ok := ud.Value.(*reference); ok {
+		return true
+	}
+	return false
+}

--- a/cmd/regbot/sandbox/reference.go
+++ b/cmd/regbot/sandbox/reference.go
@@ -72,6 +72,8 @@ func checkReference(L *lua.LState, i int) *reference {
 			L.ArgError(i, "reference expected")
 		}
 		ref = r
+	default:
+		L.ArgError(i, "reference expected")
 	}
 	return ref
 }

--- a/cmd/regbot/sandbox/reference.go
+++ b/cmd/regbot/sandbox/reference.go
@@ -26,65 +26,72 @@ type reference struct {
 }
 
 // newReference creates a reference
-func (s *Sandbox) newReference(L *lua.LState) int {
-	ref, err := regclient.NewRef(L.CheckString(1))
+func (s *Sandbox) newReference(ls *lua.LState) int {
+	ref, err := regclient.NewRef(ls.CheckString(1))
 	if err != nil {
-		L.ArgError(1, "reference parsing failed: "+err.Error())
+		ls.ArgError(1, "reference parsing failed: "+err.Error())
 	}
 	reference := &reference{Ref: ref}
-	ud := L.NewUserData()
+	ud := ls.NewUserData()
 	ud.Value = reference
-	L.SetMetatable(ud, L.GetTypeMetatable(luaReferenceName))
-	L.Push(ud)
+	ls.SetMetatable(ud, ls.GetTypeMetatable(luaReferenceName))
+	ls.Push(ud)
 	return 1
 }
 
-// referenceString converts a reference back to a common name
-func (s *Sandbox) referenceString(L *lua.LState) int {
-	r := checkReference(L, 1)
-	L.Push(lua.LString(r.Ref.CommonName()))
-	return 1
-}
-
-func (s *Sandbox) referenceGetSetTag(L *lua.LState) int {
-	r := checkReference(L, 1)
-	if L.GetTop() == 2 {
-		r.Ref.Tag = L.CheckString(2)
-		return 0
-	}
-	L.Push(lua.LString(r.Ref.Tag))
-	return 1
-}
-
-func checkReference(L *lua.LState, i int) *reference {
+func (s *Sandbox) checkReference(ls *lua.LState, i int) *reference {
 	var ref *reference
-	switch L.Get(i).Type() {
+	switch ls.Get(i).Type() {
 	case lua.LTString:
-		nr, err := regclient.NewRef(L.CheckString(1))
+		nr, err := regclient.NewRef(ls.CheckString(i))
 		if err != nil {
-			L.ArgError(i, "reference parsing failed: "+err.Error())
+			ls.ArgError(i, "reference parsing failed: "+err.Error())
 		}
 		ref = &reference{Ref: nr}
 	case lua.LTUserData:
-		ud := L.CheckUserData(i)
-		r, ok := ud.Value.(*reference)
-		if !ok {
-			L.ArgError(i, "reference expected")
+		ud := ls.CheckUserData(i)
+		switch ud.Value.(type) {
+		case *reference:
+			ref = ud.Value.(*reference)
+		case *manifest:
+			m := ud.Value.(*manifest)
+			ref = &reference{Ref: m.ref}
+		case *config:
+			c := ud.Value.(*config)
+			ref = &reference{Ref: c.ref}
+		default:
+			ls.ArgError(i, "reference expected")
 		}
-		ref = r
 	default:
-		L.ArgError(i, "reference expected")
+		ls.ArgError(i, "reference expected")
 	}
 	return ref
 }
 
-func isReference(L *lua.LState, i int) bool {
-	if L.Get(i).Type() != lua.LTUserData {
+func isReference(ls *lua.LState, i int) bool {
+	if ls.Get(i).Type() != lua.LTUserData {
 		return false
 	}
-	ud := L.CheckUserData(i)
+	ud := ls.CheckUserData(i)
 	if _, ok := ud.Value.(*reference); ok {
 		return true
 	}
 	return false
+}
+
+// referenceString converts a reference back to a common name
+func (s *Sandbox) referenceString(ls *lua.LState) int {
+	r := s.checkReference(ls, 1)
+	ls.Push(lua.LString(r.Ref.CommonName()))
+	return 1
+}
+
+func (s *Sandbox) referenceGetSetTag(ls *lua.LState) int {
+	r := s.checkReference(ls, 1)
+	if ls.GetTop() == 2 {
+		r.Ref.Tag = ls.CheckString(2)
+		return 0
+	}
+	ls.Push(lua.LString(r.Ref.Tag))
+	return 1
 }

--- a/cmd/regbot/sandbox/repo.go
+++ b/cmd/regbot/sandbox/repo.go
@@ -1,6 +1,7 @@
 package sandbox
 
 import (
+	"github.com/sirupsen/logrus"
 	lua "github.com/yuin/gopher-lua"
 )
 
@@ -23,6 +24,10 @@ func (s *Sandbox) repoLs(ls *lua.LState) int {
 		ls.ArgError(1, "Expected registry name (host and optional port)")
 	}
 	host := hostLVS.String()
+	s.log.WithFields(logrus.Fields{
+		"script": s.name,
+		"host":   host,
+	}).Debug("Listing repositories")
 	repos, err := s.rc.RepoList(s.ctx, host)
 	if err != nil {
 		ls.RaiseError("Failed retrieving repo list: %v", err)

--- a/cmd/regbot/sandbox/repo.go
+++ b/cmd/regbot/sandbox/repo.go
@@ -1,0 +1,36 @@
+package sandbox
+
+import (
+	lua "github.com/yuin/gopher-lua"
+)
+
+func setupRepo(s *Sandbox) {
+	s.setupMod(
+		luaRepoName,
+		map[string]lua.LGFunction{
+			"ls": s.repoLs,
+		},
+		map[string]map[string]lua.LGFunction{
+			"__index": {},
+		},
+	)
+}
+
+func (s *Sandbox) repoLs(ls *lua.LState) int {
+	hostLV := ls.Get(1)
+	hostLVS, ok := hostLV.(lua.LString)
+	if !ok {
+		ls.ArgError(1, "Expected registry name (host and optional port)")
+	}
+	host := hostLVS.String()
+	repos, err := s.rc.RepoList(s.ctx, host)
+	if err != nil {
+		ls.RaiseError("Failed retrieving repo list: %v", err)
+	}
+	lRepos := ls.NewTable()
+	for _, repo := range repos.Repositories {
+		lRepos.Append(lua.LString(repo))
+	}
+	ls.Push(lRepos)
+	return 1
+}

--- a/cmd/regbot/sandbox/sandbox.go
+++ b/cmd/regbot/sandbox/sandbox.go
@@ -7,6 +7,7 @@ import (
 	"github.com/regclient/regclient/regclient"
 	"github.com/sirupsen/logrus"
 	lua "github.com/yuin/gopher-lua"
+	"golang.org/x/sync/semaphore"
 )
 
 const (
@@ -20,11 +21,13 @@ const (
 
 // Sandbox defines a lua sandbox
 type Sandbox struct {
-	name string
-	ctx  context.Context
-	log  *logrus.Logger
-	ls   *lua.LState
-	rc   regclient.RegClient
+	name   string
+	ctx    context.Context
+	log    *logrus.Logger
+	ls     *lua.LState
+	rc     regclient.RegClient
+	sem    *semaphore.Weighted
+	dryRun bool
 }
 
 // LuaMod defines a mod to add to Lua's sandbox
@@ -37,17 +40,78 @@ var luaMods = []LuaMod{
 	setupImage,
 }
 
-// New creates a new sandbox
-func New(ctx context.Context, name string, rc regclient.RegClient, log *logrus.Logger) *Sandbox {
-	ls := lua.NewState()
-	// TODO: consider removing default methods from lua
-	ls.SetContext(ctx)
-	s := &Sandbox{name: name, ctx: ctx, log: log, ls: ls, rc: rc}
+// Opt function to process options on sandbox
+type Opt func(*Sandbox)
 
+// New creates a new sandbox
+func New(name string, opts ...Opt) *Sandbox {
+	// TODO: consider removing default methods from lua state
+	ls := lua.NewState()
+
+	s := &Sandbox{
+		name:   name,
+		ls:     ls,
+		dryRun: false,
+	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	// default values for various options
+	if s.ctx == nil {
+		s.ctx = context.Background()
+	}
+	if s.log == nil {
+		s.log = &logrus.Logger{}
+	}
+	if s.rc == nil {
+		s.rc = regclient.NewRegClient()
+	}
+
+	// setup modules for the sandbox
 	for _, mod := range luaMods {
 		mod(s)
 	}
+
+	// add other global functions to sandbox
+	fn := s.ls.NewFunction(s.sandboxLog)
+	s.ls.SetGlobal("log", fn)
+
 	return s
+}
+
+// WithContext defines the context for a sandbox
+func WithContext(ctx context.Context) Opt {
+	return func(s *Sandbox) {
+		s.ctx = ctx
+	}
+}
+
+// WithDryRun indicates external changes should only be logged
+func WithDryRun() Opt {
+	return func(s *Sandbox) {
+		s.dryRun = true
+	}
+}
+
+// WithLog specifies a logrus logger
+func WithLog(log *logrus.Logger) Opt {
+	return func(s *Sandbox) {
+		s.log = log
+	}
+}
+
+// WithRegClient specifies a regclient interface
+func WithRegClient(rc regclient.RegClient) Opt {
+	return func(s *Sandbox) {
+		s.rc = rc
+	}
+}
+
+// WithSemaphore defines a semaphore to limit various actions
+func WithSemaphore(sem *semaphore.Weighted) Opt {
+	return func(s *Sandbox) {
+		s.sem = sem
+	}
 }
 
 func (s *Sandbox) setupMod(name string, funcs map[string]lua.LGFunction, tables map[string]map[string]lua.LGFunction) {
@@ -67,8 +131,8 @@ func (s *Sandbox) RunScript(script string) error {
 	defer func() {
 		if r := recover(); r != nil {
 			s.log.WithFields(logrus.Fields{
-				"name":  s.name,
-				"error": r,
+				"script": s.name,
+				"error":  r,
 			}).Error("Runtime error from script")
 		}
 		err = ErrScriptFailed
@@ -80,6 +144,15 @@ func (s *Sandbox) RunScript(script string) error {
 // Close is use to stop the sandbox
 func (s *Sandbox) Close() {
 	s.ls.Close()
+}
+
+func (s *Sandbox) sandboxLog(ls *lua.LState) int {
+	msg := ls.CheckString(1)
+	s.log.WithFields(logrus.Fields{
+		"script":  s.name,
+		"message": msg,
+	}).Info("User script message")
+	return 0
 }
 
 // wrapUserData creates a userdata -> wrapped table -> userdata metatable

--- a/cmd/regbot/sandbox/sandbox.go
+++ b/cmd/regbot/sandbox/sandbox.go
@@ -1,0 +1,65 @@
+package sandbox
+
+import (
+	"context"
+
+	"github.com/regclient/regclient/regclient"
+	"github.com/sirupsen/logrus"
+	lua "github.com/yuin/gopher-lua"
+)
+
+const (
+	luaReferenceName = "reference"
+	luaTagName       = "tag"
+	luaManifestName  = "manifest"
+	luaImageName     = "image"
+)
+
+// Sandbox defines a lua sandbox
+type Sandbox struct {
+	L   *lua.LState
+	RC  regclient.RegClient
+	Ctx context.Context
+	log *logrus.Logger
+}
+
+// LuaMod defines a mod to add to Lua's sandbox
+type LuaMod func(*Sandbox)
+
+var luaMods = []LuaMod{
+	setupReference,
+	setupTag,
+	setupImage,
+}
+
+// New creates a new sandbox
+func New(ctx context.Context, rc regclient.RegClient, log *logrus.Logger) *Sandbox {
+	ls := lua.NewState()
+	s := &Sandbox{Ctx: ctx, L: ls, RC: rc, log: log}
+
+	for _, mod := range luaMods {
+		mod(s)
+	}
+	return s
+}
+
+func (s *Sandbox) setupMod(name string, funcs map[string]lua.LGFunction, tables map[string]map[string]lua.LGFunction) {
+	mt := s.L.NewTypeMetatable(name)
+	s.L.SetGlobal(name, mt)
+	for key, fn := range funcs {
+		s.L.SetField(mt, key, s.L.NewFunction(fn))
+	}
+	for key, fns := range tables {
+		s.L.SetField(mt, key, s.L.SetFuncs(s.L.NewTable(), fns))
+	}
+}
+
+// RunScript is used to execute a script in the sandbox
+func (s *Sandbox) RunScript(script string) error {
+	return s.L.DoString(script)
+}
+
+// Close is use to stop the sandbox
+func (s *Sandbox) Close() {
+	s.L.Close()
+}

--- a/cmd/regbot/sandbox/tag.go
+++ b/cmd/regbot/sandbox/tag.go
@@ -1,0 +1,33 @@
+package sandbox
+
+import (
+	lua "github.com/yuin/gopher-lua"
+)
+
+func setupTag(s *Sandbox) {
+	s.setupMod(
+		luaTagName,
+		map[string]lua.LGFunction{
+			// "new": s.newTag,
+			// "__tostring": s.referenceString,
+			"ls": s.tagLs,
+		},
+		map[string]map[string]lua.LGFunction{
+			"__index": {},
+		},
+	)
+}
+
+func (s *Sandbox) tagLs(L *lua.LState) int {
+	ref := checkReference(L, 1)
+	tl, err := s.RC.TagList(s.Ctx, ref.Ref)
+	if err != nil {
+		L.RaiseError("Failed retrieving tag list: %v", err)
+	}
+	lTags := L.NewTable()
+	for _, tag := range tl.Tags {
+		lTags.Append(lua.LString(tag))
+	}
+	L.Push(lTags)
+	return 1
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ API docs are still needed
 
 ## regctl
 
-### Top level commands
+### regctl Top level commands
 
 ```text
 $ regctl --help
@@ -229,7 +229,7 @@ regctl image inspect --format '{{range $k, $v := .Config.Labels}}{{if eq $k "org
 
 ## regsync
 
-### Top Level Commands
+### regsync Top Level Commands
 
 ```text
 $ regsync --help
@@ -390,6 +390,173 @@ template supports the following objects:
 
 See [Template Functions](#Template-Functions) for more details on the custom
 functions available in templates.
+
+## regbot
+
+### regbot Top Level Commands
+
+```text
+$ regbot --help
+Utility for automating repository actions
+More details at https://github.com/regclient/regclient
+
+Usage:
+  regbot [command]
+
+Available Commands:
+  help        Help about any command
+  once        runs each script once
+  server      run the regbot server
+
+Flags:
+  -c, --config string        Config file
+      --dry-run              Dry Run, skip all external actions
+  -h, --help                 help for regbot
+      --logopt stringArray   Log options
+  -v, --verbosity string     Log level (debug, info, warn, error, fatal, panic) (default "info")
+
+Use "regbot [command] --help" for more information about a command.
+```
+
+The `once` command can be placed in a cron or CI job to perform the
+synchronization immediately rather than following the schedule.
+
+The `server` command is useful to run a background process that continuously
+updates the target repositories as the source changes.
+
+The `--dry-run` option is useful for testing scripts without actually copying or
+deleting images.
+
+`--logopt` currently accepts `json` to format all logs as json instead of text.
+This is useful for parsing in external tools like Elastic/Splunk.
+
+### regbot Configuration File
+
+The `regbot` configuration file is yaml formatted with the following layout:
+
+```yaml
+x-sched-a: &sched-a "15 01 * * *"
+version: 1
+creds:
+  - registry: localhost:5000
+    tls: disabled
+    scheme: http
+  - registry: docker.io
+    user: "{{env \"HUB_USER\"}}"
+    pass: "{{file \"/var/run/secrets/hub_token\"}}"
+defaults:
+  parallel: 2
+  timeout: 300s
+scripts:
+  - name: Hello World
+    timeout: 10s
+    script: |
+      log "hello world"
+  - name: Busybox Tags
+    timeout: 30s
+    script: |
+      tags = tag.ls("busybox")
+      table.sort(tags)
+      for k, t in ipairs(tags) do
+        log "Found tag " .. t
+      end
+```
+
+- `version`: This should be left at version 1 or not included at all. This may
+  be incremented if future `regbot` releases change the configuration file
+  structure.
+
+- `creds`: Array of registry credentials and settings for connecting. To avoid
+  saving credentials in the same file with the other settings, consider using
+  the `${HOME}/.docker/config.json` or a template in the `user` and `pass`
+  fields to expand a variable or file contents. When using the
+  `regclient/regsync` image, the docker config is read from
+  `/home/appuser/.docker/config.json`. Each `creds` entry supports the following
+  options:
+  - `registry`: Hostname and port of the registry server used in later lines. Use `docker.io` for Docker Hub.
+  - `user`: Username
+  - `pass`: Password
+  - `tls`: Whether TLS is enabled/verified. Values include "enabled" (default), "insecure", or "disabled".
+  - `scheme`: http or https (default)
+  - `regcert`: Registry CA certificate for self signed certificates. This may be a string with `\n` for line breaks, or the yaml multi-line syntax may be used like:
+
+    ```yaml
+    regcert: |
+      -----BEGIN CERTIFICATE-----
+      MIIJDDCCBPSgAwIB....
+      -----END CERTIFICATE-----
+    ```
+
+- `defaults`: Global settings and default values applied to each sync entry:
+  - `interval`: How often to run each sync step in `server` mode.
+  - `schedule`: Cron like schedule to run each step, overrides `interval`.
+  - `parallel`: Number of concurrent actions to run. All scripts may be started
+    concurrently, but will wait on this limit when specific actions are
+    performed like an image copy. Defaults to 1.
+  - `timeout`: Time until the script is aborted. This timeout is enforced when
+    calling various actions like an image copy.
+  - `skipDockerConfig`: Do not read the user credentials in
+    `${HOME}/.docker/config.json`.
+
+- `scripts`: Array of Lua scripts to run.
+  - `script`: Text of the Lua script.
+  - `interval`, `schedule`, and `timeout`: See description under `defaults`.
+
+- `x-*`: Any field beginning with `x-` is considered a user extension and will
+  not be parsed in current for future versions of the project. These are useful
+  for integrating your own tooling, or setting values for yaml anchors and
+  aliases.
+
+[Go templates](https://golang.org/pkg/text/template/) are used to expand values
+in `user`, `pass`, and `regcert`. See [Template Functions](#Template-Functions)
+for more details on the custom functions available in templates.
+
+The Lua script interface is based on Lua 5.1. The [Lua manual is available
+online](https://www.lua.org/manual/5.1/index.html). The following additional
+functions are available:
+
+- `log <msg>`: log a message (preferred over Lua's print).
+- `reference.new <ref>`: accepts an image reference, returning a reference
+  object. Other functions that accept an image name or repository will accept a
+  reference object.
+- `<ref>:tag`: get or set the tag on a reference. This is useful when iterating
+  over tags within a repository.
+- `repo.ls <host:port>`: list the repositories on a registry server. This
+  depends on the registry supporting the API call.
+- `tag.ls <repo>`: returns an array of tags found within a repository.
+- `tag.delete <ref>`: deletes a tag from a registry. This uses the regclient tag
+  delete method that first pushes a dummy manifest to the tag, which avoids
+  deleting other tags that point to the same manifest.
+- `manifest.get`: returns the image manifest. The current platform will
+  be resolved, or it may be specified as a second arg.
+- `manifest.getList`: retrieves a manifest list without resolving the
+  current platform. If the manifest is not a multi-platform manifest list, the
+  single manifest will be returned instead.
+- `manifest.head`: retrieves the manifest using a head request. This
+  pulls the digest and current rate limit and can be used with the manifest
+  delete and ratelimit functions.
+- `<manifest>:config`: see `image.config`
+- `<manifest>:delete`: deletes a manifest. Note that a manifest list or manifest
+  head request to retrieve the manifest is recommended, otherwise the registry
+  may delete a single platform's manifest without deleting the entire
+  multi-platform image, leading to errors when attempting to access the
+  remaining manifest. If multiple tags can point to the same manifest, then
+  using `tag.delete` is recommended.
+- `<manifest>:get`: see `image.manifest`. This is useful for pulling a manifest
+  when you've only run a head request.
+- `<manifest>:ratelimit`: return the ratelimit seen when the manifest was last
+  retrieved. The ratelimit object includes `Set` (boolean indicating if a rate
+  limit was returned with the manifest), `Remain` (requests remaining), `Limit`
+  (maximum limit possible).
+- `<manifest>:ratelimitWait <limit> <poll> <timeout>`: see `image.ratelimitWait`
+- `image.config <ref>`: returns the image configuration, see `docker image
+  inspect`.
+- `image.copy <src-ref> <tgt-ref>`: copies an image. This may be retagging
+  within the same repository, copying between repositories, or copying between
+  registries.
+- `image.ratelimitWait <ref> <limit> <poll> <timeout>`: polls a registry for the
+  rate limit remaining to increase at or above the specified limit. By default
+  the polling interval is `5m` and timeout is `6h`.
 
 ## Template Functions
 

--- a/docs/regbot-quickstart.md
+++ b/docs/regbot-quickstart.md
@@ -1,0 +1,322 @@
+# regsync Quick Start
+
+## Setup a Registry
+
+```shell
+docker network create registry
+docker run -d --restart=unless-stopped --name registry --net registry \
+  -e "REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY=/var/lib/registry" \
+  -e "REGISTRY_STORAGE_DELETE_ENABLED=true" \
+  -e "REGISTRY_VALIDATION_DISABLED=true" \
+  -v "registry-data:/var/lib/registry" \
+  -p "127.0.0.1:5000:5000" \
+  registry:2
+```
+
+## Configure the Yaml File
+
+Create a file called `regbot.yml`:
+
+```yaml
+version: 1
+creds:
+  - registry: registry:5000
+    tls: disabled
+    scheme: http
+  - registry: docker.io
+    user: "{{env \"HUB_USER\"}}"
+    pass: "{{file \"/var/run/secrets/hub_token\"}}"
+defaults:
+  parallel: 2
+  interval: 60m
+  timeout: 600s
+scripts:
+  - name: mirror minor versions
+    timeout: 59m
+    script: |
+      imageList = {"library/alpine", "library/debian"}
+      localReg = "registry:5000"
+      tagExp = "^%d+%.%d+$"
+      minRateLimit = 100
+      maxKeep = 3
+
+      -- define functions for semver sorting
+      function string.split (inputStr, sep)
+        if sep == nil then
+          sep = "%s"
+        end
+        local t={}
+        for str in string.gmatch(inputStr, "([^"..sep.."]+)") do
+          table.insert(t, str)
+        end
+        return t
+      end
+      function isNumber (inputStr)
+        if string.gmatch(inputStr, "^%d+$") then
+          return true
+        else
+          return false
+        end
+      end
+      function orderSemVer(a, b)
+        aSplit = string.split(a, "%.-")
+        bSplit = string.split(b, "%.-")
+        min = (#aSplit > #bSplit) and #aSplit or #bSplit
+        for i = 1, min do
+          if isNumber(aSplit[i]) and isNumber(bSplit[i]) then
+            aNum = tonumber(aSplit[i])
+            bNum = tonumber(bSplit[i])
+            if aNum ~= bNum then
+              return aNum < bNum
+            end
+          elseif aSplit[i] ~= bSplit[i] then
+            return aSplit[i] < bSplit[i]
+          end
+        end
+        -- TODO: should check for rc/alpha/beta versions on longer string (sorting before GA), and 0 is the same as no value
+        return #aSplit < #bSplit
+      end
+
+      -- loop through images
+      for k, imageName in ipairs(imageList) do
+        upstreamRef = reference.new(imageName)
+        localRef = reference.new(localReg .. "/" .. imageName)
+        -- loop through tags on each image
+        tags = tag.ls(upstreamRef)
+        matchTags = {}
+        for k, t in pairs(tags) do
+          if string.match(t, tagExp) then
+            table.insert(matchTags, t)
+          end
+        end
+        table.sort(matchTags, orderSemVer)
+        if #matchTags > maxKeep then
+          matchTags = {unpack(matchTags, #matchTags - maxKeep + 1)}
+        end
+        for k, t in ipairs(matchTags) do
+          -- only copy tags matching the expression
+          if string.match(t, tagExp) then
+            upstreamRef:tag(t)
+            localRef:tag(t)
+            if not image.ratelimitWait(upstreamRef, minRateLimit) then
+              error "Timed out waiting on rate limit"
+            end
+            image.copy(upstreamRef, localRef)
+          end
+        end
+      end
+
+  - name: debian date stamped mirror
+    timeout: 59m
+    script: |
+      imageName = "library/debian"
+      tagExp = "^testing%-%d+$"
+      maxKeep = 3
+      minRateLimit = 150
+
+      upstreamRef = reference.new(imageName)
+      localRef = reference.new("registry:5000/" .. imageName)
+
+      -- first copy new date stamped images
+      tags = tag.ls(upstreamRef)
+      matchTags = {}
+      for k, t in pairs(tags) do
+        if string.match(t, tagExp) then
+          table.insert(matchTags, t)
+        end
+      end
+      table.sort(matchTags)
+      if #matchTags > maxKeep then
+        matchTags = {unpack(matchTags, #matchTags - maxKeep + 1)}
+        for k, t in ipairs(matchTags) do
+          upstreamRef:tag(t)
+          localRef:tag(t)
+          if not image.ratelimitWait(upstreamRef, minRateLimit) then
+            error "Timed out waiting on rate limit"
+          end
+          log("Copying " .. t)
+          image.copy(upstreamRef, localRef)
+        end
+      end
+
+      -- next delete old date stamped images
+      tags = tag.ls(localRef)
+      matchTags = {}
+      for k, t in pairs(tags) do
+        if string.match(t, tagExp) then
+          table.insert(matchTags, t)
+        end
+      end
+      table.sort(matchTags)
+      if #matchTags > maxKeep then
+        matchTags = {unpack(matchTags, 1, #matchTags - maxKeep)}
+        for k, t in ipairs(matchTags) do
+          localRef:tag(t)
+          log("Deleting " .. t)
+          tag.delete(localRef)
+        end
+      end
+
+  - name: delete old builds
+    script: |
+      imageName = "registry:5000/regclient/example"
+      tagExp = "^ci%-%d+$"
+      maxDays = 30
+      imageLabel = "org.opencontainers.image.created"
+      dateFmt = "!%Y-%m-%dT%H:%M:%SZ"
+
+      timeRef = os.time() - (86400*maxDays)
+      cutoff = os.date(dateFmt, timeRef)
+      log("Searching for images before: " .. cutoff)
+      ref = reference.new(imageName)
+      tags = tag.ls(ref)
+      table.sort(tags)
+      for k, t in pairs(tags) do
+        if string.match(t, tagExp) then
+          ref:tag(t)
+          ic = image.config(ref)
+          if ic.Config.Labels[imageLabel] < cutoff then
+            log("Deleting " .. t .. " created on " .. ic.Config.Labels[imageLabel])
+            tag.delete(ref)
+          else
+            log("Skipping " .. t .. " created on " .. ic.Config.Labels[imageLabel])
+          end
+        end
+      end
+```
+
+This file contains three scripts to run every hour:
+
+- mirror minor versions: This copies the 3 most recent minor versions from the
+  upstream repositories for Alpine and Debian, copying them to
+  `registry:5000/library/alpine` and `registry:5000/library/debian`
+  respectively. This shows how you can copy images parsing the semver and
+  including a specific range of those images.
+- debian date stamped mirror: This copies the 3 most recent `testing-` tags
+  followed by a number. A similar pattern could be used to copy nightly builds
+  of an image. This also includes a cleanup of older images, avoiding filling
+  the local registry with old images.
+- delete old builds: This examines the example images (setup below), looking for
+  anything matching the `ci-` tag followed by a number, and comparing the
+  datestamp in the "org.opencontainers.image.created" label to see if it's more
+  than 30 days old. This example could be used to automatically prune old builds
+  that may not have been promoted through the CI pipeline and are no longer
+  useful.
+
+This file assumes the local registry is `registry:5000`, which is available when
+using container-to-container networking. If you run this without container
+networking, then adjust the local registry name and any configuration details to
+access that registry with write access.
+
+## Setup regctl
+
+Run the following to setup `regctl` that will be used to setup and later inspect
+the registry.
+
+```shell
+cat >regctl <<EOF
+#!/bin/sh
+
+docker container run -it --rm --net host \\
+  -u "\$(id -u):\$(id -g)" -e HOME -v \$HOME:\$HOME \\
+  -v /etc/docker/certs.d:/etc/docker/certs.d:ro \\
+  regclient/regctl:latest "\$@"
+EOF
+chmod 755 regctl
+./regctl registry set --scheme http --tls disabled localhost:5000
+```
+
+## Load example images
+
+Copy some images to the local registry that have the specified label to see the
+"delete old builds" action work. The `regclient/regctl` image includes these
+labels, and we can also use `regctl` itself to copy these images.
+
+```shell
+./regctl image copy -v info \
+    regclient/regctl:v0.0.1 localhost:5000/regclient/example:latest \
+&& \
+./regctl image copy -v info \
+    localhost:5000/regclient/example:latest localhost:5000/regclient/example:ci-001 \
+&& \
+./regctl image copy -v info \
+    localhost:5000/regclient/example:latest localhost:5000/regclient/example:ci-002 \
+&& \
+./regctl image copy -v info \
+    localhost:5000/regclient/example:latest localhost:5000/regclient/example:ci-003 \
+&& \
+./regctl image copy -v info \
+    localhost:5000/regclient/example:latest localhost:5000/regclient/example:stable \
+&& \
+./regctl image copy -v info \
+    library/debian:latest localhost:5000/library/debian:latest \
+&& \
+./regctl tag ls localhost:5000/regclient/example
+```
+
+The last command should show the tags for 3 CI images, latest, and stable. The
+same old image was used for each, to minimize how many manifests were pulled
+from Docker Hub. For a more realistic example you could copy unique images for
+each. If you use other images, be sure the image label and date format match the
+variables in the "delete old builds" script.
+
+## Perform a Dry-Run
+
+Run regbot in the "once" mode with the "dry-run" option to test the scripts.
+Make sure to replace `your_username` with your Hub username and create the
+hub_token file with your hub password or personal access token.
+
+```shell
+export HUB_USER=your_hub_username
+echo "your_hub_password" >hub_token
+docker container run -it --rm --net registry \
+  -e "HUB_USER" \
+  -v "$(pwd)/hub_token:/var/run/secrets/hub_token:ro" \
+  -v "$(pwd)/regbot.yml:/home/appuser/regbot.yml" \
+  regclient/regbot:latest -c /home/appuser/regbot.yml once --dry-run
+```
+
+## Run the Scripts Now
+
+Repeat the above, but without the "dry-run" option to actually copy and delete
+images. Note that this command will pull a number of images from Hub, but will
+automatically rate limit itself if you have less than the specified pulls
+remaining on your account.
+
+```shell
+docker container run -it --rm --net registry \
+  -e "HUB_USER" \
+  -v "$(pwd)/hub_token:/var/run/secrets/hub_token:ro" \
+  -v "$(pwd)/regbot.yml:/home/appuser/regbot.yml" \
+  regclient/regbot:latest -c /home/appuser/regbot.yml once
+```
+
+## Run the Scripts on a Schedule
+
+If the "once" mode is successful, you can run the server in the background to
+constantly maintain the local registry using the defined scripts.
+
+```shell
+docker container run -d --restart=unless-stopped --name regbot --net registry \
+  -e "HUB_USER" \
+  -v "$(pwd)/hub_token:/var/run/secrets/hub_token:ro" \
+  -v "$(pwd)/regbot.yml:/home/appuser/regbot.yml" \
+  regclient/regbot:latest -c /home/appuser/regbot.yml server -v debug
+```
+
+## Inspect using regctl
+
+```shell
+./regctl repo ls localhost:5000
+```
+
+The repositories we've created should be visible.
+
+```shell
+./regctl tag ls localhost:5000/library/alpine | sort && \
+./regctl tag ls localhost:5000/library/debian | sort && \
+./regctl tag ls localhost:5000/regclient/example | sort
+```
+
+That should show the tags in each of the repositories, without the old example
+ci tags that were pruned, while leaving the other example tags.

--- a/docs/regsync-quickstart.md
+++ b/docs/regsync-quickstart.md
@@ -1,0 +1,150 @@
+# regsync Quick Start
+
+## Setup a Registry
+
+```shell
+docker network create registry
+docker run -d --restart=unless-stopped --name registry --net registry \
+  -e "REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY=/var/lib/registry" \
+  -e "REGISTRY_STORAGE_DELETE_ENABLED=true" \
+  -e "REGISTRY_VALIDATION_DISABLED=true" \
+  -v "registry-data:/var/lib/registry" \
+  -p "127.0.0.1:5000:5000" \
+  registry:2
+```
+
+## Configure a Sync Yaml
+
+Create a file called `regsync.yml`:
+
+```yaml
+version: 1
+creds:
+  - registry: registry:5000
+    tls: disabled
+    scheme: http
+  - registry: docker.io
+    user: "{{env \"HUB_USER\"}}"
+    pass: "{{file \"/var/run/secrets/hub_token\"}}"
+defaults:
+  ratelimit:
+    min: 100
+    retry: 15m
+  parallel: 2
+  interval: 60m
+  backup: "bkup-{{.Ref.Tag}}"
+sync:
+  - source: busybox:latest
+    target: registry:5000/library/busybox:latest
+    type: image
+  - source: alpine
+    target: registry:5000/library/alpine
+    type: repository
+    tags:
+      allow:
+      - "latest"
+      - "3"
+      - "3.\\d+"
+  - source: regclient/regctl:latest
+    target: registry:5000/regclient/regctl:latest
+    type: image
+```
+
+You'll also need to create a `hub_token` file that includes either your hub
+password or a personal access token.
+
+## Test regsync
+
+Run regsync in the "once" mode to populate your registry according to the above
+yaml. Make sure to replace `your_username` with your Hub username. Note that
+this command will pull a number of images from Hub, but will automatically rate
+limit itself if you have less than 100 pulls remaining on your account.
+
+```shell
+docker container run -it --rm --net registry \
+  -v "$(pwd)/regsync.yml:/home/appuser/regsync.yml:ro" \
+  -v "$(pwd)/hub_token:/var/run/secrets/hub_token:ro" \
+  -e "HUB_USER=your_username" \
+  regclient/regsync:latest -c /home/appuser/regsync.yml once
+```
+
+## Run regsync
+
+Once the one time sync looks good, deploy a regsync service in the background,
+again replacing `your_username`:
+
+```shell
+docker container run -d --restart=unless-stopped --name regsync --net registry \
+  -v "$(pwd)/regsync.yml:/home/appuser/regsync.yml:ro" \
+  -v "$(pwd)/hub_token:/var/run/secrets/hub_token:ro" \
+  -e "HUB_USER=your_username" \
+  regclient/regsync:latest -c /home/appuser/regsync.yml server
+```
+
+You can verify it started by checking the logs with `docker container logs
+regsync`. In server mode, no logs will show until the next scheduled run. In
+the above example, that would be 60 minutes. And then, the only output you'll
+see is when a new image gets pulled.
+
+## Use your registry
+
+Now you can run images from your registry or build new images with the above base:
+
+`docker container run -it --rm localhost:5000/library/busybox echo hello world`
+
+In your Dockerfile, you can adjust the registry with a build arg:
+
+```Dockerfile
+ARG registry=docker.io
+ARG tag=3
+FROM ${registry}/library/alpine:${tag}
+CMD echo "The time is now $(date)"
+```
+
+Build that image:
+
+```shell
+docker image build \
+  --build-arg registry=localhost:5000 \
+  -t localhost:5000/time .
+```
+
+Try running it:
+
+`docker container run --rm localhost:5000/time`
+
+Push to your local registry:
+
+`docker image push localhost:5000/time`
+
+## Inspect using regctl
+
+```shell
+cat >regctl <<EOF
+#!/bin/sh
+
+docker container run -it --rm --net host \\
+  -u "\$(id -u):\$(id -g)" -e HOME -v \$HOME:\$HOME \\
+  -v /etc/docker/certs.d:/etc/docker/certs.d:ro \\
+  regclient/regctl:latest "\$@"
+EOF
+chmod 755 regctl
+./regctl registry set --scheme http --tls disabled localhost:5000
+./regctl repo ls localhost:5000
+```
+
+You should see all the repositories setup by regsync.
+
+```shell
+./regctl tag ls localhost:5000/library/alpine
+```
+
+That shows all the tags copied.
+
+```shell
+./regctl image manifest --list localhost:5000/library/alpine:3
+```
+
+And there we can see that regsync pulled the multi-platform image from upstream,
+something that would be non-trivial with a `docker pull` and `docker push`
+command.

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/sirupsen/logrus v1.6.0
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/yuin/gopher-lua v0.0.0-20200816102855-ee81675732da
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 	golang.org/x/net v0.0.0-20200707034311-ab3426394381 // indirect
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,9 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
+github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
+github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
+github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=
@@ -185,6 +188,8 @@ github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGr
 github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
+github.com/yuin/gopher-lua v0.0.0-20200816102855-ee81675732da h1:NimzV1aGyq29m5ukMK0AMWEhFaL/lrEOaephfuoiARg=
+github.com/yuin/gopher-lua v0.0.0-20200816102855-ee81675732da/go.mod h1:E1AXubJBdNmFERAOucpDIxNzeGfLzg0mYh+UfMWdChA=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
@@ -225,6 +230,7 @@ golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190204203706-41f3e6584952/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/pkg/go2lua/convert.go
+++ b/pkg/go2lua/convert.go
@@ -1,0 +1,80 @@
+package go2lua
+
+import (
+	"reflect"
+
+	lua "github.com/yuin/gopher-lua"
+)
+
+// Convert takes an input interface and converts it to a Lua value
+func Convert(ls *lua.LState, v interface{}) lua.LValue {
+	return convertReflect(ls, reflect.ValueOf(v))
+}
+
+func convertReflect(ls *lua.LState, v reflect.Value) lua.LValue {
+	if !v.IsValid() {
+		return lua.LNil
+	}
+	switch v.Type().Kind() {
+	case reflect.Bool:
+		return lua.LBool(v.Bool())
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return lua.LNumber(float64(v.Int()))
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return lua.LNumber(float64(v.Uint()))
+	case reflect.Float32, reflect.Float64:
+		return lua.LNumber(v.Float())
+	case reflect.String:
+		return lua.LString(v.String())
+	case reflect.Array:
+		lTab := ls.NewTable()
+		for i := 0; i < v.Len(); i++ {
+			lTab.RawSetInt(i, convertReflect(ls, v.Index(i)))
+		}
+		return lTab
+	case reflect.Slice:
+		lTab := ls.NewTable()
+		for i := 0; i < v.Len(); i++ {
+			lTab.RawSetInt(i, convertReflect(ls, v.Index(i)))
+		}
+		return lTab
+	case reflect.Map:
+		lTab := ls.NewTable()
+		for _, k := range v.MapKeys() {
+			// only support String and Int keys, all other map keys are ignored
+			if k.Type().Kind() == reflect.String {
+				lTab.RawSetString(k.String(), convertReflect(ls, v.MapIndex(k)))
+			} else if k.Type().Kind() == reflect.Int {
+				lTab.RawSetInt(int(k.Int()), convertReflect(ls, v.MapIndex(k)))
+			}
+		}
+		return lTab
+	case reflect.Struct:
+		vType := v.Type()
+		lTab := ls.NewTable()
+		// TODO: should only exported struct fields be copied? And should the
+		// copy be done to json keys in addition to Go struct keys?
+		for i := 0; i < vType.NumField(); i++ {
+			field := vType.Field(i)
+			lTab.RawSetString(field.Name, convertReflect(ls, v.FieldByName(field.Name)))
+		}
+		return lTab
+	case reflect.Ptr:
+		if v.IsNil() {
+			return lua.LNil
+		}
+		return convertReflect(ls, v.Elem())
+	default:
+		// Unsupported reflect types:
+		// Invalid
+		// Uintptr
+		// Complex64
+		// Complex128
+		// Chan
+		// Func
+		// Interface
+		// UnsafePointer
+
+		return lua.LNil
+	}
+}


### PR DESCRIPTION
This adds the `regbot` command and image that can be used to run Lua scripts with the registry API to manage registries, creating complex mirroring rules and cleanup policies.