### PR TITLE
Refactoring

### DIFF
--- a/cmd/regbot/config.go
+++ b/cmd/regbot/config.go
@@ -13,43 +13,43 @@ import (
 
 // Config is parsed configuration file for regsync
 type Config struct {
-	Version  int            `json:"version"`
-	Creds    []ConfigCreds  `json:"creds"`
-	Defaults ConfigDefaults `json:"defaults"`
-	Scripts  []ConfigScript `json:"scripts"`
+	Version  int            `yaml:"version" json:"version"`
+	Creds    []ConfigCreds  `yaml:"creds" json:"creds"`
+	Defaults ConfigDefaults `yaml:"defaults" json:"defaults"`
+	Scripts  []ConfigScript `yaml:"scripts" json:"scripts"`
 }
 
 // ConfigCreds allows the registry login to be passed in the config rather than from Docker
 type ConfigCreds struct {
-	Registry   string            `json:"registry"`
-	Hostname   string            `json:"hostname"`
-	User       string            `json:"user"`
-	Pass       string            `json:"pass"`
-	TLS        regclient.TLSConf `json:"tls"`
-	Scheme     string            `json:"scheme"` // TODO: delete
-	RegCert    string            `json:"regcert"`
-	PathPrefix string            `json:"pathPrefix"`
-	Mirrors    []string          `json:"mirrors"`
-	Priority   uint              `json:"priority"`
-	API        string            `json:"api"`
+	Registry   string            `yaml:"registry" json:"registry"`
+	Hostname   string            `yaml:"hostname" json:"hostname"`
+	User       string            `yaml:"user" json:"user"`
+	Pass       string            `yaml:"pass" json:"pass"`
+	TLS        regclient.TLSConf `yaml:"tls" json:"tls"`
+	Scheme     string            `yaml:"scheme" json:"scheme"` // TODO: delete
+	RegCert    string            `yaml:"regcert" json:"regcert"`
+	PathPrefix string            `yaml:"pathPrefix" json:"pathPrefix"`
+	Mirrors    []string          `yaml:"mirrors" json:"mirrors"`
+	Priority   uint              `yaml:"priority" json:"priority"`
+	API        string            `yaml:"api" json:"api"`
 }
 
 // ConfigDefaults is uses for general options and defaults for ConfigScript entries
 type ConfigDefaults struct {
-	Interval       time.Duration `json:"interval"`
-	Schedule       string        `json:"schedule"`
-	Parallel       int           `json:"parallel"`
-	SkipDockerConf bool          `json:"skipDockerConfig"`
-	Timeout        time.Duration `json:"timeout"`
+	Interval       time.Duration `yaml:"interval" json:"interval"`
+	Schedule       string        `yaml:"schedule" json:"schedule"`
+	Parallel       int           `yaml:"parallel" json:"parallel"`
+	SkipDockerConf bool          `yaml:"skipDockerConfig" json:"skipDockerConfig"`
+	Timeout        time.Duration `yaml:"timeout" json:"timeout"`
 }
 
 // ConfigScript defines a source/target repository to sync
 type ConfigScript struct {
-	Name     string        `json:"name"`
-	Script   string        `json:"script"`
-	Interval time.Duration `json:"interval"`
-	Schedule string        `json:"schedule"`
-	Timeout  time.Duration `json:"timeout"`
+	Name     string        `yaml:"name" json:"name"`
+	Script   string        `yaml:"script" json:"script"`
+	Interval time.Duration `yaml:"interval" json:"interval"`
+	Schedule string        `yaml:"schedule" json:"schedule"`
+	Timeout  time.Duration `yaml:"timeout" json:"timeout"`
 }
 
 // ConfigNew creates an empty configuration

--- a/cmd/regbot/sandbox/image.go
+++ b/cmd/regbot/sandbox/image.go
@@ -155,11 +155,12 @@ func (s *Sandbox) configGet(ls *lua.LState) int {
 		ls.RaiseError("Failed looking up \"%s\" config digest: %v", m.ref.CommonName(), err)
 	}
 
-	conf, err := s.rc.BlobGetOCIConfig(s.ctx, m.ref, confDigest.String())
+	confBlob, err := s.rc.BlobGetOCIConfig(s.ctx, m.ref, confDigest.String())
 	if err != nil {
 		ls.RaiseError("Failed retrieving \"%s\" config: %v", m.ref.CommonName(), err)
 	}
-	ud, err := wrapUserData(ls, &config{conf: &conf.Image, m: m.m, ref: m.ref}, conf, luaImageConfigName)
+	conf := confBlob.GetConfig()
+	ud, err := wrapUserData(ls, &config{conf: &conf, m: m.m, ref: m.ref}, confBlob, luaImageConfigName)
 	if err != nil {
 		ls.RaiseError("Failed packaging \"%s\" config: %v", m.ref.CommonName(), err)
 	}

--- a/cmd/regbot/sandbox/image.go
+++ b/cmd/regbot/sandbox/image.go
@@ -16,7 +16,7 @@ import (
 type config struct {
 	m    regclient.Manifest
 	ref  regclient.Ref
-	conf *ociv1.Image
+	conf regclient.BlobOCIConfig
 }
 
 type manifest struct {
@@ -159,8 +159,7 @@ func (s *Sandbox) configGet(ls *lua.LState) int {
 	if err != nil {
 		ls.RaiseError("Failed retrieving \"%s\" config: %v", m.ref.CommonName(), err)
 	}
-	conf := confBlob.GetConfig()
-	ud, err := wrapUserData(ls, &config{conf: &conf, m: m.m, ref: m.ref}, confBlob, luaImageConfigName)
+	ud, err := wrapUserData(ls, &config{conf: confBlob, m: m.m, ref: m.ref}, confBlob.GetConfig(), luaImageConfigName)
 	if err != nil {
 		ls.RaiseError("Failed packaging \"%s\" config: %v", m.ref.CommonName(), err)
 	}

--- a/cmd/regctl/config.go
+++ b/cmd/regctl/config.go
@@ -33,12 +33,10 @@ type Config struct {
 // ConfigHost struct contains host specific settings
 type ConfigHost struct {
 	Name       string            `json:"-"`
-	Scheme     string            `json:"scheme,omitempty"` // TODO: remove
 	TLS        regclient.TLSConf `json:"tls,omitempty"`
 	RegCert    string            `json:"regcert,omitempty"`
 	ClientCert string            `json:"clientcert,omitempty"`
 	ClientKey  string            `json:"clientkey,omitempty"`
-	DNS        []string          `json:"dns,omitempty"` // TODO: remove
 	Hostname   string            `json:"hostname,omitempty"`
 	User       string            `json:"user,omitempty"`
 	Pass       string            `json:"pass,omitempty"`
@@ -97,23 +95,14 @@ func ConfigLoadReader(r io.Reader) (*Config, error) {
 		if c.Hosts[h].Name == "" {
 			c.Hosts[h].Name = h
 		}
-		if len(c.Hosts[h].DNS) == 0 {
-			c.Hosts[h].DNS = []string{h}
-		}
 		if c.Hosts[h].Hostname == "" {
 			c.Hosts[h].Hostname = h
-		}
-		if c.Hosts[h].Scheme == "" {
-			c.Hosts[h].Scheme = "https"
 		}
 		if c.Hosts[h].TLS == regclient.TLSUndefined {
 			c.Hosts[h].TLS = regclient.TLSEnabled
 		}
 		if h == regclient.DockerRegistryDNS || h == regclient.DockerRegistry {
 			c.Hosts[h].Name = regclient.DockerRegistry
-			if c.Hosts[h].DNS[0] == h {
-				c.Hosts[h].DNS[0] = regclient.DockerRegistryDNS
-			}
 			if c.Hosts[h].Hostname == h {
 				c.Hosts[h].Hostname = regclient.DockerRegistryDNS
 			}

--- a/cmd/regctl/image.go
+++ b/cmd/regctl/image.go
@@ -301,7 +301,7 @@ func runImageInspect(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	img, err := rc.BlobGetOCIConfig(context.Background(), ref, cd.String())
+	blobConfig, err := rc.BlobGetOCIConfig(context.Background(), ref, cd.String())
 	if err != nil {
 		return err
 	}
@@ -313,7 +313,7 @@ func runImageInspect(cmd *cobra.Command, args []string) error {
 	case "rawHeaders", "raw-headers", "headers":
 		imageOpts.format = "{{ range $key,$vals := .RawHeaders}}{{range $val := $vals}}{{printf \"%s: %s\\n\" $key $val }}{{end}}{{end}}"
 	}
-	return template.Writer(os.Stdout, imageOpts.format, img, template.WithFuncs(regclient.TemplateFuncs))
+	return template.Writer(os.Stdout, imageOpts.format, blobConfig, template.WithFuncs(regclient.TemplateFuncs))
 }
 
 func runImageManifest(cmd *cobra.Command, args []string) error {

--- a/cmd/regsync/config.go
+++ b/cmd/regsync/config.go
@@ -13,6 +13,12 @@ import (
 
 // delay checking for at least 5 minutes when rate limit is exceeded
 var rateLimitRetryMin time.Duration
+var defaultMediaTypes = []string{
+	regclient.MediaTypeDocker2Manifest,
+	regclient.MediaTypeDocker2ManifestList,
+	regclient.MediaTypeOCI1Manifest,
+	regclient.MediaTypeOCI1ManifestList,
+}
 
 func init() {
 	rateLimitRetryMin, _ = time.ParseDuration("5m")
@@ -20,75 +26,77 @@ func init() {
 
 // Config is parsed configuration file for regsync
 type Config struct {
-	Version  int            `json:"version"`
-	Creds    []ConfigCreds  `json:"creds"`
-	Defaults ConfigDefaults `json:"defaults"`
-	Sync     []ConfigSync   `json:"sync"`
+	Version  int            `yaml:"version" json:"version"`
+	Creds    []ConfigCreds  `yaml:"creds" json:"creds"`
+	Defaults ConfigDefaults `yaml:"defaults" json:"defaults"`
+	Sync     []ConfigSync   `yaml:"sync" json:"sync"`
 }
 
 // ConfigCreds allows the registry login to be passed in the config rather than from Docker
 type ConfigCreds struct {
-	Registry   string            `json:"registry"`
-	Hostname   string            `json:"hostname"`
-	User       string            `json:"user"`
-	Pass       string            `json:"pass"`
-	TLS        regclient.TLSConf `json:"tls"`
-	Scheme     string            `json:"scheme"` // TODO: eventually delete
-	RegCert    string            `json:"regcert"`
-	PathPrefix string            `json:"pathPrefix"`
-	Mirrors    []string          `json:"mirrors"`
-	Priority   uint              `json:"priority"`
-	API        string            `json:"api"`
+	Registry   string            `yaml:"registry" json:"registry"`
+	Hostname   string            `yaml:"hostname" json:"hostname"`
+	User       string            `yaml:"user" json:"user"`
+	Pass       string            `yaml:"pass" json:"pass"`
+	TLS        regclient.TLSConf `yaml:"tls" json:"tls"`
+	Scheme     string            `yaml:"scheme" json:"scheme"` // TODO: eventually delete
+	RegCert    string            `yaml:"regcert" json:"regcert"`
+	PathPrefix string            `yaml:"pathPrefix" json:"pathPrefix"`
+	Mirrors    []string          `yaml:"mirrors" json:"mirrors"`
+	Priority   uint              `yaml:"priority" json:"priority"`
+	API        string            `yaml:"api" json:"api"`
 }
 
 // ConfigDefaults is uses for general options and defaults for ConfigSync entries
 type ConfigDefaults struct {
-	Backup         string          `json:"backup"`
-	Interval       time.Duration   `json:"interval"`
-	Schedule       string          `json:"schedule"`
-	RateLimit      ConfigRateLimit `json:"ratelimit"`
-	Parallel       int             `json:"parallel"`
-	SkipDockerConf bool            `json:"skipDockerConfig"`
-	Hooks          ConfigHooks     `json:"hooks"`
+	Backup         string          `yaml:"backup" json:"backup"`
+	Interval       time.Duration   `yaml:"interval" json:"interval"`
+	Schedule       string          `yaml:"schedule" json:"schedule"`
+	RateLimit      ConfigRateLimit `yaml:"ratelimit" json:"ratelimit"`
+	Parallel       int             `yaml:"parallel" json:"parallel"`
+	MediaTypes     []string        `yaml:"mediaTypes" json:"mediaTypes"`
+	SkipDockerConf bool            `yaml:"skipDockerConfig" json:"skipDockerConfig"`
+	Hooks          ConfigHooks     `yaml:"hooks" json:"hooks"`
 }
 
 // ConfigRateLimit is for rate limit settings
 type ConfigRateLimit struct {
-	Min   int           `json:"min"`
-	Retry time.Duration `json:"retry"`
+	Min   int           `yaml:"min" json:"min"`
+	Retry time.Duration `yaml:"retry" json:"retry"`
 }
 
 // ConfigSync defines a source/target repository to sync
 type ConfigSync struct {
-	Source    string          `json:"source"`
-	Target    string          `json:"target"`
-	Type      string          `json:"type"`
-	Tags      ConfigTags      `json:"tags"`
-	Platform  string          `json:"platform"`
-	Backup    string          `json:"backup"`
-	Interval  time.Duration   `json:"interval"`
-	Schedule  string          `json:"schedule"`
-	RateLimit ConfigRateLimit `json:"ratelimit"`
-	Hooks     ConfigHooks     `json:"hooks"`
+	Source     string          `yaml:"source" json:"source"`
+	Target     string          `yaml:"target" json:"target"`
+	Type       string          `yaml:"type" json:"type"`
+	Tags       ConfigTags      `yaml:"tags" json:"tags"`
+	Platform   string          `yaml:"platform" json:"platform"`
+	Backup     string          `yaml:"backup" json:"backup"`
+	Interval   time.Duration   `yaml:"interval" json:"interval"`
+	Schedule   string          `yaml:"schedule" json:"schedule"`
+	RateLimit  ConfigRateLimit `yaml:"ratelimit" json:"ratelimit"`
+	MediaTypes []string        `yaml:"mediaTypes" json:"mediaTypes"`
+	Hooks      ConfigHooks     `yaml:"hooks" json:"hooks"`
 }
 
 // ConfigTags is an allow and deny list of tag regex strings
 type ConfigTags struct {
-	Allow []string `json:"allow"`
-	Deny  []string `json:"deny"`
+	Allow []string `yaml:"allow" json:"allow"`
+	Deny  []string `yaml:"deny" json:"deny"`
 }
 
 // ConfigHooks for commands that run during the sync
 type ConfigHooks struct {
-	Pre       *ConfigHook `json:"pre"`
-	Post      *ConfigHook `json:"post"`
-	Unchanged *ConfigHook `json:"unchanged"`
+	Pre       *ConfigHook `yaml:"pre" json:"pre"`
+	Post      *ConfigHook `yaml:"post" json:"post"`
+	Unchanged *ConfigHook `yaml:"unchanged" json:"unchanged"`
 }
 
 // ConfigHook identifies the hook type and params
 type ConfigHook struct {
-	Type   string   `json:"type"`
-	Params []string `json:"params"`
+	Type   string   `yaml:"type" json:"type"`
+	Params []string `yaml:"params" json:"params"`
 }
 
 // ConfigNew creates an empty configuration
@@ -198,6 +206,13 @@ func syncSetDefaults(s *ConfigSync, d ConfigDefaults) {
 		s.RateLimit.Retry = d.RateLimit.Retry
 	} else if s.RateLimit.Retry < rateLimitRetryMin {
 		s.RateLimit.Retry = rateLimitRetryMin
+	}
+	if len(s.MediaTypes) == 0 {
+		if len(d.MediaTypes) > 0 {
+			s.MediaTypes = d.MediaTypes
+		} else {
+			s.MediaTypes = defaultMediaTypes
+		}
 	}
 	if s.Hooks.Pre == nil && d.Hooks.Pre != nil {
 		s.Hooks.Pre = d.Hooks.Pre

--- a/cmd/regsync/root.go
+++ b/cmd/regsync/root.go
@@ -433,6 +433,24 @@ func (s ConfigSync) processRef(ctx context.Context, src, tgt regclient.Ref, acti
 	}
 	tgtExists := (err == nil)
 
+	// skip when source manifest is an unsupported type
+	smt := mSrc.GetMediaType()
+	found := false
+	for _, mt := range s.MediaTypes {
+		if mt == smt {
+			found = true
+			break
+		}
+	}
+	if !found {
+		log.WithFields(logrus.Fields{
+			"ref":       src.CommonName(),
+			"mediaType": mSrc.GetMediaType(),
+			"allowed":   s.MediaTypes,
+		}).Info("Skipping unsupported media type")
+		return nil
+	}
+
 	// if platform is defined and source is a list, resolve the source platform
 	if mSrc.IsList() && s.Platform != "" {
 		platDigest, err := getPlatformDigest(ctx, src, s.Platform, mSrc)

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,9 @@ require (
 	github.com/docker/distribution v2.7.1+incompatible
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200618181300-9dc6525e6118+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.6.3 // indirect
+	github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7 // indirect
 	github.com/golang/protobuf v1.4.2 // indirect
+	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.0.1
 	github.com/opencontainers/runc v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
+github.com/distribution/distribution v2.7.1+incompatible h1:aGFx4EvJWKEh//lHPLwFhFgwFHKH06TzNVPamrMn04M=
+github.com/distribution/distribution v2.7.1+incompatible/go.mod h1:EgLm2NgWtdKgzF9NpMzUKgzmR7AMmb0VQi2B+ZzDRjc=
 github.com/docker/cli v0.0.0-20200617172703-0ed913b885c8 h1:HDAal6bNQR44qAcPV2ZY0gF3nENOqYTz6q6T01FDKws=
 github.com/docker/cli v0.0.0-20200617172703-0ed913b885c8/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BUmsJpcB+cRlLU7cSug=
@@ -51,6 +53,8 @@ github.com/docker/docker-credential-helpers v0.6.3 h1:zI2p9+1NQYdnG6sMU26EX4aVGl
 github.com/docker/docker-credential-helpers v0.6.3/go.mod h1:WRaJzqw3CTB9bk10avuGsjVBZsD05qeibJ1/TYlvc0Y=
 github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
+github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7 h1:UhxFibDNY/bfvqU5CAUmr9zpesgbU6SWc8/B4mflAE4=
+github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7/go.mod h1:cyGadeNEkKy96OOhEzfZl+yxihPEzKnqJwvfuSUqbZE=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -89,6 +93,8 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0 h1:/QaMHBdZ26BB3SSst0Iwl10Epc+xhTquomWX0oZEB6w=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=

--- a/regclient/config.go
+++ b/regclient/config.go
@@ -94,8 +94,7 @@ type ConfigHost struct {
 // ConfigHostNew creates a default ConfigHost entry
 func ConfigHostNew() *ConfigHost {
 	h := ConfigHost{
-		Scheme: "https", // TODO: delete
-		TLS:    TLSEnabled,
+		TLS: TLSEnabled,
 	}
 	return &h
 }
@@ -104,10 +103,8 @@ func ConfigHostNew() *ConfigHost {
 func ConfigHostNewName(host string) *ConfigHost {
 	h := ConfigHost{
 		Name:     host,
-		Scheme:   "https", // TODO: delete
 		TLS:      TLSEnabled,
 		Hostname: host,
-		DNS:      []string{host}, // TODO: delete
 	}
 	if host == DockerRegistry || host == DockerRegistryDNS || host == DockerRegistryAuth {
 		h.Name = DockerRegistry
@@ -138,17 +135,6 @@ func (rc *regClient) mergeConfigHost(curHost, newHost ConfigHost, warn bool) Con
 			}).Warn("Changing login password for registry")
 		}
 		curHost.Pass = newHost.Pass
-	}
-
-	if newHost.Scheme != "" { // TODO: delete
-		if warn && curHost.Scheme != "" && curHost.Scheme != newHost.Scheme {
-			rc.log.WithFields(logrus.Fields{
-				"orig": curHost.Scheme,
-				"new":  newHost.Scheme,
-				"host": name,
-			}).Warn("Changing scheme for registry")
-		}
-		curHost.Scheme = newHost.Scheme
 	}
 
 	if newHost.TLS != TLSUndefined {
@@ -249,17 +235,6 @@ func (rc *regClient) mergeConfigHost(curHost, newHost ConfigHost, warn bool) Con
 			}).Warn("Changing API settings for registry")
 		}
 		curHost.API = newHost.API
-	}
-
-	if len(newHost.DNS) > 0 { // TODO: deprecate
-		if warn && len(curHost.DNS) > 0 && !stringSliceEq(curHost.DNS, newHost.DNS) {
-			rc.log.WithFields(logrus.Fields{
-				"orig": curHost.DNS,
-				"new":  newHost.DNS,
-				"host": name,
-			}).Warn("Changing DNS settings for registry")
-		}
-		curHost.DNS = newHost.DNS
 	}
 
 	return curHost

--- a/regclient/manifest.go
+++ b/regclient/manifest.go
@@ -254,6 +254,9 @@ func (m *manifestOCIM) MarshalPretty() ([]byte, error) {
 	return buf.Bytes(), nil
 }
 func (m *manifestDockerML) MarshalPretty() ([]byte, error) {
+	if m == nil {
+		return []byte{}, nil
+	}
 	buf := &bytes.Buffer{}
 	tw := tabwriter.NewWriter(buf, 0, 0, 1, ' ', 0)
 	if m.ref.Reference != "" {
@@ -285,7 +288,7 @@ func (m *manifestDockerML) MarshalPretty() ([]byte, error) {
 		if len(d.URLs) > 0 {
 			fmt.Fprintf(tw, "  URLs:\t%s\n", strings.Join(d.URLs, ", "))
 		}
-		if len(d.Annotations) > 0 {
+		if d.Annotations != nil {
 			fmt.Fprintf(tw, "  Annotations:\t\n")
 			for k, v := range d.Annotations {
 				fmt.Fprintf(tw, "    %s:\t%s\n", k, v)
@@ -296,6 +299,9 @@ func (m *manifestDockerML) MarshalPretty() ([]byte, error) {
 	return buf.Bytes(), nil
 }
 func (m *manifestOCIML) MarshalPretty() ([]byte, error) {
+	if m == nil {
+		return []byte{}, nil
+	}
 	buf := &bytes.Buffer{}
 	tw := tabwriter.NewWriter(buf, 0, 0, 1, ' ', 0)
 	if m.ref.Reference != "" {
@@ -315,19 +321,21 @@ func (m *manifestOCIML) MarshalPretty() ([]byte, error) {
 			fmt.Fprintf(tw, "  Digest:\t%s\n", string(d.Digest))
 		}
 		fmt.Fprintf(tw, "  MediaType:\t%s\n", d.MediaType)
-		if p := d.Platform; p.OS != "" {
-			fmt.Fprintf(tw, "  Platform:\t%s\n", platforms.Format(*p))
-			if p.OSVersion != "" {
-				fmt.Fprintf(tw, "  OSVersion:\t%s\n", p.OSVersion)
-			}
-			if len(p.OSFeatures) > 0 {
-				fmt.Fprintf(tw, "  OSFeatures:\t%s\n", strings.Join(p.OSFeatures, ", "))
+		if d.Platform != nil {
+			if p := d.Platform; p.OS != "" {
+				fmt.Fprintf(tw, "  Platform:\t%s\n", platforms.Format(*p))
+				if p.OSVersion != "" {
+					fmt.Fprintf(tw, "  OSVersion:\t%s\n", p.OSVersion)
+				}
+				if len(p.OSFeatures) > 0 {
+					fmt.Fprintf(tw, "  OSFeatures:\t%s\n", strings.Join(p.OSFeatures, ", "))
+				}
 			}
 		}
 		if len(d.URLs) > 0 {
 			fmt.Fprintf(tw, "  URLs:\t%s\n", strings.Join(d.URLs, ", "))
 		}
-		if len(d.Annotations) > 0 {
+		if d.Annotations != nil {
 			fmt.Fprintf(tw, "  Annotations:\t\n")
 			for k, v := range d.Annotations {
 				fmt.Fprintf(tw, "    %s:\t%s\n", k, v)

--- a/regclient/regclient.go
+++ b/regclient/regclient.go
@@ -35,6 +35,10 @@ const (
 	DockerRegistryAuth = "https://index.docker.io/v1/"
 	// DockerRegistryDNS is the host to connect to for Hub
 	DockerRegistryDNS = "registry-1.docker.io"
+	// MediaTypeDocker1Manifest deprecated media type for docker schema1 manifests
+	MediaTypeDocker1Manifest = "application/vnd.docker.distribution.manifest.v1+json"
+	// MediaTypeDocker1ManifestSigned is a deprecated schema1 manifest with jws signing
+	MediaTypeDocker1ManifestSigned = "application/vnd.docker.distribution.manifest.v1+prettyjws"
 	// MediaTypeDocker2Manifest is the media type when pulling manifests from a v2 registry
 	MediaTypeDocker2Manifest = dockerSchema2.MediaTypeManifest
 	// MediaTypeDocker2ManifestList is the media type when pulling a manifest list from a v2 registry

--- a/regclient/repo.go
+++ b/regclient/repo.go
@@ -110,7 +110,8 @@ func (rc *regClient) RepoListWithOpts(ctx context.Context, hostname string, opts
 	}
 	rlc.rawBody = respBody
 	rlc.mt = resp.HTTPResponse().Header.Get("Content-Type")
-	switch rlc.mt {
+	mt := strings.Split(rlc.mt, ";")[0] // "application/json; charset=utf-8" -> "application/json"
+	switch mt {
 	case "application/json":
 		var rdl RepoDockerList
 		err = json.Unmarshal(respBody, &rdl)
@@ -120,7 +121,7 @@ func (rc *regClient) RepoListWithOpts(ctx context.Context, hostname string, opts
 			RepoDockerList: rdl,
 		}
 	default:
-		return rl, fmt.Errorf("%w: media type: %s, hostname: %s", ErrUnsupportedMediaType, rlc.mt, hostname)
+		return rl, fmt.Errorf("%w: media type: %s, hostname: %s", ErrUnsupportedMediaType, mt, hostname)
 	}
 	if err != nil {
 		rc.log.WithFields(logrus.Fields{

--- a/regclient/repo.go
+++ b/regclient/repo.go
@@ -112,7 +112,7 @@ func (rc *regClient) RepoListWithOpts(ctx context.Context, hostname string, opts
 	rlc.mt = resp.HTTPResponse().Header.Get("Content-Type")
 	mt := strings.Split(rlc.mt, ";")[0] // "application/json; charset=utf-8" -> "application/json"
 	switch mt {
-	case "application/json":
+	case "application/json", "text/plain":
 		var rdl RepoDockerList
 		err = json.Unmarshal(respBody, &rdl)
 		rlc.orig = rdl

--- a/regclient/tag.go
+++ b/regclient/tag.go
@@ -178,7 +178,7 @@ func (rc *regClient) TagDelete(ctx context.Context, ref Ref) error {
 		}
 		tempManifest = &manifestDockerM{
 			manifestCommon: manifestCommon{
-				mt:       MediaTypeOCI1Manifest,
+				mt:       MediaTypeDocker2Manifest,
 				ref:      ref,
 				orig:     dm,
 				rawBody:  dmBytes,
@@ -271,7 +271,7 @@ func (rc *regClient) TagListWithOpts(ctx context.Context, ref Ref, opts TagOpts)
 	tc.mt = resp.HTTPResponse().Header.Get("Content-Type")
 	mt := strings.Split(tc.mt, ";")[0] // "application/json; charset=utf-8" -> "application/json"
 	switch mt {
-	case "application/json":
+	case "application/json", "text/plain":
 		var tdl TagDockerList
 		err = json.Unmarshal(respBody, &tdl)
 		tc.orig = tdl

--- a/regclient/tag.go
+++ b/regclient/tag.go
@@ -269,7 +269,8 @@ func (rc *regClient) TagListWithOpts(ctx context.Context, ref Ref, opts TagOpts)
 	}
 	tc.rawBody = respBody
 	tc.mt = resp.HTTPResponse().Header.Get("Content-Type")
-	switch tc.mt {
+	mt := strings.Split(tc.mt, ";")[0] // "application/json; charset=utf-8" -> "application/json"
+	switch mt {
 	case "application/json":
 		var tdl TagDockerList
 		err = json.Unmarshal(respBody, &tdl)
@@ -279,7 +280,7 @@ func (rc *regClient) TagListWithOpts(ctx context.Context, ref Ref, opts TagOpts)
 			TagDockerList: tdl,
 		}
 	default:
-		return tl, fmt.Errorf("%w: media type: %s, reference: %s", ErrUnsupportedMediaType, tc.mt, ref.CommonName())
+		return tl, fmt.Errorf("%w: media type: %s, reference: %s", ErrUnsupportedMediaType, mt, ref.CommonName())
 	}
 	if err != nil {
 		rc.log.WithFields(logrus.Fields{


### PR DESCRIPTION
This update continues to refactor away some of the old design decisions like removing DNS and Scheme from the various calls. It also adds Docker Schema v1 support, which while deprecated, is still seen in some older images. This also fixes some yaml parsing issues.