### PR TITLE
Blob refactor

### DIFF
--- a/cmd/regbot/sandbox/blob.go
+++ b/cmd/regbot/sandbox/blob.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/opencontainers/go-digest"
-	"github.com/regclient/regclient/regclient"
+	"github.com/regclient/regclient/regclient/blob"
 	"github.com/regclient/regclient/regclient/types"
 	"github.com/sirupsen/logrus"
 	lua "github.com/yuin/gopher-lua"
@@ -15,7 +15,7 @@ import (
 
 type sbBlob struct {
 	d   digest.Digest
-	b   regclient.Blob
+	b   blob.Blob
 	ref types.Ref
 	rdr io.Reader
 }
@@ -108,7 +108,7 @@ func (s *Sandbox) blobGet(ls *lua.LState) int {
 		ls.RaiseError("Failed retrieving \"%s\" blob \"%s\": %v", ref.ref.CommonName(), d, err)
 	}
 
-	ud, err := wrapUserData(ls, &sbBlob{b: b, ref: ref.ref, rdr: b}, b.GetOrig(), luaBlobName)
+	ud, err := wrapUserData(ls, &sbBlob{b: b, ref: ref.ref, rdr: b}, nil, luaBlobName)
 	if err != nil {
 		ls.RaiseError("Failed packaging \"%s\" blob \"%s\": %v", ref.ref.CommonName(), d, err)
 	}
@@ -132,7 +132,7 @@ func (s *Sandbox) blobHead(ls *lua.LState) int {
 		ls.RaiseError("Failed retrieving \"%s\" blob \"%s\": %v", ref.ref.CommonName(), d, err)
 	}
 
-	ud, err := wrapUserData(ls, &sbBlob{b: b, ref: ref.ref}, b.GetOrig(), luaBlobName)
+	ud, err := wrapUserData(ls, &sbBlob{b: b, ref: ref.ref}, nil, luaBlobName)
 	if err != nil {
 		ls.RaiseError("Failed packaging \"%s\" blob \"%s\": %v", ref.ref.CommonName(), d, err)
 	}

--- a/cmd/regbot/sandbox/image.go
+++ b/cmd/regbot/sandbox/image.go
@@ -7,7 +7,7 @@ import (
 
 	ociv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/regclient/regclient/pkg/go2lua"
-	"github.com/regclient/regclient/regclient"
+	"github.com/regclient/regclient/regclient/blob"
 	"github.com/regclient/regclient/regclient/manifest"
 	"github.com/regclient/regclient/regclient/types"
 	"github.com/sirupsen/logrus"
@@ -17,7 +17,7 @@ import (
 type config struct {
 	m    manifest.Manifest
 	ref  types.Ref
-	conf regclient.BlobOCIConfig
+	conf blob.OCIConfig
 }
 
 func setupImage(s *Sandbox) {
@@ -119,7 +119,7 @@ func (s *Sandbox) configExport(ls *lua.LState) int {
 			ls.RaiseError("Failed exporting config (go2lua): %v", err)
 		}
 		// save image to a new config
-		bc := regclient.NewBlobOCIConfig(ociImage)
+		bc := blob.NewOCIConfig(ociImage)
 		newC = &config{
 			conf: bc,
 			m:    origC.m,

--- a/regclient/blob/blob.go
+++ b/regclient/blob/blob.go
@@ -1,0 +1,7 @@
+package blob
+
+// Blob interface is used for returning blobs
+type Blob interface {
+	Common
+	RawBody() ([]byte, error)
+}

--- a/regclient/blob/common.go
+++ b/regclient/blob/common.go
@@ -1,0 +1,74 @@
+package blob
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/opencontainers/go-digest"
+	"github.com/regclient/regclient/regclient/types"
+)
+
+// Common interface is provided by all Blob implementations
+type Common interface {
+	Digest() digest.Digest
+	Length() int64
+	MediaType() string
+	Response() *http.Response
+	RawHeaders() http.Header
+	SetMeta(ref types.Ref, d digest.Digest, cl int64)
+	SetResp(resp *http.Response)
+}
+
+type common struct {
+	ref       types.Ref
+	digest    digest.Digest
+	cl        int64
+	mt        string
+	blobSet   bool
+	rawHeader http.Header
+	resp      *http.Response
+}
+
+// Digest returns the provided or calculated digest of the blob
+func (b *common) Digest() digest.Digest {
+	return b.digest
+}
+
+// Length returns the provided or calculated length of the blob
+func (b *common) Length() int64 {
+	return b.cl
+}
+
+// MediaType returns the Content-Type header received from the registry
+func (b *common) MediaType() string {
+	return b.mt
+}
+
+// RawHeaders returns the headers received from the registry
+func (b *common) RawHeaders() http.Header {
+	return b.rawHeader
+}
+
+// Response returns the response associated with the blob
+func (b *common) Response() *http.Response {
+	return b.resp
+}
+
+// SetMeta sets the various blob metadata (reference, digest, and content length)
+func (b *common) SetMeta(ref types.Ref, d digest.Digest, cl int64) {
+	b.ref = ref
+	b.digest = d
+	b.cl = cl
+}
+
+// SetResp sets the response header data when pulling from a registry
+func (b *common) SetResp(resp *http.Response) {
+	if resp == nil {
+		return
+	}
+	b.resp = resp
+	b.rawHeader = resp.Header
+	cl, _ := strconv.Atoi(resp.Header.Get("Content-Length"))
+	b.cl = int64(cl)
+	b.mt = resp.Header.Get("Content-Type")
+}

--- a/regclient/blob/ociconfig.go
+++ b/regclient/blob/ociconfig.go
@@ -1,0 +1,51 @@
+package blob
+
+import (
+	"encoding/json"
+	"fmt"
+
+	ociv1 "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// OCIConfig wraps an OCI Config struct extracted from a Blob
+type OCIConfig interface {
+	Blob
+	GetConfig() ociv1.Image
+}
+
+// ociConfig includes an OCI Config struct extracted from a Blob
+// Image is included as an anonymous field to facilitate json and templating calls transparently
+type ociConfig struct {
+	common
+	rawBody []byte
+	ociv1.Image
+}
+
+// NewOCIConfig creates a new BlobOCIConfig from an OCI Image
+func NewOCIConfig(ociImage ociv1.Image) OCIConfig {
+	bc := common{
+		blobSet: true,
+	}
+	b := ociConfig{
+		common: bc,
+		Image:  ociImage,
+	}
+	return &b
+}
+
+// GetConfig returns the original body from the request
+func (b *ociConfig) GetConfig() ociv1.Image {
+	return b.Image
+}
+
+// RawBody returns the original body from the request
+func (b *ociConfig) RawBody() ([]byte, error) {
+	var err error
+	if !b.blobSet {
+		return []byte{}, fmt.Errorf("Blob is not defined")
+	}
+	if len(b.rawBody) == 0 {
+		b.rawBody, err = json.Marshal(b.Image)
+	}
+	return b.rawBody, err
+}

--- a/regclient/blob/reader.go
+++ b/regclient/blob/reader.go
@@ -1,0 +1,63 @@
+package blob
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+
+	ociv1 "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// Reader is an unprocessed Blob with an available ReadCloser for reading the Blob
+type Reader interface {
+	Blob
+	io.ReadCloser
+	ToOCIConfig() (OCIConfig, error)
+}
+
+// reader is the internal struct implementing BlobReader
+type reader struct {
+	common
+	io.ReadCloser
+}
+
+// TODO: wrap the ReadCloser, running all reads through a digester
+// on final EOF, either save the digest and length, or report an error if the length and/or digest doesn't match
+
+// NewReader creates a new reader
+func NewReader(rc io.ReadCloser) Reader {
+	bc := common{}
+	if rc != nil {
+		bc.blobSet = true
+	}
+	br := reader{
+		common:     bc,
+		ReadCloser: rc,
+	}
+	return &br
+}
+
+// RawBody returns the original body from the request
+func (b *reader) RawBody() ([]byte, error) {
+	return ioutil.ReadAll(b)
+}
+
+// ToOCIConfig converts a blobReader to a BlobOCIConfig
+func (b *reader) ToOCIConfig() (OCIConfig, error) {
+	if !b.blobSet {
+		return nil, fmt.Errorf("Blob is not defined")
+	}
+	// TODO: error if blob read has already been called
+	blobBody, err := ioutil.ReadAll(b)
+	if err != nil {
+		return nil, fmt.Errorf("Error reading image config for %s: %w", b.ref.CommonName(), err)
+	}
+	var ociImage ociv1.Image
+	err = json.Unmarshal(blobBody, &ociImage)
+	if err != nil {
+		return nil, fmt.Errorf("Error parsing image config for %s: %w", b.ref.CommonName(), err)
+	}
+	// return the resulting blobOCIConfig, reuse blobCommon, setting rawBody read above, and the unmarshaled OCI image config
+	return &ociConfig{common: b.common, rawBody: blobBody, Image: ociImage}, nil
+}

--- a/regclient/blob/reader.go
+++ b/regclient/blob/reader.go
@@ -6,7 +6,9 @@ import (
 	"io"
 	"io/ioutil"
 
+	"github.com/opencontainers/go-digest"
 	ociv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/regclient/regclient/regclient/types"
 )
 
 // Reader is an unprocessed Blob with an available ReadCloser for reading the Blob
@@ -19,23 +21,34 @@ type Reader interface {
 // reader is the internal struct implementing BlobReader
 type reader struct {
 	common
-	io.ReadCloser
+	readBytes int64
+	reader    io.Reader
+	closer    io.Closer
+	digester  digest.Digester
+	// io.ReadCloser
 }
 
-// TODO: wrap the ReadCloser, running all reads through a digester
-// on final EOF, either save the digest and length, or report an error if the length and/or digest doesn't match
-
 // NewReader creates a new reader
-func NewReader(rc io.ReadCloser) Reader {
-	bc := common{}
-	if rc != nil {
+func NewReader(rdr io.ReadCloser) Reader {
+	digester := digest.Canonical.Digester()
+	digestRdr := io.TeeReader(rdr, digester.Hash())
+	bc := common{
+		ref: types.Ref{},
+	}
+	if rdr != nil {
 		bc.blobSet = true
 	}
 	br := reader{
-		common:     bc,
-		ReadCloser: rc,
+		common:   bc,
+		reader:   digestRdr,
+		closer:   rdr,
+		digester: digester,
 	}
 	return &br
+}
+
+func (b *reader) Close() error {
+	return b.closer.Close()
 }
 
 // RawBody returns the original body from the request
@@ -43,12 +56,35 @@ func (b *reader) RawBody() ([]byte, error) {
 	return ioutil.ReadAll(b)
 }
 
+// Read passes through the read operation while computing the digest and tracking the size
+func (b *reader) Read(p []byte) (int, error) {
+	size, err := b.reader.Read(p)
+	b.readBytes = b.readBytes + int64(size)
+	if err == io.EOF {
+		// check/save size
+		if b.cl == 0 {
+			b.cl = b.readBytes
+		} else if b.readBytes != b.cl {
+			err = fmt.Errorf("Expected size mismatch [expected %d, received %d]: %w", b.cl, b.readBytes, err)
+		}
+		// check/save digest
+		if b.digest == "" {
+			b.digest = b.digester.Digest()
+		} else if b.digest != b.digester.Digest() {
+			err = fmt.Errorf("Expected digest mismatch [expected %s, calculated %s]: %w", b.digest.String(), b.digester.Digest().String(), err)
+		}
+	}
+	return size, err
+}
+
 // ToOCIConfig converts a blobReader to a BlobOCIConfig
 func (b *reader) ToOCIConfig() (OCIConfig, error) {
 	if !b.blobSet {
 		return nil, fmt.Errorf("Blob is not defined")
 	}
-	// TODO: error if blob read has already been called
+	if b.readBytes != 0 {
+		return nil, fmt.Errorf("Unable to convert after read has been performed")
+	}
 	blobBody, err := ioutil.ReadAll(b)
 	if err != nil {
 		return nil, fmt.Errorf("Error reading image config for %s: %w", b.ref.CommonName(), err)


### PR DESCRIPTION
Like the manifest refactor, this moves blobs out to a separate package. Additionally the blob reader now checks the digest and size as the blob is read.