### PR TITLE
Adding OCI Import/Export

### DIFF
--- a/pkg/archive/errors.go
+++ b/pkg/archive/errors.go
@@ -5,6 +5,8 @@ import "errors"
 var (
 	// ErrNotImplemented used for routines that need to be developed still
 	ErrNotImplemented = errors.New("This archive routine is not implemented yet")
+	// ErrUnknownType used for unknown compression types
+	ErrUnknownType = errors.New("Unknown compression type")
 	// ErrXzUnsupported because there isn't a Go package for this and I'm
 	// avoiding dependencies on external binaries
 	ErrXzUnsupported = errors.New("Xz compression is currently unsupported")

--- a/pkg/retryable/error.go
+++ b/pkg/retryable/error.go
@@ -17,8 +17,6 @@ var (
 	ErrNotImplemented = errors.New("Not implemented")
 	// ErrRetryNeeded indicates a request needs to be retried
 	ErrRetryNeeded = errors.New("Retry needed")
-	// ErrStatusCode indicates an unsuccessful status code
-	ErrStatusCode = errors.New("Status code indicates the request failed")
 	// ErrUnauthorized request was not authorized
 	ErrUnauthorized = errors.New("Unauthorized")
 )

--- a/regclient/blob.go
+++ b/regclient/blob.go
@@ -202,7 +202,7 @@ func (rc *regClient) BlobPut(ctx context.Context, ref types.Ref, d digest.Digest
 	}
 
 	// send upload as one-chunk
-	if d != "" {
+	if d != "" && cl > 0 {
 		err = rc.blobPutUploadFull(ctx, ref, d, putURL, rdr, ct, cl)
 		return digest.Digest(d), cl, err
 	}
@@ -238,7 +238,6 @@ func (rc *regClient) blobGetUploadURL(ctx context.Context, ref types.Ref) (*url.
 	location := resp.HTTPResponse().Header.Get("Location")
 	rc.log.WithFields(logrus.Fields{
 		"location": location,
-		"headers":  resp.HTTPResponse().Header,
 	}).Debug("Upload location received")
 	// put url may be relative to the above post URL, so parse in that context
 	postURL := resp.HTTPResponse().Request.URL

--- a/regclient/blob.go
+++ b/regclient/blob.go
@@ -3,7 +3,6 @@ package regclient
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -104,7 +103,7 @@ func (rc *regClient) BlobGet(ctx context.Context, ref types.Ref, d digest.Digest
 		},
 	}
 	resp, err := rc.httpDo(ctx, req)
-	if err != nil && !errors.Is(err, retryable.ErrStatusCode) {
+	if err != nil {
 		return nil, fmt.Errorf("Failed to get blob, digest %s, ref %s: %w", d, ref.CommonName(), err)
 	}
 	if resp.HTTPResponse().StatusCode != 200 {
@@ -139,7 +138,7 @@ func (rc *regClient) BlobHead(ctx context.Context, ref types.Ref, d digest.Diges
 		},
 	}
 	resp, err := rc.httpDo(ctx, req)
-	if err != nil && !errors.Is(err, retryable.ErrStatusCode) {
+	if err != nil {
 		return nil, fmt.Errorf("Failed to request blob head, digest %s, ref %s: %w", d, ref.CommonName(), err)
 	}
 	defer resp.Close()
@@ -176,7 +175,7 @@ func (rc *regClient) BlobMount(ctx context.Context, refSrc types.Ref, refTgt typ
 		},
 	}
 	resp, err := rc.httpDo(ctx, req)
-	if err != nil && !errors.Is(err, retryable.ErrStatusCode) {
+	if err != nil {
 		return fmt.Errorf("Failed to mount blob, digest %s, ref %s: %w", d, refTgt.CommonName(), err)
 	}
 	defer resp.Close()
@@ -226,7 +225,7 @@ func (rc *regClient) blobGetUploadURL(ctx context.Context, ref types.Ref) (*url.
 		},
 	}
 	resp, err := rc.httpDo(ctx, req)
-	if err != nil && !errors.Is(err, retryable.ErrStatusCode) {
+	if err != nil {
 		return nil, fmt.Errorf("Failed to send blob post, ref %s: %w", ref.CommonName(), err)
 	}
 	defer resp.Close()
@@ -276,7 +275,7 @@ func (rc *regClient) blobPutUploadFull(ctx context.Context, ref types.Ref, d dig
 	opts = append(opts, retryable.WithScope(ref.Repository, true))
 	rty := rc.getRetryable(host)
 	resp, err := rty.DoRequest(ctx, "PUT", []url.URL{*putURL}, opts...)
-	if err != nil && !errors.Is(err, retryable.ErrStatusCode) {
+	if err != nil {
 		return fmt.Errorf("Failed to send blob (put), digest %s, ref %s: %w", d, ref.CommonName(), err)
 	}
 	defer resp.Close()
@@ -330,7 +329,7 @@ func (rc *regClient) blobPutUploadChunked(ctx context.Context, ref types.Ref, pu
 
 			rty := rc.getRetryable(host)
 			resp, err := rty.DoRequest(ctx, "PATCH", []url.URL{chunkURL}, opts...)
-			if err != nil && !errors.Is(err, retryable.ErrStatusCode) {
+			if err != nil {
 				return "", 0, fmt.Errorf("Failed to send blob (chunk), ref %s: %w", ref.CommonName(), err)
 			}
 			resp.Close()
@@ -377,7 +376,7 @@ func (rc *regClient) blobPutUploadChunked(ctx context.Context, ref types.Ref, pu
 	opts = append(opts, retryable.WithScope(ref.Repository, true))
 	rty := rc.getRetryable(host)
 	resp, err := rty.DoRequest(ctx, "PUT", []url.URL{chunkURL}, opts...)
-	if err != nil && !errors.Is(err, retryable.ErrStatusCode) {
+	if err != nil {
 		return "", 0, fmt.Errorf("Failed to send blob (chunk digest), digest %s, ref %s: %w", d, ref.CommonName(), err)
 	}
 	defer resp.Close()

--- a/regclient/error.go
+++ b/regclient/error.go
@@ -7,6 +7,8 @@ var (
 	ErrAPINotFound = errors.New("API not found")
 	// ErrCanceled if the context was canceled
 	ErrCanceled = errors.New("Context was canceled")
+	// ErrHttpStatus if the http status code was unexpected
+	ErrHttpStatus = errors.New("Unexpected http status code")
 	// ErrMissingDigest returned when image reference does not include a digest
 	ErrMissingDigest = errors.New("Digest missing from image reference")
 	// ErrMissingName returned when name missing for host

--- a/regclient/image.go
+++ b/regclient/image.go
@@ -1,6 +1,7 @@
 package regclient
 
 import (
+	"archive/tar"
 	"context"
 	"encoding/json"
 	"errors"
@@ -12,17 +13,60 @@ import (
 	"time"
 
 	// "github.com/docker/docker/pkg/archive"
+	"github.com/docker/distribution"
+	dockerSchema2 "github.com/docker/distribution/manifest/schema2"
 	digest "github.com/opencontainers/go-digest"
 	ociv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/regclient/regclient/pkg/archive"
+	"github.com/regclient/regclient/regclient/manifest"
 	"github.com/regclient/regclient/regclient/types"
 	"github.com/sirupsen/logrus"
+)
+
+const (
+	dockerManifestFilename = "manifest.json"
+	ociLayoutVersion       = "1.0.0"
+	ociIndexFilename       = "index.json"
 )
 
 // ImageClient provides registry client requests to images
 type ImageClient interface {
 	ImageCopy(ctx context.Context, refSrc types.Ref, refTgt types.Ref) error
 	ImageExport(ctx context.Context, ref types.Ref, outStream io.Writer) error
+	ImageImport(ctx context.Context, ref types.Ref, tarFile string) error
+}
+
+// used by import/export to match docker tar expected format
+type dockerTarManifest struct {
+	Config       string
+	RepoTags     []string
+	Layers       []string
+	Parent       digest.Digest                      `json:",omitempty"`
+	LayerSources map[digest.Digest]ociv1.Descriptor `json:",omitempty"`
+}
+
+type tarFileHandler func(header *tar.Header, trd *tarReadData) error
+type tarReadData struct {
+	tr          *tar.Reader
+	handleAdded bool
+	handlers    map[string]tarFileHandler
+	processed   map[string]bool
+	finish      []func() error
+	// data processed from various handlers
+	manifests           map[digest.Digest]manifest.Manifest
+	ociIndex            ociv1.Index
+	ociManifest         manifest.Manifest
+	dockerManifestFound bool
+	dockerManifestList  []dockerTarManifest
+	dockerManifest      dockerSchema2.Manifest
+}
+type tarWriteData struct {
+	tw        *tar.Writer
+	dirs      map[string]bool
+	files     map[string]bool
+	uid, gid  int
+	mode      int64
+	timestamp time.Time
 }
 
 func (rc *regClient) ImageCopy(ctx context.Context, refSrc types.Ref, refTgt types.Ref) error {
@@ -143,17 +187,32 @@ func (rc *regClient) ImageCopy(ctx context.Context, refSrc types.Ref, refTgt typ
 	return nil
 }
 
-// used by import/export to match docker tar expected format
-type dockerTarManifest struct {
-	Config   string
-	RepoTags []string
-	Layers   []string
-}
-
+// ImageExport exports an image to an output stream.
+// The format is compatible with "docker load" if a single image is selected and not a manifest list.
+// The ref must include a tag for exporting to docker (defaults to latest), and may also include a digest.
+// The export is also formatted according to OCI layout which supports multi-platform images.
+// <https://github.com/opencontainers/image-spec/blob/master/image-layout.md>
+// A tar file will be sent to outStream.
+//
+// Resulting filesystem:
+// oci-layout: created at top level, can be done at the start
+// index.json: created at top level, based on manifest and possibly build if manifest is not an OCI Index already
+// manifest.json: created at top level, based on every layer added, only works for a single arch image
+// blobs/$algo/$hash: each content addressable object (manifest, config, or layer), created recursively
 func (rc *regClient) ImageExport(ctx context.Context, ref types.Ref, outStream io.Writer) error {
-	expManifest := dockerTarManifest{}
-	expManifest.RepoTags = append(expManifest.RepoTags, ref.CommonName())
+	var ociIndex ociv1.Index
 
+	// create tar writer object
+	tw := tar.NewWriter(outStream)
+	defer tw.Close()
+	twd := &tarWriteData{
+		tw:    tw,
+		dirs:  map[string]bool{},
+		files: map[string]bool{},
+		mode:  0644,
+	}
+
+	// retrieve image manifest
 	m, err := rc.ManifestGet(ctx, ref)
 	if err != nil {
 		rc.log.WithFields(logrus.Fields{
@@ -163,229 +222,650 @@ func (rc *regClient) ImageExport(ctx context.Context, ref types.Ref, outStream i
 		return err
 	}
 
-	// write to a temp directory
-	tempDir, err := ioutil.TempDir("", "regclient-export-")
+	// build/write oci-layout
+	ociLayout := ociv1.ImageLayout{Version: ociLayoutVersion}
+	err = twd.tarWriteFileJSON(ociv1.ImageLayoutFile, ociLayout)
 	if err != nil {
-		rc.log.WithFields(logrus.Fields{
-			"ref": ref.CommonName(),
-			"dir": tempDir,
-			"err": err,
-		}).Warn("Failed to create temp directory")
-		return fmt.Errorf("Export failed for %s, unable to create temp dir: %w", ref.CommonName(), err)
+		return err
 	}
-	defer os.RemoveAll(tempDir)
 
-	rc.log.WithFields(logrus.Fields{
-		"dir": tempDir,
-	}).Debug("Using temp directory for export")
-
-	// retrieve the config blob
-	cd, err := m.GetConfigDigest()
-	if err != nil {
-		rc.log.WithFields(logrus.Fields{
-			"ref": ref.CommonName(),
-			"err": err,
-		}).Warn("Failed to get config digest from manifest")
-		return err
-	}
-	confBlob, err := rc.BlobGet(ctx, ref, cd, []string{MediaTypeDocker2ImageConfig, ociv1.MediaTypeImageConfig})
-	if err != nil {
-		rc.log.WithFields(logrus.Fields{
-			"ref":    ref.Reference,
-			"digest": cd.String(),
-			"err":    err,
-		}).Warn("Failed to get config")
-		return err
-	}
-	confStr, err := ioutil.ReadAll(confBlob)
-	if err != nil {
-		rc.log.WithFields(logrus.Fields{
-			"ref":    ref.CommonName(),
-			"digest": cd.String(),
-			"err":    err,
-		}).Warn("Failed to download config")
-		return err
-	}
-	confDigest := digest.FromBytes(confStr)
-	if cd != confDigest {
-		rc.log.WithFields(logrus.Fields{
-			"ref":        ref.CommonName(),
-			"expected":   cd.String(),
-			"calculated": confDigest.String(),
-		}).Warn("Config digest mismatch")
-
-		fmt.Fprintf(os.Stderr, "Warning: digest for image config does not match, pulled %s, calculated %s\n", cd.String(), confDigest.String())
-	}
-	conf := ociv1.Image{}
-	err = json.Unmarshal(confStr, &conf)
-	if err != nil {
-		return err
-	}
-	// reset the rootfs DiffIDs and recalculate them as layers are downloaded from the manifest
-	// layer digest will change when decompressed and docker load expects layers as tar files
-	conf.RootFS.DiffIDs = []digest.Digest{}
-
-	l, err := m.GetLayers()
-	if err != nil {
-		rc.log.WithFields(logrus.Fields{
-			"err": err,
-		}).Warn("Failed to get layers for manifest")
-		return err
-	}
-	for _, layerDesc := range l {
-		// TODO: wrap layer download in a concurrency throttled goroutine
-		// create tempdir for layer
-		layerDir, err := ioutil.TempDir(tempDir, "layer-*")
+	if orig, ok := m.GetOrigManifest().(ociv1.Index); ok {
+		// if the image is already an OCI Index, send as is
+		ociIndex = orig
+		ociJson, err := m.RawBody()
 		if err != nil {
 			return err
 		}
-		// no need to defer remove of layerDir, it is inside of tempDir
-
-		// request layer
-		layerBlob, err := rc.BlobGet(ctx, ref, layerDesc.Digest, []string{})
+		err = twd.tarWriteHeader(ociIndexFilename, int64(len(ociJson)))
 		if err != nil {
-			rc.log.WithFields(logrus.Fields{
-				"ref":   ref.CommonName(),
-				"layer": layerDesc.Digest.String(),
-				"err":   err,
-			}).Warn("Failed to download layer")
 			return err
 		}
-		defer layerBlob.Close()
-		// decompress layer
-		layerTarStream, err := archive.Decompress(layerBlob)
+		_, err = tw.Write(ociJson)
 		if err != nil {
-			rc.log.WithFields(logrus.Fields{
-				"err":    err,
-				"ref":    ref.CommonName(),
-				"digest": layerDesc.Digest.String(),
-			}).Warn("Failed to decompress layer")
 			return err
 		}
-		// TODO: verify received layer is a tgz, check mediatype?
-		// generate digest of decompressed layer
-		digestTar := digest.Canonical.Digester()
-		tr := io.TeeReader(layerTarStream, digestTar.Hash())
 
-		// download to a temp location
-		layerTarFile := filepath.Join(layerDir, "layer.tar")
-		lf, err := os.OpenFile(layerTarFile, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
+		// loop over platform descriptors
+		dl, err := m.GetDescriptorList()
 		if err != nil {
-			rc.log.WithFields(logrus.Fields{
-				"ref":  ref.CommonName(),
-				"err":  err,
-				"file": layerTarFile,
-			}).Warn("Failed to create temp layer file")
 			return err
 		}
-		_, err = io.Copy(lf, tr)
+		for _, d := range dl {
+			err = rc.imageExportDescriptor(ctx, ref, d, twd)
+			if err != nil {
+				return err
+			}
+		}
+	} else {
+		// create a manifest descriptor
+		mBody, err := m.RawBody()
 		if err != nil {
-			rc.log.WithFields(logrus.Fields{
-				"err":    err,
-				"ref":    ref.CommonName(),
-				"digest": layerDesc.Digest.String(),
-				"file":   layerTarFile,
-			}).Warn("Failed to download layer")
 			return err
 		}
-		lf.Close()
+		mDesc := ociv1.Descriptor{
+			MediaType: m.GetMediaType(),
+			Digest:    m.GetDigest(),
+			Size:      int64(len(mBody)),
+		}
 
-		// update references to uncompressed tar digest in the filesystem, manifest, and image config
-		digestFull := digestTar.Digest()
-		digestHex := digestFull.Encoded()
-		digestDir := filepath.Join(tempDir, digestHex)
-		digestFile := filepath.Join(digestHex, "layer.tar")
-		digestFileFull := filepath.Join(tempDir, digestFile)
-		if err := os.Rename(layerDir, digestDir); err != nil {
-			rc.log.WithFields(logrus.Fields{
-				"err": err,
-				"src": layerDir,
-				"tgt": digestDir,
-			}).Warn("Failed to rename layer temp dir")
+		// generate/write an OCI index
+		ociIndex.SchemaVersion = 2
+		ociIndex.Manifests = append(ociIndex.Manifests, mDesc)
+		err = twd.tarWriteFileJSON(ociIndexFilename, ociIndex)
+		if err != nil {
 			return err
 		}
-		if err := os.Chtimes(digestDir, *conf.Created, *conf.Created); err != nil {
-			rc.log.WithFields(logrus.Fields{
-				"err":  err,
-				"file": digestDir,
-			}).Warn("Failed to adjust creation time")
+
+		// append to docker manifest with tag, config filename, each layer filename, and layer descriptors
+		if !m.IsList() {
+			conf, err := m.GetConfigDescriptor()
+			if err != nil {
+				return err
+			}
+			refTag := ref
+			if refTag.Digest != "" {
+				refTag.Digest = ""
+			}
+			dockerManifest := dockerTarManifest{
+				RepoTags:     []string{refTag.CommonName()},
+				Config:       tarOCILayoutDescPath(conf),
+				Layers:       []string{},
+				LayerSources: map[digest.Digest]ociv1.Descriptor{},
+			}
+			dl, err := m.GetLayers()
+			if err != nil {
+				return err
+			}
+			for _, d := range dl {
+				dockerManifest.Layers = append(dockerManifest.Layers, tarOCILayoutDescPath(d))
+				dockerManifest.LayerSources[d.Digest] = d
+			}
+
+			// marshal manifest and write manifest.json
+			err = twd.tarWriteFileJSON(dockerManifestFilename, []dockerTarManifest{dockerManifest})
+			if err != nil {
+				return err
+			}
+		}
+
+		// recursively include manifests and nested blobs
+		err = rc.imageExportDescriptor(ctx, ref, mDesc, twd)
+		if err != nil {
 			return err
 		}
-		if err := os.Chtimes(digestFileFull, *conf.Created, *conf.Created); err != nil {
-			rc.log.WithFields(logrus.Fields{
-				"err":  err,
-				"file": digestFileFull,
-			}).Warn("Failed to adjust creation time")
-			return err
-		}
-		expManifest.Layers = append(expManifest.Layers, digestFile)
-		conf.RootFS.DiffIDs = append(conf.RootFS.DiffIDs, digestFull)
-	}
-	// TODO: if using goroutines, wait for all layers to finish
-
-	// calc config digest and write to file
-	confStr, err = json.Marshal(conf)
-	if err != nil {
-		rc.log.WithFields(logrus.Fields{
-			"ref": ref.CommonName(),
-			"err": err,
-		}).Warn("Error marshaling conf json")
-		return err
-	}
-	confDigest = digest.Canonical.FromBytes(confStr)
-	confFile := confDigest.Encoded() + ".json"
-	confFileFull := filepath.Join(tempDir, confFile)
-	if err := ioutil.WriteFile(confFileFull, confStr, 0644); err != nil {
-		rc.log.WithFields(logrus.Fields{
-			"ref": ref.CommonName(),
-			"err": err,
-		}).Warn("Error writing conf json")
-		return err
-	}
-	if err := os.Chtimes(confFileFull, *conf.Created, *conf.Created); err != nil {
-		rc.log.WithFields(logrus.Fields{
-			"ref": ref.CommonName(),
-			"err": err,
-		}).Warn("Error changing conf json timestamp")
-		return err
-	}
-	expManifest.Config = confFile
-
-	// convert to list and write manifest
-	ml := []dockerTarManifest{expManifest}
-	mlj, err := json.Marshal(ml)
-	if err != nil {
-		rc.log.WithFields(logrus.Fields{
-			"ref": ref.CommonName(),
-			"err": err,
-		}).Warn("Error marshaling manifest")
-		return err
-	}
-	manifestFile := filepath.Join(tempDir, "manifest.json")
-	if err := ioutil.WriteFile(manifestFile, mlj, 0644); err != nil {
-		rc.log.WithFields(logrus.Fields{
-			"ref": ref.CommonName(),
-			"err": err,
-		}).Warn("Error writing manifest")
-		return err
-	}
-	if err := os.Chtimes(manifestFile, time.Unix(0, 0), time.Unix(0, 0)); err != nil {
-		rc.log.WithFields(logrus.Fields{
-			"ref": ref.CommonName(),
-			"err": err,
-		}).Warn("Error changing manifest timestamp")
-		return err
-	}
-
-	// package in tar file
-	err = archive.Tar(ctx, tempDir, outStream, archive.Uncompressed)
-	if err != nil {
-		rc.log.WithFields(logrus.Fields{
-			"ref": ref.CommonName(),
-			"err": err,
-		}).Warn("Error taring temp dir")
-		return err
 	}
 
 	return nil
+}
+
+// imageExportDescriptor pulls a manifest or blob, outputs to a tar file, and recursively processes any nested manifests or blobs
+func (rc *regClient) imageExportDescriptor(ctx context.Context, ref types.Ref, desc ociv1.Descriptor, twd *tarWriteData) error {
+	tarFilename := tarOCILayoutDescPath(desc)
+	if twd.files[tarFilename] {
+		// blob has already been imported into tar, skip
+		return nil
+	}
+	switch desc.MediaType {
+	case MediaTypeDocker1Manifest, MediaTypeDocker1ManifestSigned, MediaTypeDocker2Manifest, MediaTypeOCI1Manifest:
+		// Handle single platform manifests
+		// retrieve manifest
+		mRef := ref
+		mRef.Digest = desc.Digest.String()
+		m, err := rc.ManifestGet(ctx, mRef)
+		if err != nil {
+			return err
+		}
+		// write manifest body by digest
+		mBody, err := m.RawBody()
+		if err != nil {
+			return err
+		}
+		err = twd.tarWriteHeader(tarFilename, int64(len(mBody)))
+		if err != nil {
+			return err
+		}
+		_, err = twd.tw.Write(mBody)
+		if err != nil {
+			return err
+		}
+
+		// add config
+		confD, err := m.GetConfigDescriptor()
+		// ignore unsupported media type errors
+		if err != nil && !errors.Is(err, manifest.ErrUnsupportedMediaType) {
+			return err
+		}
+		if err == nil {
+			err = rc.imageExportDescriptor(ctx, ref, confD, twd)
+			if err != nil {
+				return err
+			}
+		}
+
+		// loop over layers
+		layerDL, err := m.GetLayers()
+		// ignore unsupported media type errors
+		if err != nil && !errors.Is(err, manifest.ErrUnsupportedMediaType) {
+			return err
+		}
+		if err == nil {
+			for _, layerD := range layerDL {
+				err = rc.imageExportDescriptor(ctx, ref, layerD, twd)
+				if err != nil {
+					return err
+				}
+			}
+		}
+
+	case MediaTypeDocker2ManifestList, MediaTypeOCI1ManifestList:
+		// handle OCI index and Docker manifest list
+		// retrieve manifest
+		mRef := ref
+		mRef.Digest = desc.Digest.String()
+		m, err := rc.ManifestGet(ctx, mRef)
+		if err != nil {
+			return err
+		}
+		// write manifest body by digest
+		mBody, err := m.RawBody()
+		if err != nil {
+			return err
+		}
+		err = twd.tarWriteHeader(tarFilename, int64(len(mBody)))
+		if err != nil {
+			return err
+		}
+		_, err = twd.tw.Write(mBody)
+		if err != nil {
+			return err
+		}
+		// recurse over entries in the list/index
+		mdl, err := m.GetDescriptorList()
+		if err != nil {
+			return err
+		}
+		for _, md := range mdl {
+			err = rc.imageExportDescriptor(ctx, ref, md, twd)
+			if err != nil {
+				return err
+			}
+		}
+
+	default:
+		// get blob
+		blobR, err := rc.BlobGet(ctx, ref, desc.Digest, []string{})
+		if err != nil {
+			return err
+		}
+		defer blobR.Close()
+		// write blob by digest
+		err = twd.tarWriteHeader(tarFilename, int64(desc.Size))
+		if err != nil {
+			return err
+		}
+		size, err := io.Copy(twd.tw, blobR)
+		if err != nil {
+			return fmt.Errorf("Failed to export blob %s: %w", desc.Digest.String(), err)
+		}
+		if size != desc.Size {
+			return fmt.Errorf("Blob size mismatch, descriptor %d, received %d", desc.Size, size)
+		}
+	}
+
+	return nil
+}
+
+// ImageImport pushes an image from a tar file to a registry
+func (rc *regClient) ImageImport(ctx context.Context, ref types.Ref, tarFile string) error {
+	trd := &tarReadData{
+		handlers:  map[string]tarFileHandler{},
+		processed: map[string]bool{},
+		finish:    []func() error{},
+		manifests: map[digest.Digest]manifest.Manifest{},
+	}
+	// open tarFile
+	fh, err := os.Open(tarFile)
+	if err != nil {
+		return err
+	}
+
+	// add handler for oci-layout, index.json, and manifest.json
+	rc.imageImportOCIAddHandler(ctx, ref, trd)
+	rc.imageImportDockerAddHandler(trd)
+
+	// process tar file looking for oci-layout and index.json, load manifests/blobs on success
+	err = trd.tarReadAll(fh)
+
+	if err != nil && errors.Is(err, ErrNotFound) && trd.dockerManifestFound {
+		// import failed but manifest.json found, fall back to manifest.json processing
+		// add handlers for the docker manifest layers
+		rc.imageImportDockerAddLayerHandlers(ctx, ref, trd)
+		// reprocess the tar looking for manifest.json files
+		err = trd.tarReadAll(fh)
+		if err != nil {
+			return fmt.Errorf("Failed to import layers from docker tar: %w", err)
+		}
+		// push docker manifest
+		m, err := manifest.FromOrig(trd.dockerManifest)
+		if err != nil {
+			return err
+		}
+		err = rc.ManifestPut(ctx, ref, m)
+		if err != nil {
+			return err
+		}
+	} else if err != nil {
+		// unhandled error from tar read
+		return err
+	} else {
+		// successful load of OCI blobs, now push manifest and tag
+		err = rc.imageImportOCIPushManifests(ctx, ref, trd)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (rc *regClient) imageImportBlob(ctx context.Context, ref types.Ref, desc ociv1.Descriptor, trd *tarReadData) error {
+	// skip if blob already exists
+	_, err := rc.BlobHead(ctx, ref, desc.Digest)
+	if err == nil {
+		return nil
+	}
+	// upload blob
+	_, _, err = rc.BlobPut(ctx, ref, desc.Digest, trd.tr, "", desc.Size)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// imageImportDockerAddHandler processes tar files generated by docker
+func (rc *regClient) imageImportDockerAddHandler(trd *tarReadData) {
+	trd.handlers[dockerManifestFilename] = func(header *tar.Header, trd *tarReadData) error {
+		err := trd.tarReadFileJSON(&trd.dockerManifestList)
+		if err != nil {
+			return err
+		}
+		trd.dockerManifestFound = true
+		return nil
+	}
+}
+
+// imageImportDockerAddLayerHandlers imports the docker layers when OCI import fails and docker manifest found
+func (rc *regClient) imageImportDockerAddLayerHandlers(ctx context.Context, ref types.Ref, trd *tarReadData) {
+	// remove handlers for OCI
+	delete(trd.handlers, ociv1.ImageLayoutFile)
+	delete(trd.handlers, ociIndexFilename)
+
+	// make a docker v2 manifest from first json array entry (can only tag one image)
+	trd.dockerManifest.SchemaVersion = 2
+	trd.dockerManifest.MediaType = MediaTypeDocker2Manifest
+	trd.dockerManifest.Layers = make([]distribution.Descriptor, len(trd.dockerManifestList[0].Layers))
+
+	// add handler for config
+	trd.handlers[trd.dockerManifestList[0].Config] = func(header *tar.Header, trd *tarReadData) error {
+		// upload blob, digest is unknown
+		d, size, err := rc.BlobPut(ctx, ref, "", trd.tr, "", header.Size)
+		if err != nil {
+			return err
+		}
+		// save the resulting descriptor to the manifest
+		if od, ok := trd.dockerManifestList[0].LayerSources[d]; ok {
+			trd.dockerManifest.Config = oci2DDesc(od)
+		} else {
+			trd.dockerManifest.Config = distribution.Descriptor{
+				Digest:    d,
+				Size:      size,
+				MediaType: MediaTypeDocker2ImageConfig,
+			}
+		}
+		return nil
+	}
+	// add handlers for each layer
+	for i, layerFile := range trd.dockerManifestList[0].Layers {
+		func(i int) {
+			trd.handlers[layerFile] = func(header *tar.Header, trd *tarReadData) error {
+				// ensure blob is compressed with gzip to match media type
+				gzipR, err := archive.Compress(trd.tr, archive.CompressGzip)
+				if err != nil {
+					return err
+				}
+				// upload blob, digest and size is unknown
+				d, size, err := rc.BlobPut(ctx, ref, "", gzipR, "", 0)
+				if err != nil {
+					return err
+				}
+				// save the resulting descriptor in the appropriate layer
+				if od, ok := trd.dockerManifestList[0].LayerSources[d]; ok {
+					trd.dockerManifest.Layers[i] = oci2DDesc(od)
+				} else {
+					trd.dockerManifest.Layers[i] = distribution.Descriptor{
+						MediaType: MediaTypeDocker2Layer,
+						Size:      size,
+						Digest:    d,
+					}
+				}
+				return nil
+			}
+		}(i)
+	}
+	trd.handleAdded = true
+}
+
+// imageImportOCIAddHandler adds handlers for oci-layout and index.json found in OCI layout tar files
+func (rc *regClient) imageImportOCIAddHandler(ctx context.Context, ref types.Ref, trd *tarReadData) {
+	// add handler for oci-layout, index.json, and manifest.json
+	var err error
+	var foundLayout, foundIndex bool
+
+	// common handler code when both oci-layout and index.json have been processed
+	ociHandler := func(trd *tarReadData) error {
+		// no need to process docker manifest.json when OCI layout is available
+		delete(trd.handlers, dockerManifestFilename)
+		// create a manifest from the index
+		trd.ociManifest, err = manifest.FromOrig(trd.ociIndex)
+		if err != nil {
+			return err
+		}
+		// start recursively processing manifests starting with the index
+		// there's no need to push the index.json by digest, it will be pushed by tag if needed
+		err = rc.imageImportOCIHandleManifest(ctx, ref, trd.ociManifest, trd, false)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+	trd.handlers[ociv1.ImageLayoutFile] = func(header *tar.Header, trd *tarReadData) error {
+		var ociLayout ociv1.ImageLayout
+		err := trd.tarReadFileJSON(&ociLayout)
+		if err != nil {
+			return err
+		}
+		if ociLayout.Version != ociLayoutVersion {
+			// unknown version, ignore
+			rc.log.WithFields(logrus.Fields{
+				"version": ociLayout.Version,
+			}).Warn("Unsupported oci-layout version")
+			return nil
+		}
+		foundLayout = true
+		if foundIndex {
+			err = ociHandler(trd)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	trd.handlers[ociIndexFilename] = func(header *tar.Header, trd *tarReadData) error {
+		err := trd.tarReadFileJSON(&trd.ociIndex)
+		if err != nil {
+			return err
+		}
+		foundIndex = true
+		if foundLayout {
+			err = ociHandler(trd)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+// imageImportOCIHandleManifest recursively processes index and manifest entries from an OCI layout tar
+func (rc *regClient) imageImportOCIHandleManifest(ctx context.Context, ref types.Ref, m manifest.Manifest, trd *tarReadData, push bool) error {
+	// cache the manifest to avoid needing to pull again later, this is used if index.json is a wrapper around some other manifest
+	trd.manifests[m.GetDigest()] = m
+	if m.IsList() {
+		// for index/manifest lists, add handlers for each embedded manifest
+		dl, err := m.GetDescriptorList()
+		if err != nil {
+			return err
+		}
+		for _, d := range dl {
+			filename := tarOCILayoutDescPath(d)
+			if !trd.processed[filename] && trd.handlers[filename] == nil {
+				func(d ociv1.Descriptor) {
+					trd.handlers[filename] = func(header *tar.Header, trd *tarReadData) error {
+						b, err := ioutil.ReadAll(trd.tr)
+						if err != nil {
+							return err
+						}
+						md, err := manifest.FromDescriptor(d, b)
+						if err != nil {
+							return err
+						}
+						return rc.imageImportOCIHandleManifest(ctx, ref, md, trd, true)
+					}
+				}(d)
+			}
+		}
+	} else {
+		// else if a single image/manifest
+		// add handler for the config descriptor if it's defined
+		cd, err := m.GetConfigDescriptor()
+		if err == nil {
+			filename := tarOCILayoutDescPath(cd)
+			if !trd.processed[filename] && trd.handlers[filename] == nil {
+				func(cd ociv1.Descriptor) {
+					trd.handlers[filename] = func(header *tar.Header, trd *tarReadData) error {
+						return rc.imageImportBlob(ctx, ref, cd, trd)
+					}
+				}(cd)
+			}
+		}
+		// add handlers for each layer
+		layers, err := m.GetLayers()
+		if err != nil {
+			return err
+		}
+		for _, d := range layers {
+			filename := tarOCILayoutDescPath(d)
+			if !trd.processed[filename] && trd.handlers[filename] == nil {
+				func(d ociv1.Descriptor) {
+					trd.handlers[filename] = func(header *tar.Header, trd *tarReadData) error {
+						return rc.imageImportBlob(ctx, ref, d, trd)
+					}
+				}(d)
+			}
+		}
+	}
+	// add a finish func to push the manifest, this gets skipped for the index.json
+	if push {
+		trd.finish = append(trd.finish, func() error {
+			mRef := ref
+			mRef.Digest = string(m.GetDigest())
+			_, err := rc.ManifestHead(ctx, mRef)
+			if err == nil {
+				return nil
+			}
+			return rc.ManifestPut(ctx, mRef, m)
+		})
+	}
+	trd.handleAdded = true
+	return nil
+}
+
+// imageImportOCIPushManifests uploads manifests after OCI blobs were successfully loaded
+func (rc *regClient) imageImportOCIPushManifests(ctx context.Context, ref types.Ref, trd *tarReadData) error {
+	// run finish handlers in reverse order to upload nested manifests
+	for i := len(trd.finish) - 1; i >= 0; i-- {
+		err := trd.finish[i]()
+		if err != nil {
+			return err
+		}
+	}
+
+	if len(trd.ociIndex.Manifests) == 1 && trd.ociIndex.Manifests[0].Platform == nil {
+		// if index.json a stub for single image, push manifest for single image as tag
+		d := trd.ociIndex.Manifests[0].Digest
+		m, ok := trd.manifests[d]
+		if !ok {
+			return fmt.Errorf("Unable to put manifest digest %s: %w", d.String(), ErrNotFound)
+		}
+		err := rc.ManifestPut(ctx, ref, m)
+		if err != nil {
+			return err
+		}
+	} else {
+		// else push index.json as tag
+		err := rc.ManifestPut(ctx, ref, trd.ociManifest)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func oci2DDesc(od ociv1.Descriptor) distribution.Descriptor {
+	return distribution.Descriptor{
+		MediaType:   od.MediaType,
+		Digest:      od.Digest,
+		Size:        od.Size,
+		URLs:        od.URLs,
+		Annotations: od.Annotations,
+		Platform:    od.Platform,
+	}
+}
+
+// tarReadAll processes the tar file in a loop looking for matching filenames in the list of handlers
+// handlers for filenames are added at the top level, and by manifest imports
+func (trd *tarReadData) tarReadAll(fh *os.File) error {
+	// return immediately if nothing to do
+	if len(trd.handlers) == 0 {
+		return nil
+	}
+	for {
+		// reset back to beginning of tar file
+		_, err := fh.Seek(0, 0)
+		if err != nil {
+			return err
+		}
+		trd.tr = tar.NewReader(fh)
+		trd.handleAdded = false
+		// loop over each entry of the tar file
+		for {
+			header, err := trd.tr.Next()
+			if err == io.EOF {
+				break
+			} else if err != nil {
+				return err
+			}
+			// if a handler exists, run it, remove handler, and check if we are done
+			if trd.handlers[header.Name] != nil {
+				err = trd.handlers[header.Name](header, trd)
+				if err != nil {
+					return err
+				}
+				delete(trd.handlers, header.Name)
+				trd.processed[header.Name] = true
+				// return if last handler processed
+				if len(trd.handlers) == 0 {
+					return nil
+				}
+			}
+		}
+		// if entire file read without adding a new handler, fail
+		if !trd.handleAdded {
+			files := []string{}
+			for file := range trd.handlers {
+				files = append(files, file)
+			}
+			return fmt.Errorf("Unable to export all files from tar: %w", ErrNotFound)
+		}
+	}
+}
+
+// tarReadFileJSON reads the current tar entry and unmarshals json into provided interface
+func (trd *tarReadData) tarReadFileJSON(data interface{}) error {
+	b, err := ioutil.ReadAll(trd.tr)
+	if err != nil {
+		return err
+	}
+	err = json.Unmarshal(b, data)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+var errTarFileExists = errors.New("Tar file already exists")
+
+func (td *tarWriteData) tarWriteHeader(filename string, size int64) error {
+	dirname := filepath.Dir(filename)
+	if !td.dirs[dirname] && dirname != "." {
+		header := tar.Header{
+			Format:     tar.FormatPAX,
+			Typeflag:   tar.TypeDir,
+			Name:       dirname,
+			Size:       0,
+			Mode:       td.mode | 0511,
+			ModTime:    td.timestamp,
+			AccessTime: td.timestamp,
+			ChangeTime: td.timestamp,
+		}
+		err := td.tw.WriteHeader(&header)
+		if err != nil {
+			return err
+		}
+		td.dirs[dirname] = true
+	}
+	if td.files[filename] {
+		return fmt.Errorf("%w: %s", errTarFileExists, filename)
+	}
+	td.files[filename] = true
+	header := tar.Header{
+		Format:     tar.FormatPAX,
+		Typeflag:   tar.TypeReg,
+		Name:       filename,
+		Size:       size,
+		Mode:       td.mode | 0400,
+		ModTime:    td.timestamp,
+		AccessTime: td.timestamp,
+		ChangeTime: td.timestamp,
+	}
+	return td.tw.WriteHeader(&header)
+}
+
+func (td *tarWriteData) tarWriteFileJSON(filename string, data interface{}) error {
+	dataJson, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+	err = td.tarWriteHeader(filename, int64(len(dataJson)))
+	if err != nil {
+		return err
+	}
+	_, err = td.tw.Write(dataJson)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func tarOCILayoutDescPath(d ociv1.Descriptor) string {
+	return fmt.Sprintf("blobs/%s/%s", d.Digest.Algorithm(), d.Digest.Encoded())
 }

--- a/regclient/manifest.go
+++ b/regclient/manifest.go
@@ -2,12 +2,10 @@ package regclient
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 
-	"github.com/regclient/regclient/pkg/retryable"
 	"github.com/regclient/regclient/pkg/wraperr"
 	"github.com/regclient/regclient/regclient/manifest"
 	"github.com/regclient/regclient/regclient/types"
@@ -51,7 +49,7 @@ func (rc *regClient) ManifestDelete(ctx context.Context, ref types.Ref) error {
 		},
 	}
 	resp, err := rc.httpDo(ctx, req)
-	if err != nil && !errors.Is(err, retryable.ErrStatusCode) {
+	if err != nil {
 		return fmt.Errorf("Failed to delete manifest %s: %w", ref.CommonName(), err)
 	}
 	defer resp.Close()
@@ -95,7 +93,7 @@ func (rc *regClient) ManifestGet(ctx context.Context, ref types.Ref) (manifest.M
 		},
 	}
 	resp, err := rc.httpDo(ctx, req)
-	if err != nil && !errors.Is(err, retryable.ErrStatusCode) {
+	if err != nil {
 		return nil, fmt.Errorf("Failed to get manifest %s: %w", ref.CommonName(), err)
 	}
 	defer resp.Close()
@@ -149,7 +147,7 @@ func (rc *regClient) ManifestHead(ctx context.Context, ref types.Ref) (manifest.
 		},
 	}
 	resp, err := rc.httpDo(ctx, req)
-	if err != nil && !errors.Is(err, retryable.ErrStatusCode) {
+	if err != nil {
 		return nil, fmt.Errorf("Failed to request manifest head %s: %w", ref.CommonName(), err)
 	}
 	defer resp.Close()
@@ -205,7 +203,7 @@ func (rc *regClient) ManifestPut(ctx context.Context, ref types.Ref, m manifest.
 		},
 	}
 	resp, err := rc.httpDo(ctx, req)
-	if err != nil && !errors.Is(err, retryable.ErrStatusCode) {
+	if err != nil {
 		return fmt.Errorf("Failed to put manifest %s: %w", ref.CommonName(), err)
 	}
 	defer resp.Close()

--- a/regclient/manifest/docker1.go
+++ b/regclient/manifest/docker1.go
@@ -27,8 +27,14 @@ type docker1SignedManifest struct {
 	dockerSchema1.SignedManifest
 }
 
+func (m *docker1Manifest) GetConfigDescriptor() (ociv1.Descriptor, error) {
+	return ociv1.Descriptor{}, wraperr.New(fmt.Errorf("Config digest not available for media type %s", m.mt), ErrUnsupportedMediaType)
+}
 func (m *docker1Manifest) GetConfigDigest() (digest.Digest, error) {
 	return "", wraperr.New(fmt.Errorf("Config digest not available for media type %s", m.mt), ErrUnsupportedMediaType)
+}
+func (m *docker1SignedManifest) GetConfigDescriptor() (ociv1.Descriptor, error) {
+	return ociv1.Descriptor{}, wraperr.New(fmt.Errorf("Config digest not available for media type %s", m.mt), ErrUnsupportedMediaType)
 }
 func (m *docker1SignedManifest) GetConfigDigest() (digest.Digest, error) {
 	return "", wraperr.New(fmt.Errorf("Config digest not available for media type %s", m.mt), ErrUnsupportedMediaType)

--- a/regclient/manifest/docker2.go
+++ b/regclient/manifest/docker2.go
@@ -31,8 +31,21 @@ type docker2ManifestList struct {
 	dockerManifestList.ManifestList
 }
 
+func (m *docker2Manifest) GetConfigDescriptor() (ociv1.Descriptor, error) {
+	return ociv1.Descriptor{
+		MediaType:   m.Config.MediaType,
+		Digest:      m.Config.Digest,
+		Size:        m.Config.Size,
+		URLs:        m.Config.URLs,
+		Annotations: m.Config.Annotations,
+		Platform:    m.Config.Platform,
+	}, nil
+}
 func (m *docker2Manifest) GetConfigDigest() (digest.Digest, error) {
 	return m.Config.Digest, nil
+}
+func (m *docker2ManifestList) GetConfigDescriptor() (ociv1.Descriptor, error) {
+	return ociv1.Descriptor{}, wraperr.New(fmt.Errorf("Config digest not available for media type %s", m.mt), ErrUnsupportedMediaType)
 }
 func (m *docker2ManifestList) GetConfigDigest() (digest.Digest, error) {
 	return "", wraperr.New(fmt.Errorf("Config digest not available for media type %s", m.mt), ErrUnsupportedMediaType)

--- a/regclient/manifest/oci1.go
+++ b/regclient/manifest/oci1.go
@@ -29,8 +29,14 @@ type oci1Index struct {
 	ociv1.Index
 }
 
+func (m *oci1Manifest) GetConfigDescriptor() (ociv1.Descriptor, error) {
+	return m.Config, nil
+}
 func (m *oci1Manifest) GetConfigDigest() (digest.Digest, error) {
 	return m.Config.Digest, nil
+}
+func (m *oci1Index) GetConfigDescriptor() (ociv1.Descriptor, error) {
+	return ociv1.Descriptor{}, wraperr.New(fmt.Errorf("Config digest not available for media type %s", m.mt), ErrUnsupportedMediaType)
 }
 func (m *oci1Index) GetConfigDigest() (digest.Digest, error) {
 	return "", wraperr.New(fmt.Errorf("Config digest not available for media type %s", m.mt), ErrUnsupportedMediaType)

--- a/regclient/manifest/unknown.go
+++ b/regclient/manifest/unknown.go
@@ -17,6 +17,10 @@ type UnknownData struct {
 	Data map[string]interface{}
 }
 
+func (m *unknown) GetConfigDescriptor() (ociv1.Descriptor, error) {
+	return ociv1.Descriptor{}, wraperr.New(fmt.Errorf("Config digest not available for media type %s", m.mt), ErrUnsupportedMediaType)
+}
+
 func (m *unknown) GetConfigDigest() (digest.Digest, error) {
 	return "", wraperr.New(fmt.Errorf("Config digest not available for media type %s", m.mt), ErrUnsupportedMediaType)
 }

--- a/regclient/regclient.go
+++ b/regclient/regclient.go
@@ -51,6 +51,8 @@ const (
 	MediaTypeOCI1ManifestList = ociv1.MediaTypeImageIndex
 	// MediaTypeOCI1ImageConfig OCI v1 configuration json object media type
 	MediaTypeOCI1ImageConfig = ociv1.MediaTypeImageConfig
+	// MediaTypeDocker2Layer is the default compressed layer for docker schema2
+	MediaTypeDocker2Layer = dockerSchema2.MediaTypeLayer
 )
 
 var (

--- a/regclient/regclient.go
+++ b/regclient/regclient.go
@@ -157,11 +157,12 @@ func WithConfigHosts(configHosts []ConfigHost) Opt {
 					configHost.Hostname = DockerRegistryDNS
 				}
 			}
+			tls, _ := configHost.TLS.MarshalText()
 			rc.log.WithFields(logrus.Fields{
 				"name":       configHost.Name,
 				"user":       configHost.User,
 				"hostname":   configHost.Hostname,
-				"tls":        configHost.TLS,
+				"tls":        string(tls),
 				"pathPrefix": configHost.PathPrefix,
 				"mirrors":    configHost.Mirrors,
 				"api":        configHost.API,

--- a/regclient/repo.go
+++ b/regclient/repo.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -13,7 +12,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/regclient/regclient/pkg/retryable"
 	"github.com/sirupsen/logrus"
 )
 
@@ -91,7 +89,7 @@ func (rc *regClient) RepoListWithOpts(ctx context.Context, hostname string, opts
 		},
 	}
 	resp, err := rc.httpDo(ctx, req)
-	if err != nil && !errors.Is(err, retryable.ErrStatusCode) {
+	if err != nil {
 		return rl, fmt.Errorf("Failed to list repositories for %s: %w", hostname, err)
 	}
 	defer resp.Close()

--- a/regclient/tag.go
+++ b/regclient/tag.go
@@ -20,7 +20,6 @@ import (
 	"github.com/opencontainers/go-digest"
 	ociv1Specs "github.com/opencontainers/image-spec/specs-go"
 	ociv1 "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/regclient/regclient/pkg/retryable"
 	"github.com/regclient/regclient/regclient/manifest"
 	"github.com/regclient/regclient/regclient/types"
 	"github.com/sirupsen/logrus"
@@ -105,8 +104,6 @@ func (rc *regClient) TagDelete(ctx context.Context, ref types.Ref) error {
 	}
 	if err == nil {
 		return nil
-	} else if errors.Is(err, retryable.ErrStatusCode) {
-		return fmt.Errorf("Failed to delete tag %s: %w", ref.CommonName(), httpError(resp.HTTPResponse().StatusCode))
 	} else if !errors.Is(err, ErrAPINotFound) {
 		return fmt.Errorf("Failed to delete tag %s: %w", ref.CommonName(), err)
 	}
@@ -246,7 +243,7 @@ func (rc *regClient) TagListWithOpts(ctx context.Context, ref types.Ref, opts Ta
 		},
 	}
 	resp, err := rc.httpDo(ctx, req)
-	if err != nil && !errors.Is(err, retryable.ErrStatusCode) {
+	if err != nil {
 		return tl, fmt.Errorf("Failed to list tags for %s: %w", ref.CommonName(), err)
 	}
 	defer resp.Close()


### PR DESCRIPTION
This adds the ability to export images to OCI Layout format, which supports multi-platform images. It also adds the ability to import from the OCI Layout (or the already supported `docker save` tar syntax). This facilitates air-gapped workflows.