### PR TITLE
Support regctl manifest and blob put

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,17 @@ LD_FLAGS=-X \"github.com/regclient/regclient/regclient.VCSRef=$(VCS_REF)\" \
 GO_BUILD_FLAGS=-ldflags "$(LD_FLAGS)"
 DOCKER_ARGS=--build-arg "VCS_REF=$(VCS_REF)" --build-arg "LD_FLAGS=$(LD_FLAGS)"
 
-.PHONY: all binaries vendor docker test plugin-user plugin-host .FORCE
+.PHONY: all binaries vendor docker fmt vet test plugin-user plugin-host .FORCE
 
 .FORCE:
 
-all: test binaries
+all: fmt vet test binaries
+
+fmt:
+	go fmt ./...
+
+vet:
+	go vet ./...
 
 test:
 	go test ./...

--- a/README.md
+++ b/README.md
@@ -7,24 +7,24 @@ This includes `regctl` for a command line interface to manage registries.
 
 ## regctl Features
 
-- Ability to inspect repo tags, manifests, and image configs without downloading
-  the full image.
-- Ability to copy or retag an image without pulling it into docker. Layers are
-  only pulled if you are copying between different registries and the target
-  registry does not have the layers already.
+- Ability to inspect repo tags, manifests, and image configs without downloading the full image.
+- Ability to copy or retag an image without pulling it into docker.
+  Layers are only pulled if you are copying between different registries and the target registry does not have the layers already.
+- Ability to copy all platforms of a multi-platform image.
 - Ability to export an image from a registry without a docker engine.
 - Ability to delete an image manifest.
 - Ability to delete a tag without removing the entire manifest.
-- Uses docker registry logins and /etc/docker/certs.d by default to support
-  private repositories and self signed registries.
+- Uses docker registry logins and `/etc/docker/certs.d` by default to support private repositories and self signed registries.
 - Shows current usage of Docker Hub's rate limit.
 
 ## regsync features
 
+- Ability to copy or retag an image without pulling it into docker.
+  Layers are only pulled if you are copying between different registries and the target registry does not have the layers already.
+- Ability to copy all platforms of a multi-platform image.
 - Mirrors repositories or images based on a yaml configuration.
 - Can use user's docker configuration for registry credentials.
-- Ability to run on a cron schedule, one time synchronization, or only check
-  for stale images.
+- Ability to run on a cron schedule, one time synchronization, or only check for stale images.
 - Ability to backup previous target image before overwriting.
 - Ability to postpone mirror step when rate limit is below a threshold.
 - Ability to mirror multiple images concurrently.
@@ -52,7 +52,6 @@ Unfinished or not yet started work includes:
 
 - Ability to import images from a tar to a registry.
 - Ability to export a multi-platform image.
-- Ability to concurrently download layers.
 - Ability to retry from a partial layer download.
 - Documentation.
 - Testing.
@@ -168,22 +167,20 @@ See the [project documentation](docs/README.md).
 
 Registry client API:
 
-- containerd: containerd'd registry APIs focus more on pulling images than on a
-  general purpose registry client API. This means various registry API calls are
-  not provided.
-- docker/distribution: Docker's client libraries would have needed a fair bit of
-  modification to support OCI images, and behave similar to the docker command
-  line with registry logins.
+- containerd:
+  containerd'd registry APIs focus more on pulling images than on a general purpose registry client API.
+  This means various registry API calls are not provided.
+- distribution/distribution:
+  The distribution project is focused on the server side of the registry API.
+  There are a few client API's, but they appear to be intended for internal use.
 
 There are also a variety of registry command line tools available:
 
-- genuinetools/img: img works on top of buildkit for image creation and
-  management. Using this for a registry client means including lots of
-  dependencies that many will not need.
-- genuinetools/reg: reg is probably the closest match to this project. Some
-  features included in regctl that aren't included in reg are the ability to
-  inject self signed certs, store login credentials separate from docker, copy
-  or retag images, and export images into a tar file.
-- containers/skopeo: Because of RedHat's push to remove any docker solutions
-  from their stack, their skopeo project wasn't considered when searching for a
-  complement to the docker command line.
+- genuinetools/img:
+  img works on top of buildkit for image creation and management.
+  Using this for a registry client means including lots of dependencies that many will not need.
+- genuinetools/reg:
+  reg is probably the closest match to this project.
+  Some features included in regctl that aren't included in reg are the ability to inject self signed certs, store login credentials separate from docker, copy or retag images, and export images into a tar file.
+- containers/skopeo:
+  Because of RedHat's push to remove any docker solutions from their stack, their skopeo project wasn't considered when searching for a complement to docker's tooling.

--- a/cmd/regbot/sandbox/image.go
+++ b/cmd/regbot/sandbox/image.go
@@ -155,7 +155,7 @@ func (s *Sandbox) configGet(ls *lua.LState) int {
 		ls.RaiseError("Failed looking up \"%s\" config digest: %v", m.ref.CommonName(), err)
 	}
 
-	confBlob, err := s.rc.BlobGetOCIConfig(s.ctx, m.ref, confDigest.String())
+	confBlob, err := s.rc.BlobGetOCIConfig(s.ctx, m.ref, confDigest)
 	if err != nil {
 		ls.RaiseError("Failed retrieving \"%s\" config: %v", m.ref.CommonName(), err)
 	}

--- a/cmd/regbot/sandbox/image.go
+++ b/cmd/regbot/sandbox/image.go
@@ -9,19 +9,21 @@ import (
 	ociv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/regclient/regclient/pkg/go2lua"
 	"github.com/regclient/regclient/regclient"
+	"github.com/regclient/regclient/regclient/manifest"
+	"github.com/regclient/regclient/regclient/types"
 	"github.com/sirupsen/logrus"
 	lua "github.com/yuin/gopher-lua"
 )
 
 type config struct {
-	m    regclient.Manifest
-	ref  regclient.Ref
+	m    manifest.Manifest
+	ref  types.Ref
 	conf regclient.BlobOCIConfig
 }
 
