### PR TITLE
Updating user-agent header per command

### DIFF
--- a/cmd/regbot/main.go
+++ b/cmd/regbot/main.go
@@ -6,9 +6,6 @@ import (
 )
 
 func main() {
-	// regclient.ConfigDir = ".regsync"
-	// regclient.ConfigEnv = "REGSYNC_CONFIG"
-
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/cmd/regbot/root.go
+++ b/cmd/regbot/root.go
@@ -108,6 +108,7 @@ func rootPreRun(cmd *cobra.Command, args []string) error {
 	}).Debug("Configuring parallel settings")
 	sem = semaphore.NewWeighted(int64(config.Defaults.Parallel))
 	// set the regclient, loading docker creds unless disabled, and inject logins from config file
+	regclient.UserAgent = "regclient/regbot"
 	rcOpts := []regclient.Opt{regclient.WithLog(log)}
 	if !config.Defaults.SkipDockerConf {
 		rcOpts = append(rcOpts, regclient.WithDockerCreds(), regclient.WithDockerCerts())

--- a/cmd/regctl/main.go
+++ b/cmd/regctl/main.go
@@ -7,5 +7,6 @@ import (
 func main() {
 	regclient.ConfigDir = ".regctl"
 	regclient.ConfigEnv = "REGCLI_CONFIG"
+	regclient.UserAgent = "regclient/regctl"
 	Execute()
 }

--- a/cmd/regsync/main.go
+++ b/cmd/regsync/main.go
@@ -6,9 +6,6 @@ import (
 )
 
 func main() {
-	// regclient.ConfigDir = ".regsync"
-	// regclient.ConfigEnv = "REGSYNC_CONFIG"
-
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/cmd/regsync/root.go
+++ b/cmd/regsync/root.go
@@ -126,6 +126,7 @@ func rootPreRun(cmd *cobra.Command, args []string) error {
 	}).Debug("Configuring parallel settings")
 	sem = semaphore.NewWeighted(int64(config.Defaults.Parallel))
 	// set the regclient, loading docker creds unless disabled, and inject logins from config file
+	regclient.UserAgent = "regclient/regsync"
 	rcOpts := []regclient.Opt{regclient.WithLog(log)}
 	if !config.Defaults.SkipDockerConf {
 		rcOpts = append(rcOpts, regclient.WithDockerCreds(), regclient.WithDockerCerts())


### PR DESCRIPTION
This creates unique user-agent headers including regclient/regctl, regclient/regsync, and regclient/regbot.

Signed-off-by: Brandon Mitchell <git@bmitch.net>