### PR TITLE
Adjust parallel=0 with "once" commands

### DIFF
--- a/cmd/regbot/config.go
+++ b/cmd/regbot/config.go
@@ -72,10 +72,6 @@ func ConfigLoadReader(r io.Reader) (*Config, error) {
 	if c.Version > 1 {
 		return c, ErrUnsupportedConfigVersion
 	}
-	// apply top level defaults
-	if c.Defaults.Parallel <= 0 {
-		c.Defaults.Parallel = 1
-	}
 	// apply defaults to each step
 	for i := range c.Scripts {
 		scriptSetDefaults(&c.Scripts[i], c.Defaults)

--- a/cmd/regsync/config.go
+++ b/cmd/regsync/config.go
@@ -120,9 +120,6 @@ func ConfigLoadReader(r io.Reader) (*Config, error) {
 		return c, ErrUnsupportedConfigVersion
 	}
 	// apply top level defaults
-	if c.Defaults.Parallel <= 0 {
-		c.Defaults.Parallel = 1
-	}
 	if c.Defaults.RateLimit.Retry < rateLimitRetryMin {
 		c.Defaults.RateLimit.Retry = rateLimitRetryMin
 	}


### PR DESCRIPTION
When running a "once" action on regbot and regsync without defining parallel or defining it to a value of 0 or less, run steps in order without any concurrency.

This also adjusts some error handling on regsync when one bad image is encountered, continuing to the process the remaining images.

Signed-off-by: Brandon Mitchell <git@bmitch.net>