### PR TITLE
regsync: allow registry field to be templated

### DIFF
--- a/cmd/regsync/config.go
+++ b/cmd/regsync/config.go
@@ -157,7 +157,12 @@ func ConfigLoadFile(filename string) (*Config, error) {
 // expand templates in various parts of the config
 func configExpandTemplates(c *Config) error {
 	for i := range c.Creds {
-		val, err := template.String(c.Creds[i].User, nil)
+		val, err := template.String(c.Creds[i].Registry, nil)
+		if err != nil {
+			return err
+		}
+		c.Creds[i].Registry = val
+		val, err = template.String(c.Creds[i].User, nil)
 		if err != nil {
 			return err
 		}

--- a/docs/README.md
+++ b/docs/README.md
@@ -397,7 +397,7 @@ sync:
   Any field beginning with `x-` is considered a user extension and will not be parsed in current or future versions of the project.
   These are useful for integrating your own tooling, or setting values for yaml anchors and aliases.
 
-[Go templates](https://golang.org/pkg/text/template/) are used to expand values in `user`, `pass`, `regcert`, `source`, `target`, and `backup`.
+[Go templates](https://golang.org/pkg/text/template/) are used to expand values in `registry`, `user`, `pass`, `regcert`, `source`, `target`, and `backup`.
 The `backup` template supports the following objects:
 
 - `.Ref`: Reference object about to be overwritten


### PR DESCRIPTION
This allows the registry field to have templates, which may be useful in CI pipelines that pass the local registry name as a variable.