-type manifest struct {
-	m   regclient.Manifest
-	ref regclient.Ref
+type sbManifest struct {
+	m   manifest.Manifest
+	ref types.Ref
 }
 
 func setupImage(s *Sandbox) {
@@ -87,11 +89,11 @@ func (s *Sandbox) checkConfig(ls *lua.LState, i int) *config {
 	return c
 }
 
-func (s *Sandbox) checkManifest(ls *lua.LState, i int, list bool, head bool) *manifest {
-	var m *manifest
+func (s *Sandbox) checkManifest(ls *lua.LState, i int, list bool, head bool) *sbManifest {
+	var m *sbManifest
 	switch ls.Get(i).Type() {
 	case lua.LTString:
-		ref, err := regclient.NewRef(ls.CheckString(1))
+		ref, err := types.NewRef(ls.CheckString(1))
 		if err != nil {
 			ls.RaiseError("reference parsing failed: %v", err)
 		}
@@ -100,22 +102,22 @@ func (s *Sandbox) checkManifest(ls *lua.LState, i int, list bool, head bool) *ma
 			if err != nil {
 				ls.RaiseError("Failed retrieving \"%s\" manifest: %v", ref.CommonName(), err)
 			}
-			m = &manifest{m: rcM, ref: ref}
+			m = &sbManifest{m: rcM, ref: ref}
 		} else {
 			rcM, err := s.rcManifestGet(ref, list, "")
 			if err != nil {
 				ls.RaiseError("manifest pull failed: %v", err)
 			}
-			m = &manifest{m: rcM, ref: ref}
+			m = &sbManifest{m: rcM, ref: ref}
 		}
 	case lua.LTUserData:
 		ud := ls.CheckUserData(i)
 		switch ud.Value.(type) {
-		case *manifest:
-			m = ud.Value.(*manifest)
+		case *sbManifest:
+			m = ud.Value.(*sbManifest)
 		case *config:
 			c := ud.Value.(*config)
-			m = &manifest{ref: c.ref, m: c.m}
+			m = &sbManifest{ref: c.ref, m: c.m}
 		case *reference:
 			r := ud.Value.(*reference)
 			if head {
@@ -123,13 +125,13 @@ func (s *Sandbox) checkManifest(ls *lua.LState, i int, list bool, head bool) *ma
 				if err != nil {
 					ls.RaiseError("Failed retrieving \"%s\" manifest: %v", r.ref.CommonName(), err)
 				}
-				m = &manifest{m: rcM, ref: r.ref}
+				m = &sbManifest{m: rcM, ref: r.ref}
 			} else {
 				rcM, err := s.rcManifestGet(r.ref, list, "")
 				if err != nil {
 					ls.RaiseError("manifest pull failed: %v", err)
 				}
-				m = &manifest{m: rcM, ref: r.ref}
+				m = &sbManifest{m: rcM, ref: r.ref}
 			}
 		default:
 			ls.ArgError(i, "manifest expected")
@@ -225,7 +227,7 @@ func (s *Sandbox) manifestGetWithOpts(ls *lua.LState, list bool) int {
 		ls.RaiseError("Failed retrieving \"%s\" manifest: %v", ref.ref.CommonName(), err)
 	}
 
-	ud, err := wrapUserData(ls, &manifest{m: m, ref: ref.ref}, m.GetOrigManifest(), luaManifestName)
+	ud, err := wrapUserData(ls, &sbManifest{m: m, ref: ref.ref}, m.GetOrigManifest(), luaManifestName)
 	if err != nil {
 		ls.RaiseError("Failed packaging \"%s\" manifest: %v", ref.ref.CommonName(), err)
 	}
@@ -246,7 +248,7 @@ func (s *Sandbox) manifestHead(ls *lua.LState) int {
 		ls.RaiseError("Failed retrieving \"%s\" manifest: %v", ref.ref.CommonName(), err)
 	}
 
-	ud, err := wrapUserData(ls, &manifest{m: m, ref: ref.ref}, m, luaManifestName)
+	ud, err := wrapUserData(ls, &sbManifest{m: m, ref: ref.ref}, m, luaManifestName)
 	if err != nil {
 		ls.RaiseError("Failed packaging \"%s\" manifest: %v", ref.ref.CommonName(), err)
 	}
@@ -354,7 +356,7 @@ func (s *Sandbox) manifestJSON(ls *lua.LState) int {
 	return 1
 }
 
-func (s *Sandbox) rcManifestGet(ref regclient.Ref, list bool, platform string) (regclient.Manifest, error) {
+func (s *Sandbox) rcManifestGet(ref types.Ref, list bool, platform string) (manifest.Manifest, error) {
 	m, err := s.rc.ManifestGet(s.ctx, ref)
 	if err != nil {
 		return m, err

--- a/cmd/regbot/sandbox/reference.go
+++ b/cmd/regbot/sandbox/reference.go
@@ -1,7 +1,7 @@
 package sandbox
 
 import (
-	"github.com/regclient/regclient/regclient"
+	"github.com/regclient/regclient/regclient/types"
 	lua "github.com/yuin/gopher-lua"
 )
 
@@ -23,7 +23,7 @@ func setupReference(s *Sandbox) {
 
 // reference refers to a repository or image name
 type reference struct {
-	ref regclient.Ref
+	ref types.Ref
 }
 
 // newReference creates a reference
@@ -40,7 +40,7 @@ func (s *Sandbox) checkReference(ls *lua.LState, i int) *reference {
 	var ref *reference
 	switch ls.Get(i).Type() {
 	case lua.LTString:
-		nr, err := regclient.NewRef(ls.CheckString(i))
+		nr, err := types.NewRef(ls.CheckString(i))
 		if err != nil {
 			ls.ArgError(i, "reference parsing failed: "+err.Error())
 		}
@@ -50,8 +50,8 @@ func (s *Sandbox) checkReference(ls *lua.LState, i int) *reference {
 		switch ud.Value.(type) {
 		case *reference:
 			ref = ud.Value.(*reference)
-		case *manifest:
-			m := ud.Value.(*manifest)
+		case *sbManifest:
+			m := ud.Value.(*sbManifest)
 			ref = &reference{ref: m.ref}
 		case *config:
 			c := ud.Value.(*config)

--- a/cmd/regctl/blob.go
+++ b/cmd/regctl/blob.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/opencontainers/go-digest"
 	"github.com/regclient/regclient/pkg/template"
 	"github.com/regclient/regclient/regclient"
 	"github.com/sirupsen/logrus"
@@ -26,17 +27,31 @@ registry. The blob or layer digest can be found in the image manifest.`,
 	Args: cobra.RangeArgs(2, 2),
 	RunE: runBlobGet,
 }
+var blobPutCmd = &cobra.Command{
+	Use:     "put <repository>",
+	Aliases: []string{"pull"},
+	Short:   "upload a blob/layer",
+	Long: `Upload a blob to a repository. Stdin must be the blob contents. The output
+is the digest of the blob.`,
+	Args: cobra.RangeArgs(1, 1),
+	RunE: runBlobPut,
+}
 
 var blobOpts struct {
 	format string
 	mt     string
+	digest string
 }
 
 func init() {
 	blobGetCmd.Flags().StringVarP(&blobOpts.format, "format", "", "{{printPretty .}}", "Format output with go template syntax")
 	blobGetCmd.Flags().StringVarP(&blobOpts.mt, "media-type", "", "", "Set the requested mediaType")
 
+	blobPutCmd.Flags().StringVarP(&blobOpts.mt, "content-type", "", "", "Set the requested content type")
+	blobPutCmd.Flags().StringVarP(&blobOpts.digest, "digest", "", "", "Set the expected digest")
+
 	blobCmd.AddCommand(blobGetCmd)
+	blobCmd.AddCommand(blobPutCmd)
 	rootCmd.AddCommand(blobCmd)
 }
 
@@ -56,7 +71,11 @@ func runBlobGet(cmd *cobra.Command, args []string) error {
 		"repository": ref.Repository,
 		"digest":     args[1],
 	}).Debug("Pulling blob")
-	blob, err := rc.BlobGet(context.Background(), ref, args[1], accepts)
+	d, err := digest.Parse(args[1])
+	if err != nil {
+		return err
+	}
+	blob, err := rc.BlobGet(context.Background(), ref, d, accepts)
 	if err != nil {
 		return err
 	}
@@ -75,4 +94,31 @@ func runBlobGet(cmd *cobra.Command, args []string) error {
 	}
 
 	return template.Writer(os.Stdout, blobOpts.format, blob, template.WithFuncs(regclient.TemplateFuncs))
+}
+
+func runBlobPut(cmd *cobra.Command, args []string) error {
+	ref, err := regclient.NewRef(args[0])
+	if err != nil {
+		return err
+	}
+	rc := newRegClient()
+
+	log.WithFields(logrus.Fields{
+		"host":         ref.Registry,
+		"repository":   ref.Repository,
+		"digest":       blobOpts.digest,
+		"content-type": blobOpts.mt,
+	}).Debug("Pushing blob")
+	dOut, err := rc.BlobPut(context.Background(), ref, digest.Digest(blobOpts.digest), os.Stdin, blobOpts.mt, 0)
+	if err != nil {
+		return err
+	}
+
+	result := struct {
+		Digest digest.Digest
+	}{
+		Digest: dOut,
+	}
+
+	return template.Writer(os.Stdout, blobOpts.format, result, template.WithFuncs(regclient.TemplateFuncs))
 }

--- a/cmd/regctl/blob.go
+++ b/cmd/regctl/blob.go
@@ -8,6 +8,7 @@ import (
 	"github.com/opencontainers/go-digest"
 	"github.com/regclient/regclient/pkg/template"
 	"github.com/regclient/regclient/regclient"
+	"github.com/regclient/regclient/regclient/types"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -56,7 +57,7 @@ func init() {
 }
 
 func runBlobGet(cmd *cobra.Command, args []string) error {
-	ref, err := regclient.NewRef(args[0])
+	ref, err := types.NewRef(args[0])
 	if err != nil {
 		return err
 	}
@@ -97,7 +98,7 @@ func runBlobGet(cmd *cobra.Command, args []string) error {
 }
 
 func runBlobPut(cmd *cobra.Command, args []string) error {
-	ref, err := regclient.NewRef(args[0])
+	ref, err := types.NewRef(args[0])
 	if err != nil {
 		return err
 	}

--- a/cmd/regctl/image.go
+++ b/cmd/regctl/image.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/regclient/regclient/pkg/template"
 	"github.com/regclient/regclient/regclient"
+	"github.com/regclient/regclient/regclient/types"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -87,17 +88,17 @@ var imageOpts struct {
 }
 
 func init() {
-	imageDigestCmd.Flags().BoolVarP(&imageOpts.list, "list", "", false, "Do not resolve platform from manifest list (recommended)")
-	imageDigestCmd.Flags().StringVarP(&imageOpts.platform, "platform", "p", "", "Specify platform (e.g. linux/amd64)")
-	imageDigestCmd.Flags().BoolVarP(&imageOpts.requireList, "require-list", "", false, "Fail if manifest list is not received")
+	imageDigestCmd.Flags().BoolVarP(&manifestOpts.list, "list", "", false, "Do not resolve platform from manifest list (recommended)")
+	imageDigestCmd.Flags().StringVarP(&manifestOpts.platform, "platform", "p", "", "Specify platform (e.g. linux/amd64)")
+	imageDigestCmd.Flags().BoolVarP(&manifestOpts.requireList, "require-list", "", false, "Fail if manifest list is not received")
 
 	imageInspectCmd.Flags().StringVarP(&imageOpts.platform, "platform", "p", "", "Specify platform (e.g. linux/amd64)")
 	imageInspectCmd.Flags().StringVarP(&imageOpts.format, "format", "", "{{printPretty .}}", "Format output with go template syntax")
 
-	imageManifestCmd.Flags().BoolVarP(&imageOpts.list, "list", "", false, "Output manifest list if available")
-	imageManifestCmd.Flags().StringVarP(&imageOpts.platform, "platform", "p", "", "Specify platform (e.g. linux/amd64)")
-	imageManifestCmd.Flags().BoolVarP(&imageOpts.requireList, "require-list", "", false, "Fail if manifest list is not received")
-	imageManifestCmd.Flags().StringVarP(&imageOpts.format, "format", "", "{{printPretty .}}", "Format output with go template syntax")
+	imageManifestCmd.Flags().BoolVarP(&manifestOpts.list, "list", "", false, "Output manifest list if available")
+	imageManifestCmd.Flags().StringVarP(&manifestOpts.platform, "platform", "p", "", "Specify platform (e.g. linux/amd64)")
+	imageManifestCmd.Flags().BoolVarP(&manifestOpts.requireList, "require-list", "", false, "Fail if manifest list is not received")
+	imageManifestCmd.Flags().StringVarP(&manifestOpts.format, "format", "", "{{printPretty .}}", "Format output with go template syntax")
 
 	imageRateLimitCmd.Flags().StringVarP(&imageOpts.format, "format", "", "{{printPretty .}}", "Format output with go template syntax")
 
@@ -113,11 +114,11 @@ func init() {
 }
 
 func runImageCopy(cmd *cobra.Command, args []string) error {
-	refSrc, err := regclient.NewRef(args[0])
+	refSrc, err := types.NewRef(args[0])
 	if err != nil {
 		return err
 	}
-	refTgt, err := regclient.NewRef(args[1])
+	refTgt, err := types.NewRef(args[1])
 	if err != nil {
 		return err
 	}
@@ -134,7 +135,7 @@ func runImageCopy(cmd *cobra.Command, args []string) error {
 }
 
 func runImageExport(cmd *cobra.Command, args []string) error {
-	ref, err := regclient.NewRef(args[0])
+	ref, err := types.NewRef(args[0])
 	if err != nil {
 		return err
 	}
@@ -152,7 +153,7 @@ func runImageImport(cmd *cobra.Command, args []string) error {
 }
 
 func runImageInspect(cmd *cobra.Command, args []string) error {
-	ref, err := regclient.NewRef(args[0])
+	ref, err := types.NewRef(args[0])
 	if err != nil {
 		return err
 	}
@@ -190,7 +191,7 @@ func runImageInspect(cmd *cobra.Command, args []string) error {
 }
 
 func runImageRateLimit(cmd *cobra.Command, args []string) error {
-	ref, err := regclient.NewRef(args[0])
+	ref, err := types.NewRef(args[0])
 	if err != nil {
 		return err
 	}

--- a/cmd/regctl/image.go
+++ b/cmd/regctl/image.go
@@ -2,12 +2,8 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"os"
-	"strings"
 
-	"github.com/containerd/containerd/platforms"
-	ociv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/regclient/regclient/pkg/template"
 	"github.com/regclient/regclient/regclient"
 	"github.com/sirupsen/logrus"
@@ -32,15 +28,15 @@ sends the manifest with the new tag.`,
 var imageDeleteCmd = &cobra.Command{
 	Use:     "delete <image_ref>",
 	Aliases: []string{"del", "rm", "remove"},
-	Short:   "delete image",
+	Short:   "delete image, same as \"manifest delete\"",
 	Args:    cobra.RangeArgs(1, 1),
-	RunE:    runImageDelete,
+	RunE:    runManifestDelete,
 }
 var imageDigestCmd = &cobra.Command{
 	Use:   "digest <image_ref>",
-	Short: "show digest for pinning",
+	Short: "show digest for pinning, same as \"manifest digest\"",
 	Args:  cobra.RangeArgs(1, 1),
-	RunE:  runImageDigest,
+	RunE:  runManifestDigest,
 }
 var imageExportCmd = &cobra.Command{
 	Use:   "export <image_ref>",
@@ -68,10 +64,10 @@ in docker, and inspecting it, but without pulling any of the image layers.`,
 }
 var imageManifestCmd = &cobra.Command{
 	Use:   "manifest <image_ref>",
-	Short: "show manifest or manifest list",
+	Short: "show manifest or manifest list, same as \"manifest get\"",
 	Long:  `Shows the manifest or manifest list of the specified image.`,
 	Args:  cobra.RangeArgs(1, 1),
-	RunE:  runImageManifest,
+	RunE:  runManifestGet,
 }
 var imageRateLimitCmd = &cobra.Command{
 	Use:   "ratelimit <image_ref>",
@@ -116,80 +112,6 @@ func init() {
 	rootCmd.AddCommand(imageCmd)
 }
 
-func getManifest(rc regclient.RegClient, ref regclient.Ref) (regclient.Manifest, error) {
-	m, err := rc.ManifestGet(context.Background(), ref)
-	if err != nil {
-		return m, err
-	}
-
-	// add warning if not list and list required or platform requested
-	if !m.IsList() && imageOpts.requireList {
-		log.Warn("Manifest list unavailable")
-		return m, ErrNotFound
-	}
-	if !m.IsList() && imageOpts.platform != "" {
-		log.Info("Manifest list unavailable, ignoring platform flag")
-	}
-
-	// retrieve the specified platform from the manifest list
-	if m.IsList() && !imageOpts.list && !imageOpts.requireList {
-		desc, err := getPlatformDesc(rc, m)
-		ref.Digest = desc.Digest.String()
-		m, err = rc.ManifestGet(context.Background(), ref)
-		if err != nil {
-			return m, fmt.Errorf("Failed to pull platform specific digest: %w", err)
-		}
-	}
-	return m, nil
-}
-
-func getPlatformDesc(rc regclient.RegClient, m regclient.Manifest) (*ociv1.Descriptor, error) {
-	var desc *ociv1.Descriptor
-	var err error
-	if !m.IsList() {
-		return desc, fmt.Errorf("%w: manifest is not a list", ErrInvalidInput)
-	}
-	if !m.IsSet() {
-		m, err = rc.ManifestGet(context.Background(), m.GetRef())
-		if err != nil {
-			return desc, err
-		}
-	}
-
-	var plat ociv1.Platform
-	if imageOpts.platform != "" {
-		plat, err = platforms.Parse(imageOpts.platform)
-		if err != nil {
-			log.WithFields(logrus.Fields{
-				"platform": imageOpts.platform,
-				"err":      err,
-			}).Warn("Could not parse platform")
-		}
-	}
-	if plat.OS == "" {
-		plat = platforms.DefaultSpec()
-	}
-	desc, err = m.GetPlatformDesc(&plat)
-	if err != nil {
-		pl, _ := m.GetPlatformList()
-		var ps []string
-		for _, p := range pl {
-			ps = append(ps, platforms.Format(*p))
-		}
-		log.WithFields(logrus.Fields{
-			"platform":  platforms.Format(plat),
-			"err":       err,
-			"platforms": strings.Join(ps, ", "),
-		}).Warn("Platform could not be found in manifest list")
-		return desc, ErrNotFound
-	}
-	log.WithFields(logrus.Fields{
-		"platform": platforms.Format(plat),
-		"digest":   desc.Digest.String(),
-	}).Debug("Found platform specific digest in manifest list")
-	return desc, nil
-}
-
 func runImageCopy(cmd *cobra.Command, args []string) error {
 	refSrc, err := regclient.NewRef(args[0])
 	if err != nil {
@@ -209,68 +131,6 @@ func runImageCopy(cmd *cobra.Command, args []string) error {
 		"target tag":  refTgt.Tag,
 	}).Debug("Image copy")
 	return rc.ImageCopy(context.Background(), refSrc, refTgt)
-}
-
-func runImageDelete(cmd *cobra.Command, args []string) error {
-	ref, err := regclient.NewRef(args[0])
-	if err != nil {
-		return err
-	}
-	rc := newRegClient()
-
-	log.WithFields(logrus.Fields{
-		"host": ref.Registry,
-		"repo": ref.Repository,
-		"tag":  ref.Tag,
-	}).Debug("Image digest")
-
-	err = rc.ManifestDelete(context.Background(), ref)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func runImageDigest(cmd *cobra.Command, args []string) error {
-	ref, err := regclient.NewRef(args[0])
-	if err != nil {
-		return err
-	}
-	rc := newRegClient()
-
-	log.WithFields(logrus.Fields{
-		"host": ref.Registry,
-		"repo": ref.Repository,
-		"tag":  ref.Tag,
-	}).Debug("Image digest")
-
-	// attempt to request only the headers, avoids Docker Hub rate limits
-	m, err := rc.ManifestHead(context.Background(), ref)
-	if err != nil {
-		return err
-	}
-
-	// add warning if not list and list required or platform requested
-	if !m.IsList() && imageOpts.requireList {
-		log.Warn("Manifest list unavailable")
-		return ErrNotFound
-	}
-	if !m.IsList() && imageOpts.platform != "" {
-		log.Info("Manifest list unavailable, ignoring platform flag")
-	}
-
-	// retrieve the specified platform from the manifest list
-	for m.IsList() && !imageOpts.list && !imageOpts.requireList {
-		desc, err := getPlatformDesc(rc, m)
-		ref.Digest = desc.Digest.String()
-		m, err = rc.ManifestHead(context.Background(), ref)
-		if err != nil {
-			return fmt.Errorf("Failed retrieving platform specific digest: %w", err)
-		}
-	}
-
-	fmt.Println(m.GetDigest().String())
-	return nil
 }
 
 func runImageExport(cmd *cobra.Command, args []string) error {
@@ -314,7 +174,7 @@ func runImageInspect(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	blobConfig, err := rc.BlobGetOCIConfig(context.Background(), ref, cd.String())
+	blobConfig, err := rc.BlobGetOCIConfig(context.Background(), ref, cd)
 	if err != nil {
 		return err
 	}
@@ -327,29 +187,6 @@ func runImageInspect(cmd *cobra.Command, args []string) error {
 		imageOpts.format = "{{ range $key,$vals := .RawHeaders}}{{range $val := $vals}}{{printf \"%s: %s\\n\" $key $val }}{{end}}{{end}}"
 	}
 	return template.Writer(os.Stdout, imageOpts.format, blobConfig, template.WithFuncs(regclient.TemplateFuncs))
-}
-
-func runImageManifest(cmd *cobra.Command, args []string) error {
-	ref, err := regclient.NewRef(args[0])
-	if err != nil {
-		return err
-	}
-	rc := newRegClient()
-
-	m, err := getManifest(rc, ref)
-	if err != nil {
-		return err
-	}
-
-	switch imageOpts.format {
-	case "raw":
-		imageOpts.format = "{{ range $key,$vals := .RawHeaders}}{{range $val := $vals}}{{printf \"%s: %s\\n\" $key $val }}{{end}}{{end}}{{printf \"\\n%s\" .RawBody}}"
-	case "rawBody", "raw-body", "body":
-		imageOpts.format = "{{printf \"%s\" .RawBody}}"
-	case "rawHeaders", "raw-headers", "headers":
-		imageOpts.format = "{{ range $key,$vals := .RawHeaders}}{{range $val := $vals}}{{printf \"%s: %s\\n\" $key $val }}{{end}}{{end}}"
-	}
-	return template.Writer(os.Stdout, imageOpts.format, m, template.WithFuncs(regclient.TemplateFuncs))
 }
 
 func runImageRateLimit(cmd *cobra.Command, args []string) error {

--- a/cmd/regctl/manifest.go
+++ b/cmd/regctl/manifest.go
@@ -1,0 +1,325 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/containerd/containerd/platforms"
+	dockerManifestList "github.com/docker/distribution/manifest/manifestlist"
+	dockerSchema1 "github.com/docker/distribution/manifest/schema1"
+	dockerSchema2 "github.com/docker/distribution/manifest/schema2"
+	ociv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/regclient/regclient/pkg/template"
+	"github.com/regclient/regclient/regclient"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var manifestCmd = &cobra.Command{
+	Use:   "manifest <cmd>",
+	Short: "manage manifests",
+}
+
+var manifestDeleteCmd = &cobra.Command{
+	Use:     "delete <image_ref>",
+	Aliases: []string{"del", "rm", "remove"},
+	Short:   "delete a manifest",
+	Args:    cobra.RangeArgs(1, 1),
+	RunE:    runManifestDelete,
+}
+
+var manifestDigestCmd = &cobra.Command{
+	Use:   "digest <image_ref>",
+	Short: "retrieve digest of manifest",
+	Args:  cobra.RangeArgs(1, 1),
+	RunE:  runManifestDigest,
+}
+
+var manifestGetCmd = &cobra.Command{
+	Use:   "get <image_ref>",
+	Short: "retrieve manifest or manifest list",
+	Long:  `Shows the manifest or manifest list of the specified image.`,
+	Args:  cobra.RangeArgs(1, 1),
+	RunE:  runManifestGet,
+}
+
+var manifestPutCmd = &cobra.Command{
+	Use:   "put <image_ref>",
+	Short: "push manifest or manifest list",
+	Long:  `Pushes a manifest or manifest list to a repository.`,
+	Args:  cobra.RangeArgs(1, 1),
+	RunE:  runManifestPut,
+}
+
+var manifestOpts struct {
+	list        bool
+	platform    string
+	requireList bool
+	format      string
+	contentType string
+}
+
+func init() {
+	manifestDigestCmd.Flags().BoolVarP(&manifestOpts.list, "list", "", false, "Do not resolve platform from manifest list (recommended)")
+	manifestDigestCmd.Flags().StringVarP(&manifestOpts.platform, "platform", "p", "", "Specify platform (e.g. linux/amd64)")
+	manifestDigestCmd.Flags().BoolVarP(&manifestOpts.requireList, "require-list", "", false, "Fail if manifest list is not received")
+
+	manifestGetCmd.Flags().BoolVarP(&manifestOpts.list, "list", "", false, "Output manifest list if available")
+	manifestGetCmd.Flags().StringVarP(&manifestOpts.platform, "platform", "p", "", "Specify platform (e.g. linux/amd64)")
+	manifestGetCmd.Flags().BoolVarP(&manifestOpts.requireList, "require-list", "", false, "Fail if manifest list is not received")
+	manifestGetCmd.Flags().StringVarP(&manifestOpts.format, "format", "", "{{printPretty .}}", "Format output with go template syntax")
+
+	manifestPutCmd.Flags().StringVarP(&manifestOpts.contentType, "content-type", "t", "", "Specify content-type (e.g. application/vnd.docker.distribution.manifest.v2+json)")
+	manifestPutCmd.MarkFlagRequired("content-type")
+
+	manifestCmd.AddCommand(manifestDeleteCmd)
+	manifestCmd.AddCommand(manifestDigestCmd)
+	manifestCmd.AddCommand(manifestGetCmd)
+	manifestCmd.AddCommand(manifestPutCmd)
+	rootCmd.AddCommand(manifestCmd)
+}
+
+func getManifest(rc regclient.RegClient, ref regclient.Ref) (regclient.Manifest, error) {
+	m, err := rc.ManifestGet(context.Background(), ref)
+	if err != nil {
+		return m, err
+	}
+
+	// add warning if not list and list required or platform requested
+	if !m.IsList() && manifestOpts.requireList {
+		log.Warn("Manifest list unavailable")
+		return m, ErrNotFound
+	}
+	if !m.IsList() && manifestOpts.platform != "" {
+		log.Info("Manifest list unavailable, ignoring platform flag")
+	}
+
+	// retrieve the specified platform from the manifest list
+	if m.IsList() && !manifestOpts.list && !manifestOpts.requireList {
+		desc, err := getPlatformDesc(rc, m)
+		ref.Digest = desc.Digest.String()
+		m, err = rc.ManifestGet(context.Background(), ref)
+		if err != nil {
+			return m, fmt.Errorf("Failed to pull platform specific digest: %w", err)
+		}
+	}
+	return m, nil
+}
+
+func getPlatformDesc(rc regclient.RegClient, m regclient.Manifest) (*ociv1.Descriptor, error) {
+	var desc *ociv1.Descriptor
+	var err error
+	if !m.IsList() {
+		return desc, fmt.Errorf("%w: manifest is not a list", ErrInvalidInput)
+	}
+	if !m.IsSet() {
+		m, err = rc.ManifestGet(context.Background(), m.GetRef())
+		if err != nil {
+			return desc, err
+		}
+	}
+
+	var plat ociv1.Platform
+	if manifestOpts.platform != "" {
+		plat, err = platforms.Parse(manifestOpts.platform)
+		if err != nil {
+			log.WithFields(logrus.Fields{
+				"platform": manifestOpts.platform,
+				"err":      err,
+			}).Warn("Could not parse platform")
+		}
+	}
+	if plat.OS == "" {
+		plat = platforms.DefaultSpec()
+	}
+	desc, err = m.GetPlatformDesc(&plat)
+	if err != nil {
+		pl, _ := m.GetPlatformList()
+		var ps []string
+		for _, p := range pl {
+			ps = append(ps, platforms.Format(*p))
+		}
+		log.WithFields(logrus.Fields{
+			"platform":  platforms.Format(plat),
+			"err":       err,
+			"platforms": strings.Join(ps, ", "),
+		}).Warn("Platform could not be found in manifest list")
+		return desc, ErrNotFound
+	}
+	log.WithFields(logrus.Fields{
+		"platform": platforms.Format(plat),
+		"digest":   desc.Digest.String(),
+	}).Debug("Found platform specific digest in manifest list")
+	return desc, nil
+}
+
+func runManifestDelete(cmd *cobra.Command, args []string) error {
+	ref, err := regclient.NewRef(args[0])
+	if err != nil {
+		return err
+	}
+	rc := newRegClient()
+
+	log.WithFields(logrus.Fields{
+		"host": ref.Registry,
+		"repo": ref.Repository,
+		"tag":  ref.Tag,
+	}).Debug("Image digest")
+
+	err = rc.ManifestDelete(context.Background(), ref)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func runManifestDigest(cmd *cobra.Command, args []string) error {
+	ref, err := regclient.NewRef(args[0])
+	if err != nil {
+		return err
+	}
+	rc := newRegClient()
+
+	log.WithFields(logrus.Fields{
+		"host": ref.Registry,
+		"repo": ref.Repository,
+		"tag":  ref.Tag,
+	}).Debug("Image digest")
+
+	// attempt to request only the headers, avoids Docker Hub rate limits
+	m, err := rc.ManifestHead(context.Background(), ref)
+	if err != nil {
+		return err
+	}
+
+	// add warning if not list and list required or platform requested
+	if !m.IsList() && manifestOpts.requireList {
+		log.Warn("Manifest list unavailable")
+		return ErrNotFound
+	}
+	if !m.IsList() && manifestOpts.platform != "" {
+		log.Info("Manifest list unavailable, ignoring platform flag")
+	}
+
+	// retrieve the specified platform from the manifest list
+	for m.IsList() && !manifestOpts.list && !manifestOpts.requireList {
+		desc, err := getPlatformDesc(rc, m)
+		ref.Digest = desc.Digest.String()
+		m, err = rc.ManifestHead(context.Background(), ref)
+		if err != nil {
+			return fmt.Errorf("Failed retrieving platform specific digest: %w", err)
+		}
+	}
+
+	fmt.Println(m.GetDigest().String())
+	return nil
+}
+
+func runManifestGet(cmd *cobra.Command, args []string) error {
+	ref, err := regclient.NewRef(args[0])
+	if err != nil {
+		return err
+	}
+	rc := newRegClient()
+
+	m, err := getManifest(rc, ref)
+	if err != nil {
+		return err
+	}
+
+	switch manifestOpts.format {
+	case "raw":
+		manifestOpts.format = "{{ range $key,$vals := .RawHeaders}}{{range $val := $vals}}{{printf \"%s: %s\\n\" $key $val }}{{end}}{{end}}{{printf \"\\n%s\" .RawBody}}"
+	case "rawBody", "raw-body", "body":
+		manifestOpts.format = "{{printf \"%s\" .RawBody}}"
+	case "rawHeaders", "raw-headers", "headers":
+		manifestOpts.format = "{{ range $key,$vals := .RawHeaders}}{{range $val := $vals}}{{printf \"%s: %s\\n\" $key $val }}{{end}}{{end}}"
+	}
+	return template.Writer(os.Stdout, manifestOpts.format, m, template.WithFuncs(regclient.TemplateFuncs))
+}
+
+func runManifestPut(cmd *cobra.Command, args []string) error {
+	ref, err := regclient.NewRef(args[0])
+	if err != nil {
+		return err
+	}
+	rc := newRegClient()
+	var rcM regclient.Manifest
+
+	switch manifestOpts.contentType {
+	case regclient.MediaTypeDocker1Manifest:
+		raw, err := ioutil.ReadAll(os.Stdin)
+		if err != nil {
+			return err
+		}
+		var m dockerSchema1.Manifest
+		err = json.Unmarshal(raw, &m)
+		if err != nil {
+			return err
+		}
+		rcM = regclient.NewManifestDocker1M(m, raw)
+	case regclient.MediaTypeDocker1ManifestSigned:
+		raw, err := ioutil.ReadAll(os.Stdin)
+		if err != nil {
+			return err
+		}
+		var m dockerSchema1.SignedManifest
+		err = json.Unmarshal(raw, &m)
+		if err != nil {
+			return err
+		}
+		rcM = regclient.NewManifestDocker1MS(m, raw)
+	case regclient.MediaTypeDocker2Manifest:
+		raw, err := ioutil.ReadAll(os.Stdin)
+		if err != nil {
+			return err
+		}
+		var m dockerSchema2.Manifest
+		err = json.Unmarshal(raw, &m)
+		if err != nil {
+			return err
+		}
+		rcM = regclient.NewManifestDockerM(m, raw)
+	case regclient.MediaTypeDocker2ManifestList:
+		raw, err := ioutil.ReadAll(os.Stdin)
+		if err != nil {
+			return err
+		}
+		var m dockerManifestList.ManifestList
+		err = json.Unmarshal(raw, &m)
+		if err != nil {
+			return err
+		}
+		rcM = regclient.NewManifestDockerML(m, raw)
+	case regclient.MediaTypeOCI1Manifest:
+		raw, err := ioutil.ReadAll(os.Stdin)
+		if err != nil {
+			return err
+		}
+		var m ociv1.Manifest
+		err = json.Unmarshal(raw, &m)
+		if err != nil {
+			return err
+		}
+		rcM = regclient.NewManifestOCIM(m, raw)
+	case regclient.MediaTypeOCI1ManifestList:
+		raw, err := ioutil.ReadAll(os.Stdin)
+		if err != nil {
+			return err
+		}
+		var m ociv1.Index
+		err = json.Unmarshal(raw, &m)
+		if err != nil {
+			return err
+		}
+		rcM = regclient.NewManifestOCIML(m, raw)
+	default:
+		return fmt.Errorf("%w: unknown content-type: %s", ErrInvalidInput, manifestOpts.contentType)
+	}
+
+	return rc.ManifestPut(context.Background(), ref, rcM)
+}

--- a/cmd/regctl/tag.go
+++ b/cmd/regctl/tag.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/regclient/regclient/pkg/template"
 	"github.com/regclient/regclient/regclient"
+	"github.com/regclient/regclient/regclient/types"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -50,7 +51,7 @@ func init() {
 }
 
 func runTagDelete(cmd *cobra.Command, args []string) error {
-	ref, err := regclient.NewRef(args[0])
+	ref, err := types.NewRef(args[0])
 	if err != nil {
 		return err
 	}
@@ -68,7 +69,7 @@ func runTagDelete(cmd *cobra.Command, args []string) error {
 }
 
 func runTagLs(cmd *cobra.Command, args []string) error {
-	ref, err := regclient.NewRef(args[0])
+	ref, err := types.NewRef(args[0])
 	if err != nil {
 		return err
 	}

--- a/regclient/blob.go
+++ b/regclient/blob.go
@@ -1,6 +1,7 @@
 package regclient
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -18,11 +19,11 @@ import (
 
 // BlobClient provides registry client requests to Blobs
 type BlobClient interface {
-	BlobCopy(ctx context.Context, refSrc Ref, refTgt Ref, d string) error
-	BlobGet(ctx context.Context, ref Ref, d string, accepts []string) (BlobReader, error)
-	BlobGetOCIConfig(ctx context.Context, ref Ref, d string) (BlobOCIConfig, error)
-	BlobMount(ctx context.Context, refSrc Ref, refTgt Ref, d string) error
-	BlobPut(ctx context.Context, ref Ref, d string, rdr io.ReadCloser, ct string, cl int64) error
+	BlobCopy(ctx context.Context, refSrc Ref, refTgt Ref, d digest.Digest) error
+	BlobGet(ctx context.Context, ref Ref, d digest.Digest, accepts []string) (BlobReader, error)
+	BlobGetOCIConfig(ctx context.Context, ref Ref, d digest.Digest) (BlobOCIConfig, error)
+	BlobMount(ctx context.Context, refSrc Ref, refTgt Ref, d digest.Digest) error
+	BlobPut(ctx context.Context, ref Ref, d digest.Digest, rdr io.Reader, ct string, cl int64) (digest.Digest, error)
 }
 
 // Blob interface is used for returning blobs
@@ -69,7 +70,7 @@ type blobOCIConfig struct {
 	ociv1.Image
 }
 
-func (rc *regClient) BlobCopy(ctx context.Context, refSrc Ref, refTgt Ref, d string) error {
+func (rc *regClient) BlobCopy(ctx context.Context, refSrc Ref, refTgt Ref, d digest.Digest) error {
 	// for the same repository, there's nothing to copy
 	if refSrc.Registry == refTgt.Registry && refSrc.Repository == refTgt.Repository {
 		rc.log.WithFields(logrus.Fields{
@@ -115,7 +116,7 @@ func (rc *regClient) BlobCopy(ctx context.Context, refSrc Ref, refTgt Ref, d str
 		return err
 	}
 	defer blobIO.Close()
-	if err := rc.BlobPut(ctx, refTgt, d, blobIO, blobIO.MediaType(), blobIO.Response().ContentLength); err != nil {
+	if _, err := rc.BlobPut(ctx, refTgt, d, blobIO, blobIO.MediaType(), blobIO.Response().ContentLength); err != nil {
 		rc.log.WithFields(logrus.Fields{
 			"err": err,
 			"src": refSrc.Reference,
@@ -126,23 +127,15 @@ func (rc *regClient) BlobCopy(ctx context.Context, refSrc Ref, refTgt Ref, d str
 	return nil
 }
 
-func (rc *regClient) BlobGet(ctx context.Context, ref Ref, d string, accepts []string) (BlobReader, error) {
+func (rc *regClient) BlobGet(ctx context.Context, ref Ref, d digest.Digest, accepts []string) (BlobReader, error) {
 	return rc.blobGet(ctx, ref, d, accepts)
 }
 
-func (rc *regClient) blobGet(ctx context.Context, ref Ref, d string, accepts []string) (blobReader, error) {
+func (rc *regClient) blobGet(ctx context.Context, ref Ref, d digest.Digest, accepts []string) (blobReader, error) {
 	var b blobReader
 	bc := blobCommon{
 		ref:    ref,
-		digest: d,
-	}
-	dp, err := digest.Parse(d)
-	if err != nil {
-		rc.log.WithFields(logrus.Fields{
-			"err":    err,
-			"digest": d,
-		}).Warn("Failed to parse digest")
-		return b, fmt.Errorf("Failed to parse blob digest %s, ref %s: %w", d, ref.CommonName(), err)
+		digest: d.String(),
 	}
 
 	// build/send request
@@ -155,9 +148,9 @@ func (rc *regClient) blobGet(ctx context.Context, ref Ref, d string, accepts []s
 		apis: map[string]httpReqAPI{
 			"": {
 				method:  "GET",
-				path:    ref.Repository + "/blobs/" + d,
+				path:    ref.Repository + "/blobs/" + d.String(),
 				headers: headers,
-				digest:  dp,
+				digest:  d,
 			},
 		},
 	}
@@ -179,7 +172,7 @@ func (rc *regClient) blobGet(ctx context.Context, ref Ref, d string, accepts []s
 	return b, nil
 }
 
-func (rc *regClient) BlobGetOCIConfig(ctx context.Context, ref Ref, d string) (BlobOCIConfig, error) {
+func (rc *regClient) BlobGetOCIConfig(ctx context.Context, ref Ref, d digest.Digest) (BlobOCIConfig, error) {
 	b, err := rc.blobGet(ctx, ref, d, []string{MediaTypeDocker2ImageConfig, ociv1.MediaTypeImageConfig})
 	if err != nil {
 		return blobOCIConfig{}, err
@@ -189,14 +182,14 @@ func (rc *regClient) BlobGetOCIConfig(ctx context.Context, ref Ref, d string) (B
 
 // BlobHead is used to verify if a blob exists and is accessible
 // TODO: on success, return a Blob with non-content data configured
-func (rc *regClient) BlobHead(ctx context.Context, ref Ref, d string) error {
+func (rc *regClient) BlobHead(ctx context.Context, ref Ref, d digest.Digest) error {
 	// build/send request
 	req := httpReq{
 		host: ref.Registry,
 		apis: map[string]httpReqAPI{
 			"": {
 				method: "HEAD",
-				path:   ref.Repository + "/blobs/" + d,
+				path:   ref.Repository + "/blobs/" + d.String(),
 			},
 		},
 	}
@@ -212,14 +205,14 @@ func (rc *regClient) BlobHead(ctx context.Context, ref Ref, d string) error {
 	return nil
 }
 
-func (rc *regClient) BlobMount(ctx context.Context, refSrc Ref, refTgt Ref, d string) error {
+func (rc *regClient) BlobMount(ctx context.Context, refSrc Ref, refTgt Ref, d digest.Digest) error {
 	if refSrc.Registry != refTgt.Registry {
 		return fmt.Errorf("Registry must match for blob mount")
 	}
 
 	// build/send request
 	query := url.Values{}
-	query.Set("mount", d)
+	query.Set("mount", d.String())
 	query.Set("from", refSrc.Repository)
 
 	req := httpReq{
@@ -245,8 +238,7 @@ func (rc *regClient) BlobMount(ctx context.Context, refSrc Ref, refTgt Ref, d st
 	return nil
 }
 
-// TODO: use BlobPut to wrap 3 types of uploads: PUT with chunks, PUT without chunks (implemented here), single POST
-func (rc *regClient) BlobPut(ctx context.Context, ref Ref, d string, rdr io.ReadCloser, ct string, cl int64) error {
+func (rc *regClient) BlobPut(ctx context.Context, ref Ref, d digest.Digest, rdr io.Reader, ct string, cl int64) (digest.Digest, error) {
 	// defaults for content-type and length
 	if ct == "" {
 		ct = "application/octet-stream"
@@ -255,6 +247,25 @@ func (rc *regClient) BlobPut(ctx context.Context, ref Ref, d string, rdr io.Read
 		cl = -1
 	}
 
+	// get the upload URL
+	putURL, err := rc.blobGetUploadURL(ctx, ref)
+	if err != nil {
+		return "", err
+	}
+
+	// send upload as one-chunk
+	if d != "" {
+		err = rc.blobPutUploadFull(ctx, ref, d, putURL, rdr, ct, cl)
+		if err == nil {
+			return digest.Digest(d), nil
+		}
+	}
+
+	// send a chunked upload if full upload not possible or failed
+	return rc.blobPutUploadChunked(ctx, ref, putURL, rdr, ct)
+}
+
+func (rc *regClient) blobGetUploadURL(ctx context.Context, ref Ref) (*url.URL, error) {
 	// request an upload location
 	req := httpReq{
 		host:      ref.Registry,
@@ -268,16 +279,15 @@ func (rc *regClient) BlobPut(ctx context.Context, ref Ref, d string, rdr io.Read
 	}
 	resp, err := rc.httpDo(ctx, req)
 	if err != nil && !errors.Is(err, retryable.ErrStatusCode) {
-		return fmt.Errorf("Failed to send blob post, digest %s, ref %s: %w", d, ref.CommonName(), err)
+		return nil, fmt.Errorf("Failed to send blob post, ref %s: %w", ref.CommonName(), err)
 	}
 	defer resp.Close()
 	if resp.HTTPResponse().StatusCode < 200 || resp.HTTPResponse().StatusCode > 299 {
-		return fmt.Errorf("Failed to send blob post, digest %s, ref %s: %w", d, ref.CommonName(), httpError(resp.HTTPResponse().StatusCode))
+		return nil, fmt.Errorf("Failed to send blob post, ref %s: %w", ref.CommonName(), httpError(resp.HTTPResponse().StatusCode))
 	}
 
 	// Extract the location into a new putURL based on whether it's relative, fqdn with a scheme, or without a scheme.
 	// This doesn't use the httpDo method since location could point to any url, negating the API expansion, mirror handling, and similar features.
-	host := rc.hostGet(ref.Registry)
 	location := resp.HTTPResponse().Header.Get("Location")
 	rc.log.WithFields(logrus.Fields{
 		"location": location,
@@ -290,14 +300,19 @@ func (rc *regClient) BlobPut(ctx context.Context, ref Ref, d string, rdr io.Read
 			"location": location,
 			"err":      err,
 		}).Warn("Location url failed to parse")
-		return fmt.Errorf("Blob upload url invalid, digest %s, ref %s: %w", d, ref.CommonName(), err)
+		return nil, fmt.Errorf("Blob upload url invalid, ref %s: %w", ref.CommonName(), err)
 	}
+	return putURL, nil
+}
+
+func (rc *regClient) blobPutUploadFull(ctx context.Context, ref Ref, d digest.Digest, putURL *url.URL, rdr io.Reader, ct string, cl int64) error {
+	host := rc.hostGet(ref.Registry)
 
 	// append digest to request to use the monolithic upload option
 	if putURL.RawQuery != "" {
-		putURL.RawQuery = putURL.RawQuery + "&digest=" + d
+		putURL.RawQuery = putURL.RawQuery + "&digest=" + d.String()
 	} else {
-		putURL.RawQuery = "digest=" + d
+		putURL.RawQuery = "digest=" + d.String()
 	}
 
 	// send the blob
@@ -309,16 +324,112 @@ func (rc *regClient) BlobPut(ctx context.Context, ref Ref, d string, rdr io.Read
 	opts = append(opts, retryable.WithContentLen(cl))
 	opts = append(opts, retryable.WithHeader("Content-Type", []string{ct}))
 	rty := rc.getRetryable(host)
-	resp, err = rty.DoRequest(ctx, "PUT", []url.URL{*putURL}, opts...)
+	resp, err := rty.DoRequest(ctx, "PUT", []url.URL{*putURL}, opts...)
 	if err != nil && !errors.Is(err, retryable.ErrStatusCode) {
-		return fmt.Errorf("Failed to send blob put, digest %s, ref %s: %w", d, ref.CommonName(), err)
+		return fmt.Errorf("Failed to send blob (put), digest %s, ref %s: %w", d, ref.CommonName(), err)
 	}
 	defer resp.Close()
 	if resp.HTTPResponse().StatusCode < 200 || resp.HTTPResponse().StatusCode > 299 {
-		return fmt.Errorf("Failed to send blob put, digest %s, ref %s: %w", d, ref.CommonName(), httpError(resp.HTTPResponse().StatusCode))
+		return fmt.Errorf("Failed to send blob (put), digest %s, ref %s: %w", d, ref.CommonName(), httpError(resp.HTTPResponse().StatusCode))
+	}
+	return nil
+}
+
+func (rc *regClient) blobPutUploadChunked(ctx context.Context, ref Ref, putURL *url.URL, rdr io.Reader, ct string) (digest.Digest, error) {
+	host := rc.hostGet(ref.Registry)
+	bufSize := int64(512 * 1024) // 512k
+
+	// setup buffer and digest pipe
+	// read manifest and compute digest
+	digester := digest.Canonical.Digester()
+	digestRdr := io.TeeReader(rdr, digester.Hash())
+	chunkBuf := new(bytes.Buffer)
+	chunkBuf.Grow(int(bufSize))
+	finalChunk := false
+	chunkStart := int64(0)
+	bodyFunc := func() (io.ReadCloser, error) {
+		return ioutil.NopCloser(chunkBuf), nil
 	}
 
-	return nil
+	for !finalChunk {
+		chunkURL := *putURL
+		// read a chunk into an input buffer, computing the digest
+		chunkSize, err := io.CopyN(chunkBuf, digestRdr, bufSize)
+		if err == io.EOF {
+			finalChunk = true
+		} else if err != nil {
+			return "", fmt.Errorf("Failed to send blob chunk, ref %s: %w", ref.CommonName(), err)
+		}
+
+		if int64(chunkBuf.Len()) != chunkSize {
+			rc.log.WithFields(logrus.Fields{
+				"buf-size":   chunkBuf.Len(),
+				"chunk-size": chunkSize,
+			}).Debug("Buffer/chunk size mismatch")
+		}
+		if chunkSize > 0 {
+			// write chunk
+			opts := []retryable.OptsReq{}
+			opts = append(opts, retryable.WithBodyFunc(bodyFunc))
+			// opts = append(opts, retryable.WithContentLen(chunkSize))
+			opts = append(opts, retryable.WithHeader("Content-Type", []string{ct}))
+			opts = append(opts, retryable.WithHeader("Content-Length", []string{fmt.Sprintf("%d", chunkSize)}))
+			opts = append(opts, retryable.WithHeader("Content-Range", []string{fmt.Sprintf("%d-%d", chunkStart, chunkStart+chunkSize)}))
+
+			rty := rc.getRetryable(host)
+			resp, err := rty.DoRequest(ctx, "PATCH", []url.URL{chunkURL}, opts...)
+			if err != nil && !errors.Is(err, retryable.ErrStatusCode) {
+				return "", fmt.Errorf("Failed to send blob (chunk), ref %s: %w", ref.CommonName(), err)
+			}
+			resp.Close()
+			if resp.HTTPResponse().StatusCode < 200 || resp.HTTPResponse().StatusCode > 299 {
+				return "", fmt.Errorf("Failed to send blob (chunk), ref %s: %w", ref.CommonName(), httpError(resp.HTTPResponse().StatusCode))
+			}
+			chunkStart += chunkSize
+			if chunkBuf.Len() != 0 {
+				rc.log.WithFields(logrus.Fields{
+					"buf-size":   chunkBuf.Len(),
+					"chunk-size": chunkSize,
+				}).Debug("Buffer was not read")
+			}
+			location := resp.HTTPResponse().Header.Get("Location")
+			rc.log.WithFields(logrus.Fields{
+				"location": location,
+			}).Debug("Next chunk upload location received")
+			prevURL := resp.HTTPResponse().Request.URL
+			putURL, err = prevURL.Parse(location)
+			if err != nil {
+				return "", fmt.Errorf("Failed to send blob (parse next chunk location), ref %s: %w", ref.CommonName(), err)
+			}
+		}
+	}
+
+	// write digest to complete request
+	d := digester.Digest()
+	// append digest to request to use the monolithic upload option
+	if putURL.RawQuery != "" {
+		putURL.RawQuery = putURL.RawQuery + "&digest=" + d.String()
+	} else {
+		putURL.RawQuery = "digest=" + d.String()
+	}
+
+	// send the blob
+	opts := []retryable.OptsReq{}
+	// opts = append(opts, retryable.WithContentLen(0))
+	opts = append(opts, retryable.WithHeader("Content-Length", []string{"0"}))
+	opts = append(opts, retryable.WithHeader("Content-Range", []string{fmt.Sprintf("%d-%d", chunkStart, chunkStart)}))
+	opts = append(opts, retryable.WithHeader("Content-Type", []string{ct}))
+	rty := rc.getRetryable(host)
+	resp, err := rty.DoRequest(ctx, "PUT", []url.URL{*putURL}, opts...)
+	if err != nil && !errors.Is(err, retryable.ErrStatusCode) {
+		return "", fmt.Errorf("Failed to send blob (chunk digest), digest %s, ref %s: %w", d, ref.CommonName(), err)
+	}
+	defer resp.Close()
+	if resp.HTTPResponse().StatusCode < 200 || resp.HTTPResponse().StatusCode > 299 {
+		return "", fmt.Errorf("Failed to send blob (chunk digest), digest %s, ref %s: %w", d, ref.CommonName(), httpError(resp.HTTPResponse().StatusCode))
+	}
+
+	return d, nil
 }
 
 func (b blobCommon) GetOrig() interface{} {
@@ -352,7 +463,7 @@ func (b blobReader) toOCIConfig() (BlobOCIConfig, error) {
 	if err != nil {
 		return blobOCIConfig{}, fmt.Errorf("Error parsing image config for %s: %w", b.ref.CommonName(), err)
 	}
-	b.orig = ociImage
+	b.orig = &ociImage
 	return blobOCIConfig{blobCommon: b.blobCommon, rawBody: blobBody, Image: ociImage}, nil
 }
 

--- a/regclient/image.go
+++ b/regclient/image.go
@@ -15,16 +15,17 @@ import (
 	digest "github.com/opencontainers/go-digest"
 	ociv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/regclient/regclient/pkg/archive"
+	"github.com/regclient/regclient/regclient/types"
 	"github.com/sirupsen/logrus"
 )
 
 // ImageClient provides registry client requests to images
 type ImageClient interface {
-	ImageCopy(ctx context.Context, refSrc Ref, refTgt Ref) error
-	ImageExport(ctx context.Context, ref Ref, outStream io.Writer) error
+	ImageCopy(ctx context.Context, refSrc types.Ref, refTgt types.Ref) error
+	ImageExport(ctx context.Context, ref types.Ref, outStream io.Writer) error
 }
 
-func (rc *regClient) ImageCopy(ctx context.Context, refSrc Ref, refTgt Ref) error {
+func (rc *regClient) ImageCopy(ctx context.Context, refSrc types.Ref, refTgt types.Ref) error {
 	// check if source and destination already match
 	msh, errS := rc.ManifestHead(ctx, refSrc)
 	mdh, errD := rc.ManifestHead(ctx, refTgt)
@@ -144,7 +145,7 @@ type dockerTarManifest struct {
 	Layers   []string
 }
 
-func (rc *regClient) ImageExport(ctx context.Context, ref Ref, outStream io.Writer) error {
+func (rc *regClient) ImageExport(ctx context.Context, ref types.Ref, outStream io.Writer) error {
 	expManifest := dockerTarManifest{}
 	expManifest.RepoTags = append(expManifest.RepoTags, ref.CommonName())
 

--- a/regclient/image.go
+++ b/regclient/image.go
@@ -81,7 +81,7 @@ func (rc *regClient) ImageCopy(ctx context.Context, refSrc Ref, refTgt Ref) erro
 				"target": refTgt.Reference,
 				"digest": cd.String(),
 			}).Info("Copy config")
-			if err := rc.BlobCopy(ctx, refSrc, refTgt, cd.String()); err != nil {
+			if err := rc.BlobCopy(ctx, refSrc, refTgt, cd); err != nil {
 				rc.log.WithFields(logrus.Fields{
 					"source": refSrc.Reference,
 					"target": refTgt.Reference,
@@ -113,7 +113,7 @@ func (rc *regClient) ImageCopy(ctx context.Context, refSrc Ref, refTgt Ref) erro
 				"target": refTgt.Reference,
 				"layer":  layerSrc.Digest.String(),
 			}).Info("Copy layer")
-			if err := rc.BlobCopy(ctx, refSrc, refTgt, layerSrc.Digest.String()); err != nil {
+			if err := rc.BlobCopy(ctx, refSrc, refTgt, layerSrc.Digest); err != nil {
 				rc.log.WithFields(logrus.Fields{
 					"source": refSrc.Reference,
 					"target": refTgt.Reference,
@@ -182,7 +182,7 @@ func (rc *regClient) ImageExport(ctx context.Context, ref Ref, outStream io.Writ
 		}).Warn("Failed to get config digest from manifest")
 		return err
 	}
-	confBlob, err := rc.BlobGet(ctx, ref, cd.String(), []string{MediaTypeDocker2ImageConfig, ociv1.MediaTypeImageConfig})
+	confBlob, err := rc.BlobGet(ctx, ref, cd, []string{MediaTypeDocker2ImageConfig, ociv1.MediaTypeImageConfig})
 	if err != nil {
 		rc.log.WithFields(logrus.Fields{
 			"ref":    ref.Reference,
@@ -236,7 +236,7 @@ func (rc *regClient) ImageExport(ctx context.Context, ref Ref, outStream io.Writ
 		// no need to defer remove of layerDir, it is inside of tempDir
 
 		// request layer
-		layerBlob, err := rc.BlobGet(ctx, ref, layerDesc.Digest.String(), []string{})
+		layerBlob, err := rc.BlobGet(ctx, ref, layerDesc.Digest, []string{})
 		if err != nil {
 			rc.log.WithFields(logrus.Fields{
 				"ref":   ref.CommonName(),

--- a/regclient/manifest.go
+++ b/regclient/manifest.go
@@ -88,6 +88,114 @@ type Manifest interface {
 	RawHeaders() (http.Header, error)
 }
 
+func NewManifestDocker1M(m dockerSchema1.Manifest, raw []byte) Manifest {
+	if len(raw) == 0 {
+		raw, _ = json.Marshal(m)
+	}
+	mc := manifestCommon{
+		mt:       MediaTypeDocker1Manifest,
+		digest:   digest.FromBytes(raw),
+		manifSet: true,
+		rawBody:  raw,
+	}
+	mStruct := manifestDocker1M{
+		manifestCommon: mc,
+		Manifest:       m,
+	}
+	mStruct.orig = &mStruct.Manifest
+	return &mStruct
+}
+
+func NewManifestDocker1MS(m dockerSchema1.SignedManifest, raw []byte) Manifest {
+	if len(raw) == 0 {
+		raw, _ = json.Marshal(m)
+	}
+	mc := manifestCommon{
+		mt:       MediaTypeDocker1ManifestSigned,
+		digest:   digest.FromBytes(raw),
+		manifSet: true,
+		rawBody:  raw,
+	}
+	mStruct := manifestDocker1MS{
+		manifestCommon: mc,
+		SignedManifest: m,
+	}
+	mStruct.orig = &mStruct.Manifest
+	return &mStruct
+}
+
+func NewManifestDockerM(m dockerSchema2.Manifest, raw []byte) Manifest {
+	if len(raw) == 0 {
+		raw, _ = json.Marshal(m)
+	}
+	mc := manifestCommon{
+		mt:       MediaTypeDocker2Manifest,
+		digest:   digest.FromBytes(raw),
+		manifSet: true,
+		rawBody:  raw,
+	}
+	mStruct := manifestDockerM{
+		manifestCommon: mc,
+		Manifest:       m,
+	}
+	mStruct.orig = &mStruct.Manifest
+	return &mStruct
+}
+
+func NewManifestDockerML(m dockerManifestList.ManifestList, raw []byte) Manifest {
+	if len(raw) == 0 {
+		raw, _ = json.Marshal(m)
+	}
+	mc := manifestCommon{
+		mt:       MediaTypeDocker2ManifestList,
+		digest:   digest.FromBytes(raw),
+		manifSet: true,
+		rawBody:  raw,
+	}
+	mStruct := manifestDockerML{
+		manifestCommon: mc,
+		ManifestList:   m,
+	}
+	mStruct.orig = &mStruct.ManifestList
+	return &mStruct
+}
+
+func NewManifestOCIM(m ociv1.Manifest, raw []byte) Manifest {
+	if len(raw) == 0 {
+		raw, _ = json.Marshal(m)
+	}
+	mc := manifestCommon{
+		mt:       MediaTypeOCI1Manifest,
+		digest:   digest.FromBytes(raw),
+		manifSet: true,
+		rawBody:  raw,
+	}
+	mStruct := manifestOCIM{
+		manifestCommon: mc,
+		Manifest:       m,
+	}
+	mStruct.orig = &mStruct.Manifest
+	return &mStruct
+}
+
+func NewManifestOCIML(m ociv1.Index, raw []byte) Manifest {
+	if len(raw) == 0 {
+		raw, _ = json.Marshal(m)
+	}
+	mc := manifestCommon{
+		mt:       MediaTypeOCI1ManifestList,
+		digest:   digest.FromBytes(raw),
+		manifSet: true,
+		rawBody:  raw,
+	}
+	mStruct := manifestOCIML{
+		manifestCommon: mc,
+		Index:          m,
+	}
+	mStruct.orig = &mStruct.Index
+	return &mStruct
+}
+
 func (m *manifestCommon) GetDigest() digest.Digest {
 	return m.digest
 }
@@ -546,33 +654,39 @@ func (rc *regClient) ManifestGet(ctx context.Context, ref Ref) (Manifest, error)
 	case MediaTypeDocker1Manifest:
 		dm := dockerSchema1.Manifest{}
 		err = json.Unmarshal(mc.rawBody, &dm)
-		mc.orig = dm
-		m = &manifestDocker1M{manifestCommon: mc, Manifest: dm}
+		mStruct := manifestDocker1M{manifestCommon: mc, Manifest: dm}
+		mStruct.orig = &mStruct.Manifest
+		m = &mStruct
 	case MediaTypeDocker1ManifestSigned:
 		dm := dockerSchema1.SignedManifest{}
 		err = json.Unmarshal(mc.rawBody, &dm)
-		mc.orig = dm
-		m = &manifestDocker1MS{manifestCommon: mc, SignedManifest: dm}
+		mStruct := manifestDocker1MS{manifestCommon: mc, SignedManifest: dm}
+		mStruct.orig = &mStruct.SignedManifest
+		m = &mStruct
 	case MediaTypeDocker2Manifest:
 		dm := dockerSchema2.Manifest{}
 		err = json.Unmarshal(mc.rawBody, &dm)
-		mc.orig = dm
-		m = &manifestDockerM{manifestCommon: mc, Manifest: dm}
+		mStruct := manifestDockerM{manifestCommon: mc, Manifest: dm}
+		mStruct.orig = &mStruct.Manifest
+		m = &mStruct
 	case MediaTypeDocker2ManifestList:
 		dml := dockerManifestList.ManifestList{}
 		err = json.Unmarshal(mc.rawBody, &dml)
-		mc.orig = dml
-		m = &manifestDockerML{manifestCommon: mc, ManifestList: dml}
+		mStruct := manifestDockerML{manifestCommon: mc, ManifestList: dml}
+		mStruct.orig = &mStruct.ManifestList
+		m = &mStruct
 	case MediaTypeOCI1Manifest:
 		om := ociv1.Manifest{}
 		err = json.Unmarshal(mc.rawBody, &om)
-		mc.orig = om
-		m = &manifestOCIM{manifestCommon: mc, Manifest: om}
+		mStruct := manifestOCIM{manifestCommon: mc, Manifest: om}
+		mStruct.orig = &mStruct.Manifest
+		m = &mStruct
 	case MediaTypeOCI1ManifestList:
 		oi := ociv1.Index{}
 		err = json.Unmarshal(mc.rawBody, &oi)
-		mc.orig = oi
-		m = &manifestOCIML{manifestCommon: mc, Index: oi}
+		mStruct := manifestOCIML{manifestCommon: mc, Index: oi}
+		mStruct.orig = &mStruct.Index
+		m = &mStruct
 	default:
 		rc.log.WithFields(logrus.Fields{
 			"mediatype": mc.mt,

--- a/regclient/manifest.go
+++ b/regclient/manifest.go
@@ -1,541 +1,28 @@
 package regclient
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net/http"
-	"strconv"
-	"strings"
-	"text/tabwriter"
 
-	"github.com/containerd/containerd/platforms"
-	dockerDistribution "github.com/docker/distribution"
-	dockerManifestList "github.com/docker/distribution/manifest/manifestlist"
-	dockerSchema1 "github.com/docker/distribution/manifest/schema1"
-	dockerSchema2 "github.com/docker/distribution/manifest/schema2"
-	digest "github.com/opencontainers/go-digest"
-	ociv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/regclient/regclient/pkg/retryable"
 	"github.com/regclient/regclient/pkg/wraperr"
+	"github.com/regclient/regclient/regclient/manifest"
+	"github.com/regclient/regclient/regclient/types"
 	"github.com/sirupsen/logrus"
 )
 
 // ManifestClient provides registry client requests to manifests
 type ManifestClient interface {
-	ManifestDelete(ctx context.Context, ref Ref) error
-	ManifestGet(ctx context.Context, ref Ref) (Manifest, error)
-	ManifestHead(ctx context.Context, ref Ref) (Manifest, error)
-	ManifestPut(ctx context.Context, ref Ref, m Manifest) error
+	ManifestDelete(ctx context.Context, ref types.Ref) error
+	ManifestGet(ctx context.Context, ref types.Ref) (manifest.Manifest, error)
+	ManifestHead(ctx context.Context, ref types.Ref) (manifest.Manifest, error)
+	ManifestPut(ctx context.Context, ref types.Ref, m manifest.Manifest) error
 }
 
-type manifestCommon struct {
-	ref       Ref
-	digest    digest.Digest
-	mt        string
-	manifSet  bool
-	orig      interface{}
-	ratelimit RateLimit
-	rawHeader http.Header
-	rawBody   []byte
-}
-type manifestDocker1M struct {
-	manifestCommon
-	dockerSchema1.Manifest
-}
-type manifestDocker1MS struct {
-	manifestCommon
-	dockerSchema1.SignedManifest
-}
-type manifestDockerM struct {
-	manifestCommon
-	dockerSchema2.Manifest
-}
-type manifestDockerML struct {
-	manifestCommon
-	dockerManifestList.ManifestList
-}
-type manifestOCIM struct {
-	manifestCommon
-	ociv1.Manifest
-}
-type manifestOCIML struct {
-	manifestCommon
-	ociv1.Index
-}
-
-// Manifest abstracts the various types of manifests that are supported
-type Manifest interface {
-	GetConfigDigest() (digest.Digest, error)
-	GetDigest() digest.Digest
-	GetDescriptorList() ([]ociv1.Descriptor, error)
-	GetLayers() ([]ociv1.Descriptor, error)
-	GetMediaType() string
-	GetPlatformDesc(p *ociv1.Platform) (*ociv1.Descriptor, error)
-	GetPlatformList() ([]*ociv1.Platform, error)
-	GetOrigManifest() interface{}
-	GetRateLimit() RateLimit
-	GetRef() Ref
-	HasRateLimit() bool
-	IsList() bool
-	IsSet() bool
-	MarshalJSON() ([]byte, error)
-	RawBody() ([]byte, error)
-	RawHeaders() (http.Header, error)
-}
-
-func NewManifestDocker1M(m dockerSchema1.Manifest, raw []byte) Manifest {
-	if len(raw) == 0 {
-		raw, _ = json.Marshal(m)
-	}
-	mc := manifestCommon{
-		mt:       MediaTypeDocker1Manifest,
-		digest:   digest.FromBytes(raw),
-		manifSet: true,
-		rawBody:  raw,
-	}
-	mStruct := manifestDocker1M{
-		manifestCommon: mc,
-		Manifest:       m,
-	}
-	mStruct.orig = &mStruct.Manifest
-	return &mStruct
-}
-
-func NewManifestDocker1MS(m dockerSchema1.SignedManifest, raw []byte) Manifest {
-	if len(raw) == 0 {
-		raw, _ = json.Marshal(m)
-	}
-	mc := manifestCommon{
-		mt:       MediaTypeDocker1ManifestSigned,
-		digest:   digest.FromBytes(raw),
-		manifSet: true,
-		rawBody:  raw,
-	}
-	mStruct := manifestDocker1MS{
-		manifestCommon: mc,
-		SignedManifest: m,
-	}
-	mStruct.orig = &mStruct.Manifest
-	return &mStruct
-}
-
-func NewManifestDockerM(m dockerSchema2.Manifest, raw []byte) Manifest {
-	if len(raw) == 0 {
-		raw, _ = json.Marshal(m)
-	}
-	mc := manifestCommon{
-		mt:       MediaTypeDocker2Manifest,
-		digest:   digest.FromBytes(raw),
-		manifSet: true,
-		rawBody:  raw,
-	}
-	mStruct := manifestDockerM{
-		manifestCommon: mc,
-		Manifest:       m,
-	}
-	mStruct.orig = &mStruct.Manifest
-	return &mStruct
-}
-
-func NewManifestDockerML(m dockerManifestList.ManifestList, raw []byte) Manifest {
-	if len(raw) == 0 {
-		raw, _ = json.Marshal(m)
-	}
-	mc := manifestCommon{
-		mt:       MediaTypeDocker2ManifestList,
-		digest:   digest.FromBytes(raw),
-		manifSet: true,
-		rawBody:  raw,
-	}
-	mStruct := manifestDockerML{
-		manifestCommon: mc,
-		ManifestList:   m,
-	}
-	mStruct.orig = &mStruct.ManifestList
-	return &mStruct
-}
-
-func NewManifestOCIM(m ociv1.Manifest, raw []byte) Manifest {
-	if len(raw) == 0 {
-		raw, _ = json.Marshal(m)
-	}
-	mc := manifestCommon{
-		mt:       MediaTypeOCI1Manifest,
-		digest:   digest.FromBytes(raw),
-		manifSet: true,
-		rawBody:  raw,
-	}
-	mStruct := manifestOCIM{
-		manifestCommon: mc,
-		Manifest:       m,
-	}
-	mStruct.orig = &mStruct.Manifest
-	return &mStruct
-}
-
-func NewManifestOCIML(m ociv1.Index, raw []byte) Manifest {
-	if len(raw) == 0 {
-		raw, _ = json.Marshal(m)
-	}
-	mc := manifestCommon{
-		mt:       MediaTypeOCI1ManifestList,
-		digest:   digest.FromBytes(raw),
-		manifSet: true,
-		rawBody:  raw,
-	}
-	mStruct := manifestOCIML{
-		manifestCommon: mc,
-		Index:          m,
-	}
-	mStruct.orig = &mStruct.Index
-	return &mStruct
-}
-
-func (m *manifestCommon) GetDigest() digest.Digest {
-	return m.digest
-}
-
-func (m *manifestCommon) GetMediaType() string {
-	return m.mt
-}
-
-func (m *manifestCommon) GetOrigManifest() interface{} {
-	return m.orig
-}
-
-func (m *manifestCommon) GetRateLimit() RateLimit {
-	return m.ratelimit
-}
-
-func (m *manifestCommon) GetRef() Ref {
-	return m.ref
-}
-
-func (m *manifestCommon) HasRateLimit() bool {
-	return m.ratelimit.Set
-}
-
-func (m *manifestCommon) IsList() bool {
-	switch m.mt {
-	case MediaTypeDocker2ManifestList, MediaTypeOCI1ManifestList:
-		return true
-	default:
-		return false
-	}
-}
-
-func (m *manifestCommon) IsSet() bool {
-	return m.manifSet
-}
-
-func (m *manifestCommon) MarshalJSON() ([]byte, error) {
-	if !m.manifSet {
-		return []byte{}, wraperr.New(fmt.Errorf("Manifest unavailable, perform a ManifestGet first"), ErrUnavailable)
-	}
-
-	if len(m.rawBody) > 0 {
-		return m.rawBody, nil
-	}
-
-	if m.orig != nil {
-		return json.Marshal((m.orig))
-	}
-	return []byte{}, wraperr.New(fmt.Errorf("Json marshalling not available for media type %s", m.mt), ErrUnsupportedMediaType)
-}
-
-func (m *manifestCommon) RawBody() ([]byte, error) {
-	return m.rawBody, nil
-}
-
-func (m *manifestCommon) RawHeaders() (http.Header, error) {
-	return m.rawHeader, nil
-}
-
-func (m *manifestDocker1M) GetConfigDigest() (digest.Digest, error) {
-	return "", wraperr.New(fmt.Errorf("Config digest not available for media type %s", m.mt), ErrUnsupportedMediaType)
-}
-func (m *manifestDocker1MS) GetConfigDigest() (digest.Digest, error) {
-	return "", wraperr.New(fmt.Errorf("Config digest not available for media type %s", m.mt), ErrUnsupportedMediaType)
-}
-func (m *manifestDockerM) GetConfigDigest() (digest.Digest, error) {
-	return m.Config.Digest, nil
-}
-func (m *manifestOCIM) GetConfigDigest() (digest.Digest, error) {
-	return m.Config.Digest, nil
-}
-func (m *manifestDockerML) GetConfigDigest() (digest.Digest, error) {
-	return "", wraperr.New(fmt.Errorf("Config digest not available for media type %s", m.mt), ErrUnsupportedMediaType)
-}
-func (m *manifestOCIML) GetConfigDigest() (digest.Digest, error) {
-	return "", wraperr.New(fmt.Errorf("Config digest not available for media type %s", m.mt), ErrUnsupportedMediaType)
-}
-
-func (m *manifestDocker1M) GetDescriptorList() ([]ociv1.Descriptor, error) {
-	return []ociv1.Descriptor{}, wraperr.New(fmt.Errorf("Platform descriptor list not available for media type %s", m.mt), ErrUnsupportedMediaType)
-}
-func (m *manifestDocker1MS) GetDescriptorList() ([]ociv1.Descriptor, error) {
-	return []ociv1.Descriptor{}, wraperr.New(fmt.Errorf("Platform descriptor list not available for media type %s", m.mt), ErrUnsupportedMediaType)
-}
-func (m *manifestDockerM) GetDescriptorList() ([]ociv1.Descriptor, error) {
-	return []ociv1.Descriptor{}, wraperr.New(fmt.Errorf("Platform descriptor list not available for media type %s", m.mt), ErrUnsupportedMediaType)
-}
-func (m *manifestOCIM) GetDescriptorList() ([]ociv1.Descriptor, error) {
-	return []ociv1.Descriptor{}, wraperr.New(fmt.Errorf("Platform descriptor list not available for media type %s", m.mt), ErrUnsupportedMediaType)
-}
-func (m *manifestDockerML) GetDescriptorList() ([]ociv1.Descriptor, error) {
-	dl := []ociv1.Descriptor{}
-	for _, d := range m.Manifests {
-		dl = append(dl, *dl2oDescriptor(d))
-	}
-	return dl, nil
-}
-func (m *manifestOCIML) GetDescriptorList() ([]ociv1.Descriptor, error) {
-	return m.Manifests, nil
-}
-
-func (m *manifestDocker1M) GetLayers() ([]ociv1.Descriptor, error) {
-	var dl []ociv1.Descriptor
-	for _, sd := range m.FSLayers {
-		dl = append(dl, ociv1.Descriptor{
-			Digest: sd.BlobSum,
-		})
-	}
-	return dl, nil
-}
-func (m *manifestDocker1MS) GetLayers() ([]ociv1.Descriptor, error) {
-	var dl []ociv1.Descriptor
-	for _, sd := range m.FSLayers {
-		dl = append(dl, ociv1.Descriptor{
-			Digest: sd.BlobSum,
-		})
-	}
-	return dl, nil
-}
-func (m *manifestDockerM) GetLayers() ([]ociv1.Descriptor, error) {
-	var dl []ociv1.Descriptor
-	for _, sd := range m.Layers {
-		dl = append(dl, *d2oDescriptor(sd))
-	}
-	return dl, nil
-}
-func (m *manifestOCIM) GetLayers() ([]ociv1.Descriptor, error) {
-	return m.Layers, nil
-}
-func (m *manifestDockerML) GetLayers() ([]ociv1.Descriptor, error) {
-	return []ociv1.Descriptor{}, wraperr.New(fmt.Errorf("Layers are not available for media type %s", m.mt), ErrUnsupportedMediaType)
-}
-func (m *manifestOCIML) GetLayers() ([]ociv1.Descriptor, error) {
-	return []ociv1.Descriptor{}, wraperr.New(fmt.Errorf("Layers are not available for media type %s", m.mt), ErrUnsupportedMediaType)
-}
-
-// GetPlatformDesc returns the descriptor for the platform from the manifest list or OCI index
-func (m *manifestDocker1M) GetPlatformDesc(p *ociv1.Platform) (*ociv1.Descriptor, error) {
-	return nil, wraperr.New(fmt.Errorf("Platform lookup not available for media type %s", m.mt), ErrUnsupportedMediaType)
-}
-func (m *manifestDocker1MS) GetPlatformDesc(p *ociv1.Platform) (*ociv1.Descriptor, error) {
-	return nil, wraperr.New(fmt.Errorf("Platform lookup not available for media type %s", m.mt), ErrUnsupportedMediaType)
-}
-func (m *manifestDockerM) GetPlatformDesc(p *ociv1.Platform) (*ociv1.Descriptor, error) {
-	return nil, wraperr.New(fmt.Errorf("Platform lookup not available for media type %s", m.mt), ErrUnsupportedMediaType)
-}
-func (m *manifestOCIM) GetPlatformDesc(p *ociv1.Platform) (*ociv1.Descriptor, error) {
-	return nil, wraperr.New(fmt.Errorf("Platform lookup not available for media type %s", m.mt), ErrUnsupportedMediaType)
-}
-func (m *manifestDockerML) GetPlatformDesc(p *ociv1.Platform) (*ociv1.Descriptor, error) {
-	dl, err := m.GetDescriptorList()
-	if err != nil {
-		return nil, err
-	}
-	return getPlatformDesc(p, dl)
-}
-func (m *manifestOCIML) GetPlatformDesc(p *ociv1.Platform) (*ociv1.Descriptor, error) {
-	dl, err := m.GetDescriptorList()
-	if err != nil {
-		return nil, err
-	}
-	return getPlatformDesc(p, dl)
-}
-func getPlatformDesc(p *ociv1.Platform, dl []ociv1.Descriptor) (*ociv1.Descriptor, error) {
-	platformCmp := platforms.NewMatcher(*p)
-	for _, d := range dl {
-		if platformCmp.Match(*d.Platform) {
-			return &d, nil
-		}
-	}
-	return nil, wraperr.New(fmt.Errorf("Platform not found: %v", p), ErrNotFound)
-}
-
-// GetPlatformList returns the list of platforms in a manifest list
-func (m *manifestDocker1M) GetPlatformList() ([]*ociv1.Platform, error) {
-	return nil, wraperr.New(fmt.Errorf("Platform list not available for media type %s", m.mt), ErrUnsupportedMediaType)
-}
-func (m *manifestDocker1MS) GetPlatformList() ([]*ociv1.Platform, error) {
-	return nil, wraperr.New(fmt.Errorf("Platform list not available for media type %s", m.mt), ErrUnsupportedMediaType)
-}
-func (m *manifestDockerM) GetPlatformList() ([]*ociv1.Platform, error) {
-	return nil, wraperr.New(fmt.Errorf("Platform list not available for media type %s", m.mt), ErrUnsupportedMediaType)
-}
-func (m *manifestOCIM) GetPlatformList() ([]*ociv1.Platform, error) {
-	return nil, wraperr.New(fmt.Errorf("Platform list not available for media type %s", m.mt), ErrUnsupportedMediaType)
-}
-func (m *manifestDockerML) GetPlatformList() ([]*ociv1.Platform, error) {
-	dl, err := m.GetDescriptorList()
-	if err != nil {
-		return nil, err
-	}
-	return getPlatformList(dl)
-}
-func (m *manifestOCIML) GetPlatformList() ([]*ociv1.Platform, error) {
-	dl, err := m.GetDescriptorList()
-	if err != nil {
-		return nil, err
-	}
-	return getPlatformList(dl)
-}
-func getPlatformList(dl []ociv1.Descriptor) ([]*ociv1.Platform, error) {
-	var l []*ociv1.Platform
-	for _, d := range dl {
-		l = append(l, d.Platform)
-	}
-	return l, nil
-}
-
-func (m *manifestDocker1MS) MarshalJSON() ([]byte, error) {
-	return m.SignedManifest.MarshalJSON()
-}
-
-// MarshalPretty is used for printPretty template formatting
-func (m *manifestDocker1M) MarshalPretty() ([]byte, error) {
-	buf := &bytes.Buffer{}
-	enc := json.NewEncoder(buf)
-	enc.SetEscapeHTML(false)
-	enc.SetIndent("", "  ")
-	enc.Encode(m.orig)
-	return buf.Bytes(), nil
-}
-func (m *manifestDocker1MS) MarshalPretty() ([]byte, error) {
-	buf := &bytes.Buffer{}
-	enc := json.NewEncoder(buf)
-	enc.SetEscapeHTML(false)
-	enc.SetIndent("", "  ")
-	enc.Encode(m.orig)
-	return buf.Bytes(), nil
-}
-func (m *manifestDockerM) MarshalPretty() ([]byte, error) {
-	buf := &bytes.Buffer{}
-	enc := json.NewEncoder(buf)
-	enc.SetEscapeHTML(false)
-	enc.SetIndent("", "  ")
-	enc.Encode(m.orig)
-	return buf.Bytes(), nil
-}
-func (m *manifestOCIM) MarshalPretty() ([]byte, error) {
-	buf := &bytes.Buffer{}
-	enc := json.NewEncoder(buf)
-	enc.SetEscapeHTML(false)
-	enc.SetIndent("", "  ")
-	enc.Encode(m.orig)
-	return buf.Bytes(), nil
-}
-func (m *manifestDockerML) MarshalPretty() ([]byte, error) {
-	if m == nil {
-		return []byte{}, nil
-	}
-	buf := &bytes.Buffer{}
-	tw := tabwriter.NewWriter(buf, 0, 0, 1, ' ', 0)
-	if m.ref.Reference != "" {
-		fmt.Fprintf(tw, "Name:\t%s\n", m.ref.Reference)
-	}
-	fmt.Fprintf(tw, "MediaType:\t%s\n", m.mt)
-	fmt.Fprintf(tw, "Digest:\t%s\n", m.digest.String())
-	fmt.Fprintf(tw, "\t\n")
-	fmt.Fprintf(tw, "Manifests:\t\n")
-	for _, d := range m.Manifests {
-		fmt.Fprintf(tw, "\t\n")
-		dRef := m.ref
-		if dRef.Reference != "" {
-			dRef.Digest = d.Digest.String()
-			fmt.Fprintf(tw, "  Name:\t%s\n", dRef.CommonName())
-		} else {
-			fmt.Fprintf(tw, "  Digest:\t%s\n", string(d.Digest))
-		}
-		fmt.Fprintf(tw, "  MediaType:\t%s\n", d.MediaType)
-		if p := d.Platform; p.OS != "" {
-			fmt.Fprintf(tw, "  Platform:\t%s\n", platforms.Format(*dlp2Platform(p)))
-			if p.OSVersion != "" {
-				fmt.Fprintf(tw, "  OSVersion:\t%s\n", p.OSVersion)
-			}
-			if len(p.OSFeatures) > 0 {
-				fmt.Fprintf(tw, "  OSFeatures:\t%s\n", strings.Join(p.OSFeatures, ", "))
-			}
-		}
-		if len(d.URLs) > 0 {
-			fmt.Fprintf(tw, "  URLs:\t%s\n", strings.Join(d.URLs, ", "))
-		}
-		if d.Annotations != nil {
-			fmt.Fprintf(tw, "  Annotations:\t\n")
-			for k, v := range d.Annotations {
-				fmt.Fprintf(tw, "    %s:\t%s\n", k, v)
-			}
-		}
-	}
-	tw.Flush()
-	return buf.Bytes(), nil
-}
-func (m *manifestOCIML) MarshalPretty() ([]byte, error) {
-	if m == nil {
-		return []byte{}, nil
-	}
-	buf := &bytes.Buffer{}
-	tw := tabwriter.NewWriter(buf, 0, 0, 1, ' ', 0)
-	if m.ref.Reference != "" {
-		fmt.Fprintf(tw, "Name:\t%s\n", m.ref.Reference)
-	}
-	fmt.Fprintf(tw, "MediaType:\t%s\n", m.mt)
-	fmt.Fprintf(tw, "Digest:\t%s\n", m.digest.String())
-	fmt.Fprintf(tw, "\t\n")
-	fmt.Fprintf(tw, "Manifests:\t\n")
-	for _, d := range m.Manifests {
-		fmt.Fprintf(tw, "\t\n")
-		dRef := m.ref
-		if dRef.Reference != "" {
-			dRef.Digest = d.Digest.String()
-			fmt.Fprintf(tw, "  Name:\t%s\n", dRef.CommonName())
-		} else {
-			fmt.Fprintf(tw, "  Digest:\t%s\n", string(d.Digest))
-		}
-		fmt.Fprintf(tw, "  MediaType:\t%s\n", d.MediaType)
-		if d.Platform != nil {
-			if p := d.Platform; p.OS != "" {
-				fmt.Fprintf(tw, "  Platform:\t%s\n", platforms.Format(*p))
-				if p.OSVersion != "" {
-					fmt.Fprintf(tw, "  OSVersion:\t%s\n", p.OSVersion)
-				}
-				if len(p.OSFeatures) > 0 {
-					fmt.Fprintf(tw, "  OSFeatures:\t%s\n", strings.Join(p.OSFeatures, ", "))
-				}
-			}
-		}
-		if len(d.URLs) > 0 {
-			fmt.Fprintf(tw, "  URLs:\t%s\n", strings.Join(d.URLs, ", "))
-		}
-		if d.Annotations != nil {
-			fmt.Fprintf(tw, "  Annotations:\t\n")
-			for k, v := range d.Annotations {
-				fmt.Fprintf(tw, "    %s:\t%s\n", k, v)
-			}
-		}
-	}
-	tw.Flush()
-	return buf.Bytes(), nil
-}
-
-func (rc *regClient) ManifestDelete(ctx context.Context, ref Ref) error {
+func (rc *regClient) ManifestDelete(ctx context.Context, ref types.Ref) error {
 	if ref.Digest == "" {
 		return wraperr.New(fmt.Errorf("Digest required to delete manifest, reference %s", ref.CommonName()), ErrMissingDigest)
 	}
@@ -574,13 +61,7 @@ func (rc *regClient) ManifestDelete(ctx context.Context, ref Ref) error {
 	return nil
 }
 
-func (rc *regClient) ManifestGet(ctx context.Context, ref Ref) (Manifest, error) {
-	var m Manifest
-	mc := manifestCommon{
-		ref:      ref,
-		manifSet: true,
-	}
-
+func (rc *regClient) ManifestGet(ctx context.Context, ref types.Ref) (manifest.Manifest, error) {
 	var tagOrDigest string
 	if ref.Digest != "" {
 		tagOrDigest = ref.Digest
@@ -620,99 +101,19 @@ func (rc *regClient) ManifestGet(ctx context.Context, ref Ref) (Manifest, error)
 		return nil, fmt.Errorf("Failed to get manifest %s: %w", ref.CommonName(), httpError(resp.HTTPResponse().StatusCode))
 	}
 
-	mc.rawHeader = resp.HTTPResponse().Header
-	rc.ratelimitHeader(&mc, resp.HTTPResponse())
-
-	// read manifest and compute digest
-	digester := digest.Canonical.Digester()
-	reader := io.TeeReader(resp, digester.Hash())
-	mc.rawBody, err = ioutil.ReadAll(reader)
+	// read manifest
+	rawBody, err := ioutil.ReadAll(resp)
 	if err != nil {
-		rc.log.WithFields(logrus.Fields{
-			"err": err,
-			"ref": ref.Reference,
-		}).Warn("Failed to read manifest")
 		return nil, fmt.Errorf("Error reading manifest for %s: %w", ref.CommonName(), err)
 	}
-	mc.digest = digester.Digest()
 
 	// parse body into variable according to media type
-	mc.mt = resp.HTTPResponse().Header.Get("Content-Type")
+	mt := resp.HTTPResponse().Header.Get("Content-Type")
 
-	headDigest := resp.HTTPResponse().Header.Get("OCI-Content-Digest")
-	if headDigest == "" {
-		headDigest = resp.HTTPResponse().Header.Get("Docker-Content-Digest")
-	}
-	if headDigest != "" && headDigest != mc.digest.String() && mc.mt != MediaTypeDocker1Manifest && mc.mt != MediaTypeDocker1ManifestSigned {
-		rc.log.WithFields(logrus.Fields{
-			"computed": mc.digest.String(),
-			"returned": headDigest,
-		}).Warn("Computed digest does not match header from registry")
-	}
-
-	switch mc.mt {
-	case MediaTypeDocker1Manifest:
-		dm := dockerSchema1.Manifest{}
-		err = json.Unmarshal(mc.rawBody, &dm)
-		mStruct := manifestDocker1M{manifestCommon: mc, Manifest: dm}
-		mStruct.orig = &mStruct.Manifest
-		m = &mStruct
-	case MediaTypeDocker1ManifestSigned:
-		dm := dockerSchema1.SignedManifest{}
-		err = json.Unmarshal(mc.rawBody, &dm)
-		mStruct := manifestDocker1MS{manifestCommon: mc, SignedManifest: dm}
-		mStruct.orig = &mStruct.SignedManifest
-		m = &mStruct
-	case MediaTypeDocker2Manifest:
-		dm := dockerSchema2.Manifest{}
-		err = json.Unmarshal(mc.rawBody, &dm)
-		mStruct := manifestDockerM{manifestCommon: mc, Manifest: dm}
-		mStruct.orig = &mStruct.Manifest
-		m = &mStruct
-	case MediaTypeDocker2ManifestList:
-		dml := dockerManifestList.ManifestList{}
-		err = json.Unmarshal(mc.rawBody, &dml)
-		mStruct := manifestDockerML{manifestCommon: mc, ManifestList: dml}
-		mStruct.orig = &mStruct.ManifestList
-		m = &mStruct
-	case MediaTypeOCI1Manifest:
-		om := ociv1.Manifest{}
-		err = json.Unmarshal(mc.rawBody, &om)
-		mStruct := manifestOCIM{manifestCommon: mc, Manifest: om}
-		mStruct.orig = &mStruct.Manifest
-		m = &mStruct
-	case MediaTypeOCI1ManifestList:
-		oi := ociv1.Index{}
-		err = json.Unmarshal(mc.rawBody, &oi)
-		mStruct := manifestOCIML{manifestCommon: mc, Index: oi}
-		mStruct.orig = &mStruct.Index
-		m = &mStruct
-	default:
-		rc.log.WithFields(logrus.Fields{
-			"mediatype": mc.mt,
-			"ref":       ref.Reference,
-		}).Warn("Unsupported media type for manifest")
-		return nil, wraperr.New(fmt.Errorf("Unsupported media type: %s, reference: %s", mc.mt, ref.CommonName()), ErrUnsupportedMediaType)
-	}
-	if err != nil {
-		rc.log.WithFields(logrus.Fields{
-			"err":       err,
-			"mediatype": mc.mt,
-			"ref":       ref.Reference,
-		}).Warn("Failed to unmarshal manifest")
-		return nil, fmt.Errorf("Error unmarshalling manifest for %s: %w", ref.CommonName(), err)
-	}
-
-	return m, nil
+	return manifest.New(mt, rawBody, ref, resp.HTTPResponse().Header)
 }
 
-func (rc *regClient) ManifestHead(ctx context.Context, ref Ref) (Manifest, error) {
-	var m Manifest
-	mc := manifestCommon{
-		ref:      ref,
-		manifSet: false,
-	}
-
+func (rc *regClient) ManifestHead(ctx context.Context, ref types.Ref) (manifest.Manifest, error) {
 	// build the request
 	var tagOrDigest string
 	if ref.Digest != "" {
@@ -720,9 +121,6 @@ func (rc *regClient) ManifestHead(ctx context.Context, ref Ref) (Manifest, error
 	} else if ref.Tag != "" {
 		tagOrDigest = ref.Tag
 	} else {
-		rc.log.WithFields(logrus.Fields{
-			"ref": ref.Reference,
-		}).Warn("Manifest requires a tag or digest")
 		return nil, wraperr.New(fmt.Errorf("Reference missing tag and digest: %s", ref.CommonName()), ErrMissingTagOrDigest)
 	}
 
@@ -756,43 +154,13 @@ func (rc *regClient) ManifestHead(ctx context.Context, ref Ref) (Manifest, error
 		return nil, fmt.Errorf("Failed to request manifest head %s: %w", ref.CommonName(), httpError(resp.HTTPResponse().StatusCode))
 	}
 
-	rc.ratelimitHeader(&mc, resp.HTTPResponse())
-
 	// extract header data
-	mc.rawHeader = resp.HTTPResponse().Header
-	mc.mt = resp.HTTPResponse().Header.Get("Content-Type")
-	mc.digest, err = digest.Parse(resp.HTTPResponse().Header.Get("Docker-Content-Digest"))
-	if err != nil {
-		rc.log.WithFields(logrus.Fields{
-			"ref": ref.Reference,
-		}).Warn("No header found for Docker-Content-Digest")
-	}
+	mt := resp.HTTPResponse().Header.Get("Content-Type")
 
-	switch mc.mt {
-	case MediaTypeDocker1Manifest:
-		m = &manifestDocker1M{manifestCommon: mc}
-	case MediaTypeDocker1ManifestSigned:
-		m = &manifestDocker1MS{manifestCommon: mc}
-	case MediaTypeDocker2Manifest:
-		m = &manifestDockerM{manifestCommon: mc}
-	case MediaTypeDocker2ManifestList:
-		m = &manifestDockerML{manifestCommon: mc}
-	case MediaTypeOCI1Manifest:
-		m = &manifestOCIM{manifestCommon: mc}
-	case MediaTypeOCI1ManifestList:
-		m = &manifestOCIML{manifestCommon: mc}
-	default:
-		rc.log.WithFields(logrus.Fields{
-			"mediatype": mc.mt,
-			"ref":       ref.Reference,
-		}).Warn("Unsupported media type for manifest")
-		return nil, wraperr.New(fmt.Errorf("Unsupported media type: %s, reference: %s", mc.mt, ref.CommonName()), ErrUnsupportedMediaType)
-	}
-
-	return m, nil
+	return manifest.New(mt, []byte{}, ref, resp.HTTPResponse().Header)
 }
 
-func (rc *regClient) ManifestPut(ctx context.Context, ref Ref, m Manifest) error {
+func (rc *regClient) ManifestPut(ctx context.Context, ref types.Ref, m manifest.Manifest) error {
 	var tagOrDigest string
 	if ref.Digest != "" {
 		tagOrDigest = ref.Digest
@@ -842,83 +210,4 @@ func (rc *regClient) ManifestPut(ctx context.Context, ref Ref, m Manifest) error
 	}
 
 	return nil
-}
-
-func (rc *regClient) ratelimitHeader(m *manifestCommon, r *http.Response) {
-	// check for rate limit headers
-	rlLimit := r.Header.Get("RateLimit-Limit")
-	rlRemain := r.Header.Get("RateLimit-Remaining")
-	rlReset := r.Header.Get("RateLimit-Reset")
-	if rlLimit != "" {
-		lpSplit := strings.Split(rlLimit, ",")
-		lSplit := strings.Split(lpSplit[0], ";")
-		rlLimitI, err := strconv.Atoi(lSplit[0])
-		if err != nil {
-			m.ratelimit.Limit = 0
-		} else {
-			m.ratelimit.Limit = rlLimitI
-		}
-		if len(lSplit) > 1 {
-			m.ratelimit.Policies = lpSplit
-		} else if len(lpSplit) > 1 {
-			m.ratelimit.Policies = lpSplit[1:]
-		}
-	}
-	if rlRemain != "" {
-		rSplit := strings.Split(rlRemain, ";")
-		rlRemainI, err := strconv.Atoi(rSplit[0])
-		if err != nil {
-			m.ratelimit.Remain = 0
-		} else {
-			m.ratelimit.Remain = rlRemainI
-			m.ratelimit.Set = true
-		}
-	}
-	if rlReset != "" {
-		rlResetI, err := strconv.Atoi(rlReset)
-		if err != nil {
-			m.ratelimit.Reset = 0
-		} else {
-			m.ratelimit.Reset = rlResetI
-		}
-	}
-	if m.ratelimit.Set {
-		rc.log.WithFields(logrus.Fields{
-			"limit":  m.ratelimit.Limit,
-			"remain": m.ratelimit.Remain,
-			"reset":  m.ratelimit.Reset,
-		}).Debug("Rate limit found")
-	}
-}
-
-func d2oDescriptor(sd dockerDistribution.Descriptor) *ociv1.Descriptor {
-	return &ociv1.Descriptor{
-		MediaType:   sd.MediaType,
-		Digest:      sd.Digest,
-		Size:        sd.Size,
-		URLs:        sd.URLs,
-		Annotations: sd.Annotations,
-		Platform:    sd.Platform,
-	}
-}
-
-func dl2oDescriptor(sd dockerManifestList.ManifestDescriptor) *ociv1.Descriptor {
-	return &ociv1.Descriptor{
-		MediaType:   sd.MediaType,
-		Digest:      sd.Digest,
-		Size:        sd.Size,
-		URLs:        sd.URLs,
-		Annotations: sd.Annotations,
-		Platform:    dlp2Platform(sd.Platform),
-	}
-}
-
-func dlp2Platform(sp dockerManifestList.PlatformSpec) *ociv1.Platform {
-	return &ociv1.Platform{
-		Architecture: sp.Architecture,
-		OS:           sp.OS,
-		Variant:      sp.Variant,
-		OSVersion:    sp.OSVersion,
-		OSFeatures:   sp.OSFeatures,
-	}
 }

--- a/regclient/manifest/common.go
+++ b/regclient/manifest/common.go
@@ -1,0 +1,115 @@
+package manifest
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+
+	digest "github.com/opencontainers/go-digest"
+	"github.com/regclient/regclient/regclient/types"
+)
+
+type common struct {
+	ref       types.Ref
+	digest    digest.Digest
+	mt        string
+	manifSet  bool
+	ratelimit types.RateLimit
+	rawHeader http.Header
+	rawBody   []byte
+}
+
+// GetDigest returns the digest
+func (m *common) GetDigest() digest.Digest {
+	return m.digest
+}
+
+// GetMediaType returns the media type
+func (m *common) GetMediaType() string {
+	return m.mt
+}
+
+// GetRateLimit returns the rate limit when the manifest was pulled from a registry.
+// This supports the headers used by Docker Hub.
+func (m *common) GetRateLimit() types.RateLimit {
+	return m.ratelimit
+}
+
+// GetRef returns the reference from the upstream registry
+func (m *common) GetRef() types.Ref {
+	return m.ref
+}
+
+// HasRateLimit indicates if the rate limit is set
+func (m *common) HasRateLimit() bool {
+	return m.ratelimit.Set
+}
+
+// IsList indicates if the manifest is a docker Manifest List or OCI Index
+func (m *common) IsList() bool {
+	switch m.mt {
+	case MediaTypeDocker2ManifestList, MediaTypeOCI1ManifestList:
+		return true
+	default:
+		return false
+	}
+}
+
+// IsSet indicates if the manifest is defined.
+// A false indicates this is from a HEAD request, providing the digest, media-type, and other headers, but no body.
+func (m *common) IsSet() bool {
+	return m.manifSet
+}
+
+// RawBody returns the raw body from the manifest if available.
+func (m *common) RawBody() ([]byte, error) {
+	if len(m.rawBody) == 0 {
+		return m.rawBody, ErrUnavailable
+	}
+	return m.rawBody, nil
+}
+
+// RawHeaders returns any headers included when manifest was pulled from a registry.
+func (m *common) RawHeaders() (http.Header, error) {
+	return m.rawHeader, nil
+}
+
+func (m *common) setRateLimit(header http.Header) {
+	// check for rate limit headers
+	rlLimit := header.Get("RateLimit-Limit")
+	rlRemain := header.Get("RateLimit-Remaining")
+	rlReset := header.Get("RateLimit-Reset")
+	if rlLimit != "" {
+		lpSplit := strings.Split(rlLimit, ",")
+		lSplit := strings.Split(lpSplit[0], ";")
+		rlLimitI, err := strconv.Atoi(lSplit[0])
+		if err != nil {
+			m.ratelimit.Limit = 0
+		} else {
+			m.ratelimit.Limit = rlLimitI
+		}
+		if len(lSplit) > 1 {
+			m.ratelimit.Policies = lpSplit
+		} else if len(lpSplit) > 1 {
+			m.ratelimit.Policies = lpSplit[1:]
+		}
+	}
+	if rlRemain != "" {
+		rSplit := strings.Split(rlRemain, ";")
+		rlRemainI, err := strconv.Atoi(rSplit[0])
+		if err != nil {
+			m.ratelimit.Remain = 0
+		} else {
+			m.ratelimit.Remain = rlRemainI
+			m.ratelimit.Set = true
+		}
+	}
+	if rlReset != "" {
+		rlResetI, err := strconv.Atoi(rlReset)
+		if err != nil {
+			m.ratelimit.Reset = 0
+		} else {
+			m.ratelimit.Reset = rlResetI
+		}
+	}
+}

--- a/regclient/manifest/docker1.go
+++ b/regclient/manifest/docker1.go
@@ -1,0 +1,115 @@
+package manifest
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	dockerSchema1 "github.com/docker/distribution/manifest/schema1"
+	digest "github.com/opencontainers/go-digest"
+	ociv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/regclient/regclient/pkg/wraperr"
+)
+
+const (
+	// MediaTypeDocker1Manifest deprecated media type for docker schema1 manifests
+	MediaTypeDocker1Manifest = "application/vnd.docker.distribution.manifest.v1+json"
+	// MediaTypeDocker1ManifestSigned is a deprecated schema1 manifest with jws signing
+	MediaTypeDocker1ManifestSigned = "application/vnd.docker.distribution.manifest.v1+prettyjws"
+)
+
+type docker1Manifest struct {
+	common
+	dockerSchema1.Manifest
+}
+type docker1SignedManifest struct {
+	common
+	dockerSchema1.SignedManifest
+}
+
+func (m *docker1Manifest) GetConfigDigest() (digest.Digest, error) {
+	return "", wraperr.New(fmt.Errorf("Config digest not available for media type %s", m.mt), ErrUnsupportedMediaType)
+}
+func (m *docker1SignedManifest) GetConfigDigest() (digest.Digest, error) {
+	return "", wraperr.New(fmt.Errorf("Config digest not available for media type %s", m.mt), ErrUnsupportedMediaType)
+}
+
+func (m *docker1Manifest) GetDescriptorList() ([]ociv1.Descriptor, error) {
+	return []ociv1.Descriptor{}, wraperr.New(fmt.Errorf("Platform descriptor list not available for media type %s", m.mt), ErrUnsupportedMediaType)
+}
+func (m *docker1SignedManifest) GetDescriptorList() ([]ociv1.Descriptor, error) {
+	return []ociv1.Descriptor{}, wraperr.New(fmt.Errorf("Platform descriptor list not available for media type %s", m.mt), ErrUnsupportedMediaType)
+}
+
+func (m *docker1Manifest) GetLayers() ([]ociv1.Descriptor, error) {
+	var dl []ociv1.Descriptor
+	for _, sd := range m.FSLayers {
+		dl = append(dl, ociv1.Descriptor{
+			Digest: sd.BlobSum,
+		})
+	}
+	return dl, nil
+}
+func (m *docker1SignedManifest) GetLayers() ([]ociv1.Descriptor, error) {
+	var dl []ociv1.Descriptor
+	for _, sd := range m.FSLayers {
+		dl = append(dl, ociv1.Descriptor{
+			Digest: sd.BlobSum,
+		})
+	}
+	return dl, nil
+}
+
+func (m *docker1Manifest) GetOrigManifest() interface{} {
+	return m.Manifest
+}
+func (m *docker1SignedManifest) GetOrigManifest() interface{} {
+	return m.SignedManifest
+}
+
+func (m *docker1Manifest) GetPlatformDesc(p *ociv1.Platform) (*ociv1.Descriptor, error) {
+	return nil, wraperr.New(fmt.Errorf("Platform lookup not available for media type %s", m.mt), ErrUnsupportedMediaType)
+}
+func (m *docker1SignedManifest) GetPlatformDesc(p *ociv1.Platform) (*ociv1.Descriptor, error) {
+	return nil, wraperr.New(fmt.Errorf("Platform lookup not available for media type %s", m.mt), ErrUnsupportedMediaType)
+}
+
+func (m *docker1Manifest) GetPlatformList() ([]*ociv1.Platform, error) {
+	return nil, wraperr.New(fmt.Errorf("Platform list not available for media type %s", m.mt), ErrUnsupportedMediaType)
+}
+func (m *docker1SignedManifest) GetPlatformList() ([]*ociv1.Platform, error) {
+	return nil, wraperr.New(fmt.Errorf("Platform list not available for media type %s", m.mt), ErrUnsupportedMediaType)
+}
+
+func (m *docker1Manifest) MarshalJSON() ([]byte, error) {
+	if !m.manifSet {
+		return []byte{}, wraperr.New(fmt.Errorf("Manifest unavailable, perform a ManifestGet first"), ErrUnavailable)
+	}
+
+	if len(m.rawBody) > 0 {
+		return m.rawBody, nil
+	}
+
+	return json.Marshal((m.Manifest))
+}
+
+func (m *docker1SignedManifest) MarshalJSON() ([]byte, error) {
+	return m.SignedManifest.MarshalJSON()
+}
+
+func (m *docker1Manifest) MarshalPretty() ([]byte, error) {
+	buf := &bytes.Buffer{}
+	enc := json.NewEncoder(buf)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	enc.Encode(m.Manifest)
+	return buf.Bytes(), nil
+}
+func (m *docker1SignedManifest) MarshalPretty() ([]byte, error) {
+	buf := &bytes.Buffer{}
+	enc := json.NewEncoder(buf)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	enc.Encode(m.SignedManifest)
+	return buf.Bytes(), nil
+}

--- a/regclient/manifest/docker2.go
+++ b/regclient/manifest/docker2.go
@@ -1,0 +1,167 @@
+package manifest
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/containerd/containerd/platforms"
+	dockerManifestList "github.com/docker/distribution/manifest/manifestlist"
+	dockerSchema2 "github.com/docker/distribution/manifest/schema2"
+	digest "github.com/opencontainers/go-digest"
+	ociv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/regclient/regclient/pkg/wraperr"
+)
+
+const (
+	// MediaTypeDocker2Manifest is the media type when pulling manifests from a v2 registry
+	MediaTypeDocker2Manifest = dockerSchema2.MediaTypeManifest
+	// MediaTypeDocker2ManifestList is the media type when pulling a manifest list from a v2 registry
+	MediaTypeDocker2ManifestList = dockerManifestList.MediaTypeManifestList
+)
+
+type docker2Manifest struct {
+	common
+	dockerSchema2.Manifest
+}
+type docker2ManifestList struct {
+	common
+	dockerManifestList.ManifestList
+}
+
+func (m *docker2Manifest) GetConfigDigest() (digest.Digest, error) {
+	return m.Config.Digest, nil
+}
+func (m *docker2ManifestList) GetConfigDigest() (digest.Digest, error) {
+	return "", wraperr.New(fmt.Errorf("Config digest not available for media type %s", m.mt), ErrUnsupportedMediaType)
+}
+
+func (m *docker2Manifest) GetDescriptorList() ([]ociv1.Descriptor, error) {
+	return []ociv1.Descriptor{}, wraperr.New(fmt.Errorf("Platform descriptor list not available for media type %s", m.mt), ErrUnsupportedMediaType)
+}
+func (m *docker2ManifestList) GetDescriptorList() ([]ociv1.Descriptor, error) {
+	dl := []ociv1.Descriptor{}
+	for _, d := range m.Manifests {
+		dl = append(dl, *dl2oDescriptor(d))
+	}
+	return dl, nil
+}
+
+func (m *docker2Manifest) GetLayers() ([]ociv1.Descriptor, error) {
+	var dl []ociv1.Descriptor
+	for _, sd := range m.Layers {
+		dl = append(dl, *d2oDescriptor(sd))
+	}
+	return dl, nil
+}
+func (m *docker2ManifestList) GetLayers() ([]ociv1.Descriptor, error) {
+	return []ociv1.Descriptor{}, wraperr.New(fmt.Errorf("Layers are not available for media type %s", m.mt), ErrUnsupportedMediaType)
+}
+
+func (m *docker2Manifest) GetOrigManifest() interface{} {
+	return m.Manifest
+}
+func (m *docker2ManifestList) GetOrigManifest() interface{} {
+	return m.ManifestList
+}
+
+func (m *docker2Manifest) GetPlatformDesc(p *ociv1.Platform) (*ociv1.Descriptor, error) {
+	return nil, wraperr.New(fmt.Errorf("Platform lookup not available for media type %s", m.mt), ErrUnsupportedMediaType)
+}
+func (m *docker2ManifestList) GetPlatformDesc(p *ociv1.Platform) (*ociv1.Descriptor, error) {
+	dl, err := m.GetDescriptorList()
+	if err != nil {
+		return nil, err
+	}
+	return getPlatformDesc(p, dl)
+}
+
+func (m *docker2Manifest) GetPlatformList() ([]*ociv1.Platform, error) {
+	return nil, wraperr.New(fmt.Errorf("Platform list not available for media type %s", m.mt), ErrUnsupportedMediaType)
+}
+func (m *docker2ManifestList) GetPlatformList() ([]*ociv1.Platform, error) {
+	dl, err := m.GetDescriptorList()
+	if err != nil {
+		return nil, err
+	}
+	return getPlatformList(dl)
+}
+
+func (m *docker2Manifest) MarshalJSON() ([]byte, error) {
+	if !m.manifSet {
+		return []byte{}, wraperr.New(fmt.Errorf("Manifest unavailable, perform a ManifestGet first"), ErrUnavailable)
+	}
+
+	if len(m.rawBody) > 0 {
+		return m.rawBody, nil
+	}
+
+	return json.Marshal((m.Manifest))
+}
+func (m *docker2ManifestList) MarshalJSON() ([]byte, error) {
+	if !m.manifSet {
+		return []byte{}, wraperr.New(fmt.Errorf("Manifest unavailable, perform a ManifestGet first"), ErrUnavailable)
+	}
+
+	if len(m.rawBody) > 0 {
+		return m.rawBody, nil
+	}
+
+	return json.Marshal((m.ManifestList))
+}
+
+func (m *docker2Manifest) MarshalPretty() ([]byte, error) {
+	buf := &bytes.Buffer{}
+	enc := json.NewEncoder(buf)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	enc.Encode(m.Manifest)
+	return buf.Bytes(), nil
+}
+func (m *docker2ManifestList) MarshalPretty() ([]byte, error) {
+	if m == nil {
+		return []byte{}, nil
+	}
+	buf := &bytes.Buffer{}
+	tw := tabwriter.NewWriter(buf, 0, 0, 1, ' ', 0)
+	if m.ref.Reference != "" {
+		fmt.Fprintf(tw, "Name:\t%s\n", m.ref.Reference)
+	}
+	fmt.Fprintf(tw, "MediaType:\t%s\n", m.mt)
+	fmt.Fprintf(tw, "Digest:\t%s\n", m.digest.String())
+	fmt.Fprintf(tw, "\t\n")
+	fmt.Fprintf(tw, "Manifests:\t\n")
+	for _, d := range m.Manifests {
+		fmt.Fprintf(tw, "\t\n")
+		dRef := m.ref
+		if dRef.Reference != "" {
+			dRef.Digest = d.Digest.String()
+			fmt.Fprintf(tw, "  Name:\t%s\n", dRef.CommonName())
+		} else {
+			fmt.Fprintf(tw, "  Digest:\t%s\n", string(d.Digest))
+		}
+		fmt.Fprintf(tw, "  MediaType:\t%s\n", d.MediaType)
+		if p := d.Platform; p.OS != "" {
+			fmt.Fprintf(tw, "  Platform:\t%s\n", platforms.Format(*dlp2Platform(p)))
+			if p.OSVersion != "" {
+				fmt.Fprintf(tw, "  OSVersion:\t%s\n", p.OSVersion)
+			}
+			if len(p.OSFeatures) > 0 {
+				fmt.Fprintf(tw, "  OSFeatures:\t%s\n", strings.Join(p.OSFeatures, ", "))
+			}
+		}
+		if len(d.URLs) > 0 {
+			fmt.Fprintf(tw, "  URLs:\t%s\n", strings.Join(d.URLs, ", "))
+		}
+		if d.Annotations != nil {
+			fmt.Fprintf(tw, "  Annotations:\t\n")
+			for k, v := range d.Annotations {
+				fmt.Fprintf(tw, "    %s:\t%s\n", k, v)
+			}
+		}
+	}
+	tw.Flush()
+	return buf.Bytes(), nil
+}

--- a/regclient/manifest/error.go
+++ b/regclient/manifest/error.go
@@ -1,0 +1,14 @@
+package manifest
+
+import "errors"
+
+var (
+	// ErrNotFound isn't there, search for your value elsewhere
+	ErrNotFound = errors.New("Not found")
+	// ErrNotImplemented returned when method has not been implemented yet
+	ErrNotImplemented = errors.New("Not implemented")
+	// ErrUnavailable when a requested value is not available
+	ErrUnavailable = errors.New("Unavailable")
+	// ErrUnsupportedMediaType returned when media type is unknown or unsupported
+	ErrUnsupportedMediaType = errors.New("Unsupported media type")
+)

--- a/regclient/manifest/manifest.go
+++ b/regclient/manifest/manifest.go
@@ -1,0 +1,229 @@
+package manifest
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/containerd/containerd/platforms"
+	dockerDistribution "github.com/docker/distribution"
+	dockerManifestList "github.com/docker/distribution/manifest/manifestlist"
+	dockerSchema1 "github.com/docker/distribution/manifest/schema1"
+	dockerSchema2 "github.com/docker/distribution/manifest/schema2"
+	digest "github.com/opencontainers/go-digest"
+	ociv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/regclient/regclient/pkg/wraperr"
+	"github.com/regclient/regclient/regclient/types"
+)
+
+// Manifest abstracts the various types of manifests that are supported
+type Manifest interface {
+	GetConfigDigest() (digest.Digest, error)
+	GetDigest() digest.Digest
+	GetDescriptorList() ([]ociv1.Descriptor, error)
+	GetLayers() ([]ociv1.Descriptor, error)
+	GetMediaType() string
+	GetPlatformDesc(p *ociv1.Platform) (*ociv1.Descriptor, error)
+	GetPlatformList() ([]*ociv1.Platform, error)
+	GetOrigManifest() interface{}
+	GetRateLimit() types.RateLimit
+	GetRef() types.Ref
+	HasRateLimit() bool
+	IsList() bool
+	IsSet() bool
+	MarshalJSON() ([]byte, error)
+	RawBody() ([]byte, error)
+	RawHeaders() (http.Header, error)
+}
+
+// New creates a new manifest from an unparsed raw manifest
+// mediaType: should be a known media-type. If empty, resp headers will be checked
+// raw: body of the manifest. If empty, unset manifest for a HEAD request is returned
+// ref: reference, may be unset
+// header: headers from request, used to extract content type, digest, and rate limits
+func New(mediaType string, raw []byte, ref types.Ref, header http.Header) (Manifest, error) {
+	var m Manifest
+	var err error
+	mc := common{
+		ref:     ref,
+		mt:      mediaType,
+		rawBody: raw,
+	}
+	if header != nil {
+		mc.rawHeader = header
+		if mc.mt == "" {
+			mc.mt = header.Get("Content-Type")
+		}
+		mc.digest, _ = digest.Parse(header.Get("Docker-Content-Digest"))
+		mc.setRateLimit(header)
+	}
+	if len(raw) > 0 {
+		mc.manifSet = true
+		if mc.digest == "" {
+			mc.digest = digest.FromBytes(raw)
+		}
+	}
+	switch mediaType {
+	case MediaTypeDocker1Manifest:
+		var mOrig dockerSchema1.Manifest
+		if len(raw) > 0 {
+			err = json.Unmarshal(mc.rawBody, &mOrig)
+		}
+		m = &docker1Manifest{common: mc, Manifest: mOrig}
+	case MediaTypeDocker1ManifestSigned:
+		var mOrig dockerSchema1.SignedManifest
+		if len(raw) > 0 {
+			err = json.Unmarshal(mc.rawBody, &mOrig)
+			mc.digest = digest.FromBytes(mOrig.Canonical)
+		}
+		m = &docker1SignedManifest{common: mc, SignedManifest: mOrig}
+	case MediaTypeDocker2Manifest:
+		var mOrig dockerSchema2.Manifest
+		if len(raw) > 0 {
+			err = json.Unmarshal(mc.rawBody, &mOrig)
+		}
+		m = &docker2Manifest{common: mc, Manifest: mOrig}
+	case MediaTypeDocker2ManifestList:
+		var mOrig dockerManifestList.ManifestList
+		if len(raw) > 0 {
+			err = json.Unmarshal(mc.rawBody, &mOrig)
+		}
+		m = &docker2ManifestList{common: mc, ManifestList: mOrig}
+	case MediaTypeOCI1Manifest:
+		var mOrig ociv1.Manifest
+		if len(raw) > 0 {
+			err = json.Unmarshal(mc.rawBody, &mOrig)
+		}
+		m = &oci1Manifest{common: mc, Manifest: mOrig}
+	case MediaTypeOCI1ManifestList:
+		var mOrig ociv1.Index
+		if len(raw) > 0 {
+			err = json.Unmarshal(mc.rawBody, &mOrig)
+		}
+		m = &oci1Index{common: mc, Index: mOrig}
+	default:
+		var mOrig UnknownData
+		if len(raw) > 0 {
+			err = json.Unmarshal(mc.rawBody, &mOrig)
+		}
+		m = &unknown{common: mc, UnknownData: mOrig}
+	}
+	if err != nil {
+		return nil, fmt.Errorf("Error unmarshaling manifest for %s: %w", ref.CommonName(), err)
+	}
+
+	return m, nil
+}
+
+// FromOrig creates a new manifest from the original upstream manifest type.
+// This method should be used if you are creating a new manifest rather than pulling one from a registry.
+func FromOrig(orig interface{}) (Manifest, error) {
+	var d digest.Digest
+	mj, err := json.Marshal(orig)
+	if err == nil {
+		d = digest.FromBytes(mj)
+	}
+
+	mc := common{
+		digest:   d,
+		manifSet: true,
+	}
+
+	switch orig.(type) {
+	case dockerSchema1.Manifest:
+		mc.mt = MediaTypeDocker1Manifest
+		return &docker1Manifest{
+			common:   mc,
+			Manifest: orig.(dockerSchema1.Manifest),
+		}, nil
+	case dockerSchema1.SignedManifest:
+		mc.digest = digest.FromBytes(orig.(dockerSchema1.SignedManifest).Canonical)
+		mc.mt = MediaTypeDocker1ManifestSigned
+		return &docker1SignedManifest{
+			common:         mc,
+			SignedManifest: orig.(dockerSchema1.SignedManifest),
+		}, nil
+	case dockerSchema2.Manifest:
+		mc.mt = MediaTypeDocker2Manifest
+		return &docker2Manifest{
+			common:   mc,
+			Manifest: orig.(dockerSchema2.Manifest),
+		}, nil
+	case dockerManifestList.ManifestList:
+		mc.mt = MediaTypeDocker2ManifestList
+		return &docker2ManifestList{
+			common:       mc,
+			ManifestList: orig.(dockerManifestList.ManifestList),
+		}, nil
+	case ociv1.Manifest:
+		mc.mt = MediaTypeOCI1Manifest
+		return &oci1Manifest{
+			common:   mc,
+			Manifest: orig.(ociv1.Manifest),
+		}, nil
+	case ociv1.Index:
+		mc.mt = MediaTypeOCI1ManifestList
+		return &oci1Index{
+			common: mc,
+			Index:  orig.(ociv1.Index),
+		}, nil
+	case UnknownData:
+		return &unknown{
+			common:      mc,
+			UnknownData: orig.(UnknownData),
+		}, nil
+	default:
+		return nil, fmt.Errorf("Unsupported type to convert to a manifest: %T", orig)
+	}
+
+}
+
+func getPlatformDesc(p *ociv1.Platform, dl []ociv1.Descriptor) (*ociv1.Descriptor, error) {
+	platformCmp := platforms.NewMatcher(*p)
+	for _, d := range dl {
+		if platformCmp.Match(*d.Platform) {
+			return &d, nil
+		}
+	}
+	return nil, wraperr.New(fmt.Errorf("Platform not found: %v", p), ErrNotFound)
+}
+
+func getPlatformList(dl []ociv1.Descriptor) ([]*ociv1.Platform, error) {
+	var l []*ociv1.Platform
+	for _, d := range dl {
+		l = append(l, d.Platform)
+	}
+	return l, nil
+}
+
+func d2oDescriptor(sd dockerDistribution.Descriptor) *ociv1.Descriptor {
+	return &ociv1.Descriptor{
+		MediaType:   sd.MediaType,
+		Digest:      sd.Digest,
+		Size:        sd.Size,
+		URLs:        sd.URLs,
+		Annotations: sd.Annotations,
+		Platform:    sd.Platform,
+	}
+}
+
+func dl2oDescriptor(sd dockerManifestList.ManifestDescriptor) *ociv1.Descriptor {
+	return &ociv1.Descriptor{
+		MediaType:   sd.MediaType,
+		Digest:      sd.Digest,
+		Size:        sd.Size,
+		URLs:        sd.URLs,
+		Annotations: sd.Annotations,
+		Platform:    dlp2Platform(sd.Platform),
+	}
+}
+
+func dlp2Platform(sp dockerManifestList.PlatformSpec) *ociv1.Platform {
+	return &ociv1.Platform{
+		Architecture: sp.Architecture,
+		OS:           sp.OS,
+		Variant:      sp.Variant,
+		OSVersion:    sp.OSVersion,
+		OSFeatures:   sp.OSFeatures,
+	}
+}

--- a/regclient/manifest/oci1.go
+++ b/regclient/manifest/oci1.go
@@ -1,0 +1,159 @@
+package manifest
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/containerd/containerd/platforms"
+	digest "github.com/opencontainers/go-digest"
+	ociv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/regclient/regclient/pkg/wraperr"
+)
+
+const (
+	// MediaTypeOCI1Manifest OCI v1 manifest media type
+	MediaTypeOCI1Manifest = ociv1.MediaTypeImageManifest
+	// MediaTypeOCI1ManifestList OCI v1 manifest list media type
+	MediaTypeOCI1ManifestList = ociv1.MediaTypeImageIndex
+)
+
+type oci1Manifest struct {
+	common
+	ociv1.Manifest
+}
+type oci1Index struct {
+	common
+	ociv1.Index
+}
+
+func (m *oci1Manifest) GetConfigDigest() (digest.Digest, error) {
+	return m.Config.Digest, nil
+}
+func (m *oci1Index) GetConfigDigest() (digest.Digest, error) {
+	return "", wraperr.New(fmt.Errorf("Config digest not available for media type %s", m.mt), ErrUnsupportedMediaType)
+}
+
+func (m *oci1Manifest) GetDescriptorList() ([]ociv1.Descriptor, error) {
+	return []ociv1.Descriptor{}, wraperr.New(fmt.Errorf("Platform descriptor list not available for media type %s", m.mt), ErrUnsupportedMediaType)
+}
+func (m *oci1Index) GetDescriptorList() ([]ociv1.Descriptor, error) {
+	return m.Manifests, nil
+}
+
+func (m *oci1Manifest) GetLayers() ([]ociv1.Descriptor, error) {
+	return m.Layers, nil
+}
+func (m *oci1Index) GetLayers() ([]ociv1.Descriptor, error) {
+	return []ociv1.Descriptor{}, wraperr.New(fmt.Errorf("Layers are not available for media type %s", m.mt), ErrUnsupportedMediaType)
+}
+
+func (m *oci1Manifest) GetOrigManifest() interface{} {
+	return m.Manifest
+}
+func (m *oci1Index) GetOrigManifest() interface{} {
+	return m.Index
+}
+
+func (m *oci1Manifest) GetPlatformDesc(p *ociv1.Platform) (*ociv1.Descriptor, error) {
+	return nil, wraperr.New(fmt.Errorf("Platform lookup not available for media type %s", m.mt), ErrUnsupportedMediaType)
+}
+func (m *oci1Index) GetPlatformDesc(p *ociv1.Platform) (*ociv1.Descriptor, error) {
+	dl, err := m.GetDescriptorList()
+	if err != nil {
+		return nil, err
+	}
+	return getPlatformDesc(p, dl)
+}
+
+func (m *oci1Manifest) GetPlatformList() ([]*ociv1.Platform, error) {
+	return nil, wraperr.New(fmt.Errorf("Platform list not available for media type %s", m.mt), ErrUnsupportedMediaType)
+}
+func (m *oci1Index) GetPlatformList() ([]*ociv1.Platform, error) {
+	dl, err := m.GetDescriptorList()
+	if err != nil {
+		return nil, err
+	}
+	return getPlatformList(dl)
+}
+
+func (m *oci1Manifest) MarshalJSON() ([]byte, error) {
+	if !m.manifSet {
+		return []byte{}, wraperr.New(fmt.Errorf("Manifest unavailable, perform a ManifestGet first"), ErrUnavailable)
+	}
+
+	if len(m.rawBody) > 0 {
+		return m.rawBody, nil
+	}
+
+	return json.Marshal((m.Manifest))
+}
+func (m *oci1Index) MarshalJSON() ([]byte, error) {
+	if !m.manifSet {
+		return []byte{}, wraperr.New(fmt.Errorf("Manifest unavailable, perform a ManifestGet first"), ErrUnavailable)
+	}
+
+	if len(m.rawBody) > 0 {
+		return m.rawBody, nil
+	}
+
+	return json.Marshal((m.Index))
+}
+
+func (m *oci1Manifest) MarshalPretty() ([]byte, error) {
+	buf := &bytes.Buffer{}
+	enc := json.NewEncoder(buf)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	enc.Encode(m.Manifest)
+	return buf.Bytes(), nil
+}
+func (m *oci1Index) MarshalPretty() ([]byte, error) {
+	if m == nil {
+		return []byte{}, nil
+	}
+	buf := &bytes.Buffer{}
+	tw := tabwriter.NewWriter(buf, 0, 0, 1, ' ', 0)
+	if m.ref.Reference != "" {
+		fmt.Fprintf(tw, "Name:\t%s\n", m.ref.Reference)
+	}
+	fmt.Fprintf(tw, "MediaType:\t%s\n", m.mt)
+	fmt.Fprintf(tw, "Digest:\t%s\n", m.digest.String())
+	fmt.Fprintf(tw, "\t\n")
+	fmt.Fprintf(tw, "Manifests:\t\n")
+	for _, d := range m.Manifests {
+		fmt.Fprintf(tw, "\t\n")
+		dRef := m.ref
+		if dRef.Reference != "" {
+			dRef.Digest = d.Digest.String()
+			fmt.Fprintf(tw, "  Name:\t%s\n", dRef.CommonName())
+		} else {
+			fmt.Fprintf(tw, "  Digest:\t%s\n", string(d.Digest))
+		}
+		fmt.Fprintf(tw, "  MediaType:\t%s\n", d.MediaType)
+		if d.Platform != nil {
+			if p := d.Platform; p.OS != "" {
+				fmt.Fprintf(tw, "  Platform:\t%s\n", platforms.Format(*p))
+				if p.OSVersion != "" {
+					fmt.Fprintf(tw, "  OSVersion:\t%s\n", p.OSVersion)
+				}
+				if len(p.OSFeatures) > 0 {
+					fmt.Fprintf(tw, "  OSFeatures:\t%s\n", strings.Join(p.OSFeatures, ", "))
+				}
+			}
+		}
+		if len(d.URLs) > 0 {
+			fmt.Fprintf(tw, "  URLs:\t%s\n", strings.Join(d.URLs, ", "))
+		}
+		if d.Annotations != nil {
+			fmt.Fprintf(tw, "  Annotations:\t\n")
+			for k, v := range d.Annotations {
+				fmt.Fprintf(tw, "    %s:\t%s\n", k, v)
+			}
+		}
+	}
+	tw.Flush()
+	return buf.Bytes(), nil
+}

--- a/regclient/manifest/unknown.go
+++ b/regclient/manifest/unknown.go
@@ -1,0 +1,46 @@
+package manifest
+
+import (
+	"fmt"
+
+	digest "github.com/opencontainers/go-digest"
+	ociv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/regclient/regclient/pkg/wraperr"
+)
+
+type unknown struct {
+	common
+	UnknownData
+}
+
+type UnknownData struct {
+	Data map[string]interface{}
+}
+
+func (m *unknown) GetConfigDigest() (digest.Digest, error) {
+	return "", wraperr.New(fmt.Errorf("Config digest not available for media type %s", m.mt), ErrUnsupportedMediaType)
+}
+
+func (m *unknown) GetDescriptorList() ([]ociv1.Descriptor, error) {
+	return []ociv1.Descriptor{}, wraperr.New(fmt.Errorf("Platform descriptor list not available for media type %s", m.mt), ErrUnsupportedMediaType)
+}
+
+func (m *unknown) GetLayers() ([]ociv1.Descriptor, error) {
+	return []ociv1.Descriptor{}, wraperr.New(fmt.Errorf("Layer list not available for media type %s", m.mt), ErrUnsupportedMediaType)
+}
+
+func (m *unknown) GetOrigManifest() interface{} {
+	return m.UnknownData
+}
+
+func (m *unknown) GetPlatformDesc(p *ociv1.Platform) (*ociv1.Descriptor, error) {
+	return nil, wraperr.New(fmt.Errorf("Platform lookup not available for media type %s", m.mt), ErrUnsupportedMediaType)
+}
+
+func (m *unknown) GetPlatformList() ([]*ociv1.Platform, error) {
+	return nil, wraperr.New(fmt.Errorf("Platform list not available for media type %s", m.mt), ErrUnsupportedMediaType)
+}
+
+func (m *unknown) MarshalJSON() ([]byte, error) {
+	return m.rawBody, nil
+}

--- a/regclient/regclient.go
+++ b/regclient/regclient.go
@@ -67,13 +67,6 @@ type RegClient interface {
 	BlobClient
 }
 
-// RateLimit is returned from some http requests
-type RateLimit struct {
-	Remain, Limit, Reset int
-	Set                  bool
-	Policies             []string
-}
-
 type regClient struct {
 	certPaths  []string
 	hosts      map[string]*regClientHost

--- a/regclient/tag.go
+++ b/regclient/tag.go
@@ -194,7 +194,7 @@ func (rc *regClient) TagDelete(ctx context.Context, ref Ref) error {
 	}).Debug("Sending dummy manifest to replace tag")
 
 	// push config
-	err = rc.BlobPut(ctx, ref, confDigest.String(), ioutil.NopCloser(bytes.NewReader(confB)), MediaTypeDocker2ImageConfig, int64(len(confB)))
+	_, err = rc.BlobPut(ctx, ref, confDigest, ioutil.NopCloser(bytes.NewReader(confB)), MediaTypeDocker2ImageConfig, int64(len(confB)))
 	if err != nil {
 		return fmt.Errorf("Failed sending dummy config to delete %s: %w", ref.CommonName(), err)
 	}
@@ -274,11 +274,12 @@ func (rc *regClient) TagListWithOpts(ctx context.Context, ref Ref, opts TagOpts)
 	case "application/json", "text/plain":
 		var tdl TagDockerList
 		err = json.Unmarshal(respBody, &tdl)
-		tc.orig = tdl
-		tl = tagDockerList{
+		tStruct := tagDockerList{
 			tagCommon:     tc,
 			TagDockerList: tdl,
 		}
+		tStruct.orig = &tStruct.TagDockerList
+		tl = tStruct
 	default:
 		return tl, fmt.Errorf("%w: media type: %s, reference: %s", ErrUnsupportedMediaType, mt, ref.CommonName())
 	}

--- a/regclient/tag.go
+++ b/regclient/tag.go
@@ -21,14 +21,16 @@ import (
 	ociv1Specs "github.com/opencontainers/image-spec/specs-go"
 	ociv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/regclient/regclient/pkg/retryable"
+	"github.com/regclient/regclient/regclient/manifest"
+	"github.com/regclient/regclient/regclient/types"
 	"github.com/sirupsen/logrus"
 )
 
 // TagClient wraps calls to tag list and delete
 type TagClient interface {
-	TagDelete(ctx context.Context, ref Ref) error
-	TagList(ctx context.Context, ref Ref) (TagList, error)
-	TagListWithOpts(ctx context.Context, ref Ref, opts TagOpts) (TagList, error)
+	TagDelete(ctx context.Context, ref types.Ref) error
+	TagList(ctx context.Context, ref types.Ref) (TagList, error)
+	TagListWithOpts(ctx context.Context, ref types.Ref, opts TagOpts) (TagList, error)
 }
 
 // TODO: consider a tag interface for future uses
@@ -49,7 +51,7 @@ type TagList interface {
 }
 
 type tagCommon struct {
-	ref       Ref
+	ref       types.Ref
 	mt        string
 	orig      interface{}
 	rawHeader http.Header
@@ -79,14 +81,17 @@ type TagOpts struct {
 // 1. Make a manifest, for this we put a few labels and timestamps to be unique.
 // 2. Push that manifest to the tag.
 // 3. Delete the digest for that new manifest that is only used by that tag.
-func (rc *regClient) TagDelete(ctx context.Context, ref Ref) error {
-	var tempManifest Manifest
+func (rc *regClient) TagDelete(ctx context.Context, ref types.Ref) error {
+	var tempManifest manifest.Manifest
 	if ref.Tag == "" {
 		return ErrMissingTag
 	}
 
 	// lookup the current manifest media type
-	curManifest, _ := rc.ManifestHead(ctx, ref)
+	curManifest, err := rc.ManifestHead(ctx, ref)
+	if err != nil {
+		return err
+	}
 
 	// create empty image config with single label
 	// Note, this should be MediaType specific, but it appears that docker uses OCI for the config
@@ -119,9 +124,9 @@ func (rc *regClient) TagDelete(ctx context.Context, ref Ref) error {
 	confDigest := digester.Digest()
 
 	// create manifest with config, matching the original tag manifest type
-	switch curManifest.(type) {
-	case *manifestOCIM, *manifestOCIML:
-		om := ociv1.Manifest{
+	switch curManifest.GetMediaType() {
+	case MediaTypeOCI1Manifest, MediaTypeOCI1ManifestList:
+		tempManifest, err = manifest.FromOrig(ociv1.Manifest{
 			Versioned: ociv1Specs.Versioned{
 				SchemaVersion: 1,
 			},
@@ -131,30 +136,12 @@ func (rc *regClient) TagDelete(ctx context.Context, ref Ref) error {
 				Size:      int64(len(confB)),
 			},
 			Layers: []ociv1.Descriptor{},
-		}
-		omBytes, err := json.Marshal(om)
+		})
 		if err != nil {
 			return err
-		}
-		digester = digest.Canonical.Digester()
-		manfBuf := bytes.NewBuffer(omBytes)
-		_, err = manfBuf.WriteTo(digester.Hash())
-		if err != nil {
-			return err
-		}
-		tempManifest = &manifestOCIM{
-			manifestCommon: manifestCommon{
-				mt:       MediaTypeOCI1Manifest,
-				ref:      ref,
-				orig:     om,
-				rawBody:  omBytes,
-				digest:   digester.Digest(),
-				manifSet: true,
-			},
-			Manifest: om,
 		}
 	default: // default to the docker v2 schema
-		dm := dockerSchema2.Manifest{
+		tempManifest, err = manifest.FromOrig(dockerSchema2.Manifest{
 			Versioned: dockerManifest.Versioned{
 				SchemaVersion: 2,
 				MediaType:     MediaTypeDocker2Manifest,
@@ -165,27 +152,9 @@ func (rc *regClient) TagDelete(ctx context.Context, ref Ref) error {
 				Size:      int64(len(confB)),
 			},
 			Layers: []dockerDistribution.Descriptor{},
-		}
-		dmBytes, err := json.Marshal(dm)
+		})
 		if err != nil {
 			return err
-		}
-		digester = digest.Canonical.Digester()
-		manfBuf := bytes.NewBuffer(dmBytes)
-		_, err = manfBuf.WriteTo(digester.Hash())
-		if err != nil {
-			return err
-		}
-		tempManifest = &manifestDockerM{
-			manifestCommon: manifestCommon{
-				mt:       MediaTypeDocker2Manifest,
-				ref:      ref,
-				orig:     dm,
-				rawBody:  dmBytes,
-				digest:   digester.Digest(),
-				manifSet: true,
-			},
-			Manifest: dm,
 		}
 	}
 
@@ -220,11 +189,11 @@ func (rc *regClient) TagDelete(ctx context.Context, ref Ref) error {
 	return nil
 }
 
-func (rc *regClient) TagList(ctx context.Context, ref Ref) (TagList, error) {
+func (rc *regClient) TagList(ctx context.Context, ref types.Ref) (TagList, error) {
 	return rc.TagListWithOpts(ctx, ref, TagOpts{})
 }
 
-func (rc *regClient) TagListWithOpts(ctx context.Context, ref Ref, opts TagOpts) (TagList, error) {
+func (rc *regClient) TagListWithOpts(ctx context.Context, ref types.Ref, opts TagOpts) (TagList, error) {
 	var tl TagList
 	tc := tagCommon{
 		ref: ref,

--- a/regclient/types/ratelimit.go
+++ b/regclient/types/ratelimit.go
@@ -1,0 +1,8 @@
+package types
+
+// RateLimit is returned from some http requests
+type RateLimit struct {
+	Remain, Limit, Reset int
+	Set                  bool
+	Policies             []string
+}

--- a/regclient/types/ref.go
+++ b/regclient/types/ref.go
@@ -1,4 +1,4 @@
-package regclient
+package types
 
 import "github.com/docker/distribution/reference"
 


### PR DESCRIPTION
This also refactored manifests to not create them inside of the ManifestGet call, and instead pulled them out into a separate package that creates the appropriate manifest based on the content type or original manifest struct.