### PR TITLE
Supporting OCI distribution-spec

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -687,7 +687,7 @@ func (b *BearerHandler) scopeExists(search string) bool {
 }
 
 func (b *BearerHandler) validateResponse(resp *http.Response) error {
-	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
+	if resp.StatusCode != 200 {
 		return ErrUnauthorized
 	}
 
@@ -783,7 +783,7 @@ func (j *JWTHubHandler) ProcessChallenge(c Challenge) error {
 	defer resp.Body.Close()
 	body, _ := ioutil.ReadAll(resp.Body)
 
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+	if resp.StatusCode != 200 || resp.StatusCode >= 300 {
 		return ErrUnauthorized
 	}
 

--- a/pkg/retryable/retryable.go
+++ b/pkg/retryable/retryable.go
@@ -24,6 +24,7 @@ import (
 // Retryable is used to create requests with built in retry capabilities
 type Retryable interface {
 	DoRequest(ctx context.Context, method string, u []url.URL, opts ...OptsReq) (Response, error)
+	BackoffClear()
 	BackoffUntil() time.Time
 }
 
@@ -200,7 +201,7 @@ func WithUserAgent(ua string) Opts {
 	}
 }
 
-func (r *retryable) backoffClear() {
+func (r *retryable) BackoffClear() {
 	if r.backoffCur > 0 {
 		r.backoffCur--
 		if r.backoffCur == 0 {
@@ -429,7 +430,7 @@ func (req *request) retryLoop() error {
 		switch {
 		case 200 <= statusCode && statusCode < 300:
 			// all 200 status codes are successful
-			req.r.backoffClear()
+			req.r.BackoffClear()
 			return nil
 		case statusCode == http.StatusUnauthorized:
 			err := req.handleAuth()

--- a/regclient/error.go
+++ b/regclient/error.go
@@ -17,6 +17,8 @@ var (
 	ErrMissingTag = errors.New("Tag missing from image reference")
 	// ErrMissingTagOrDigest returned when image reference does not include a tag or digest
 	ErrMissingTagOrDigest = errors.New("Tag or Digest missing from image reference")
+	// ErrMountReturnedLocation when a blob mount fails but a location header is received
+	ErrMountReturnedLocation = errors.New("Blob mount returned a location to upload")
 	// ErrNotFound isn't there, search for your value elsewhere
 	ErrNotFound = errors.New("Not found")
 	// ErrNotImplemented returned when method has not been implemented yet

--- a/regclient/error.go
+++ b/regclient/error.go
@@ -11,6 +11,8 @@ var (
 	ErrHttpStatus = errors.New("Unexpected http status code")
 	// ErrMissingDigest returned when image reference does not include a digest
 	ErrMissingDigest = errors.New("Digest missing from image reference")
+	// ErrMissingLocation returned when the location header is missing
+	ErrMissingLocation = errors.New("Location header missing")
 	// ErrMissingName returned when name missing for host
 	ErrMissingName = errors.New("Name missing")
 	// ErrMissingTag returned when image reference does not include a tag

--- a/regclient/manifest.go
+++ b/regclient/manifest.go
@@ -207,7 +207,7 @@ func (rc *regClient) ManifestPut(ctx context.Context, ref types.Ref, m manifest.
 		return fmt.Errorf("Failed to put manifest %s: %w", ref.CommonName(), err)
 	}
 	defer resp.Close()
-	if resp.HTTPResponse().StatusCode < 200 || resp.HTTPResponse().StatusCode > 299 {
+	if resp.HTTPResponse().StatusCode != 201 {
 		return fmt.Errorf("Failed to put manifest %s: %w", ref.CommonName(), httpError(resp.HTTPResponse().StatusCode))
 	}
 


### PR DESCRIPTION
This updates various APIs to restrict the expected HTTP status code, adds the tag delete API, and falls back to other methods when possible.