### PR TITLE
Updating docs

### DIFF
--- a/cmd/regbot/sandbox/reference.go
+++ b/cmd/regbot/sandbox/reference.go
@@ -14,7 +14,8 @@ func setupReference(s *Sandbox) {
 		},
 		map[string]map[string]lua.LGFunction{
 			"__index": {
-				"tag": s.referenceGetSetTag,
+				"digest": s.referenceGetSetDigest,
+				"tag":    s.referenceGetSetTag,
 			},
 		},
 	)
@@ -29,7 +30,7 @@ type reference struct {
 func (s *Sandbox) newReference(ls *lua.LState) int {
 	ref := s.checkReference(ls, 1)
 	ud := ls.NewUserData()
-	ud.Value = ref
+	ud.Value = &reference{ref: ref.ref}
 	ls.SetMetatable(ud, ls.GetTypeMetatable(luaReferenceName))
 	ls.Push(ud)
 	return 1
@@ -79,6 +80,16 @@ func isReference(ls *lua.LState, i int) bool {
 func (s *Sandbox) referenceString(ls *lua.LState) int {
 	r := s.checkReference(ls, 1)
 	ls.Push(lua.LString(r.ref.CommonName()))
+	return 1
+}
+
+func (s *Sandbox) referenceGetSetDigest(ls *lua.LState) int {
+	r := s.checkReference(ls, 1)
+	if ls.GetTop() == 2 {
+		r.ref.Digest = ls.CheckString(2)
+		return 0
+	}
+	ls.Push(lua.LString(r.ref.Digest))
 	return 1
 }
 

--- a/docs/examples/regsync.yml
+++ b/docs/examples/regsync.yml
@@ -24,6 +24,19 @@ sync:
       - "latest"
       - "3"
       - "3.\\d+"
+  - source: debian
+    target: registry:5000/library/debian
+    type: repository
+    tags:
+      allow:
+      - "\\d+"
+    mediaTypes:
+      - "application/vnd.docker.distribution.manifest.v1+json"
+      - "application/vnd.docker.distribution.manifest.v1+prettyjws"
+      - "application/vnd.docker.distribution.manifest.v2+json"
+      - "application/vnd.docker.distribution.manifest.list.v2+json"
+      - "application/vnd.oci.image.manifest.v1+json"
+      - "application/vnd.oci.image.index.v1+json"
   - source: regclient/regctl:latest
     target: registry:5000/regclient/regctl:latest
     type: image


### PR DESCRIPTION
- Wrap on sentences for better diffs in git.
- Document change in regctl layers to blobs.
- Document mirrors and priority.
- Document media type usage.
- Document version command.
- Document printPretty template.
- Document regbot ref:digest

This also fixes a new reference issue in regbot and adds a digest method to references.