### PR TITLE
Adding ECR and GCR support

### DIFF
--- a/cmd/regctl/registry.go
+++ b/cmd/regctl/registry.go
@@ -166,6 +166,14 @@ func runRegistryLogin(cmd *cobra.Command, args []string) error {
 			return ErrMissingInput
 		}
 	}
+	// if username is <token> then process password as an identity token
+	if h.User == "<token>" {
+		h.Token = h.Pass
+		h.User = ""
+		h.Pass = ""
+	} else {
+		h.Token = ""
+	}
 	err = c.ConfigSave()
 	if err != nil {
 		return err
@@ -194,6 +202,7 @@ func runRegistryLogout(cmd *cobra.Command, args []string) error {
 	}
 	h.User = ""
 	h.Pass = ""
+	h.Token = ""
 	err = c.ConfigSave()
 	if err != nil {
 		return err

--- a/pkg/retryable/retryable.go
+++ b/pkg/retryable/retryable.go
@@ -36,6 +36,7 @@ type Response interface {
 
 // Auth is used to process Www-Authenticate header and update request with Authorization header
 type Auth interface {
+	AddScope(host, scope string) error
 	HandleResponse(*http.Response) error
 	UpdateRequest(*http.Request) error
 }
@@ -364,6 +365,18 @@ func WithHeaders(headers http.Header) OptsReq {
 func WithProgressCB(cb func(int64, error)) OptsReq {
 	return func(req *request) {
 		req.progressCB = cb
+	}
+}
+
+func WithScope(repo string, push bool) OptsReq {
+	scope := "repository:" + repo + ":pull"
+	if push {
+		scope = scope + ",push"
+	}
+	return func(req *request) {
+		for _, url := range req.urls {
+			req.r.auth.AddScope(url.Host, scope)
+		}
 	}
 }
 

--- a/regclient/manifest.go
+++ b/regclient/manifest.go
@@ -43,9 +43,10 @@ func (rc *regClient) ManifestDelete(ctx context.Context, ref types.Ref) error {
 		noMirrors: true,
 		apis: map[string]httpReqAPI{
 			"": {
-				method:  "DELETE",
-				path:    ref.Repository + "/manifests/" + ref.Digest,
-				headers: headers,
+				method:     "DELETE",
+				repository: ref.Repository,
+				path:       "manifests/" + ref.Digest,
+				headers:    headers,
 			},
 		},
 	}
@@ -86,9 +87,10 @@ func (rc *regClient) ManifestGet(ctx context.Context, ref types.Ref) (manifest.M
 		host: ref.Registry,
 		apis: map[string]httpReqAPI{
 			"": {
-				method:  "GET",
-				path:    ref.Repository + "/manifests/" + tagOrDigest,
-				headers: headers,
+				method:     "GET",
+				repository: ref.Repository,
+				path:       "manifests/" + tagOrDigest,
+				headers:    headers,
 			},
 		},
 	}
@@ -139,9 +141,10 @@ func (rc *regClient) ManifestHead(ctx context.Context, ref types.Ref) (manifest.
 		host: ref.Registry,
 		apis: map[string]httpReqAPI{
 			"": {
-				method:  "HEAD",
-				path:    ref.Repository + "/manifests/" + tagOrDigest,
-				headers: headers,
+				method:     "HEAD",
+				repository: ref.Repository,
+				path:       "manifests/" + tagOrDigest,
+				headers:    headers,
 			},
 		},
 	}
@@ -192,11 +195,12 @@ func (rc *regClient) ManifestPut(ctx context.Context, ref types.Ref, m manifest.
 		noMirrors: true,
 		apis: map[string]httpReqAPI{
 			"": {
-				method:    "PUT",
-				path:      ref.Repository + "/manifests/" + tagOrDigest,
-				headers:   headers,
-				bodyLen:   int64(len(mj)),
-				bodyBytes: mj,
+				method:     "PUT",
+				repository: ref.Repository,
+				path:       "manifests/" + tagOrDigest,
+				headers:    headers,
+				bodyLen:    int64(len(mj)),
+				bodyBytes:  mj,
 			},
 		},
 	}

--- a/regclient/tag.go
+++ b/regclient/tag.go
@@ -237,10 +237,11 @@ func (rc *regClient) TagListWithOpts(ctx context.Context, ref types.Ref, opts Ta
 		host: ref.Registry,
 		apis: map[string]httpReqAPI{
 			"": {
-				method:  "GET",
-				path:    ref.Repository + "/tags/list",
-				query:   query,
-				headers: headers,
+				method:     "GET",
+				repository: ref.Repository,
+				path:       "tags/list",
+				query:      query,
+				headers:    headers,
 			},
 		},
 	}


### PR DESCRIPTION
This supports the docker credential helpers for ECR and GCR when run as a binary (from within a container, you would need to include the helper binary and it's source of credentials). Support for using IdentityToken values still needs testing, but that has not been seen from these registries (they each use a generic user value instead). For GCR support, the auth needed to be redesigned to update the scope in the auth request because the www-authenticate header is not valid for push requests.

Fixes #54 