### PR TITLE
Fix error handling with regclt on buildkit cache

### DIFF
--- a/cmd/regctl/manifest.go
+++ b/cmd/regctl/manifest.go
@@ -112,6 +112,9 @@ func getManifest(rc regclient.RegClient, ref types.Ref) (manifest.Manifest, erro
 	// retrieve the specified platform from the manifest list
 	if m.IsList() && !manifestOpts.list && !manifestOpts.requireList {
 		desc, err := getPlatformDesc(rc, m)
+		if err != nil {
+			return m, fmt.Errorf("Failed to lookup platform specific digest: %w", err)
+		}
 		ref.Digest = desc.Digest.String()
 		m, err = rc.ManifestGet(context.Background(), ref)
 		if err != nil {

--- a/regclient/manifest/manifest.go
+++ b/regclient/manifest/manifest.go
@@ -196,17 +196,19 @@ func fromCommon(mc common) (Manifest, error) {
 func getPlatformDesc(p *ociv1.Platform, dl []ociv1.Descriptor) (*ociv1.Descriptor, error) {
 	platformCmp := platforms.NewMatcher(*p)
 	for _, d := range dl {
-		if platformCmp.Match(*d.Platform) {
+		if d.Platform != nil && platformCmp.Match(*d.Platform) {
 			return &d, nil
 		}
 	}
-	return nil, wraperr.New(fmt.Errorf("Platform not found: %v", p), ErrNotFound)
+	return nil, wraperr.New(fmt.Errorf("Platform not found: %s", platforms.Format(*p)), ErrNotFound)
 }
 
 func getPlatformList(dl []ociv1.Descriptor) ([]*ociv1.Platform, error) {
 	var l []*ociv1.Platform
 	for _, d := range dl {
-		l = append(l, d.Platform)
+		if d.Platform != nil {
+			l = append(l, d.Platform)
+		}
 	}
 	return l, nil
 }


### PR DESCRIPTION
Buildkit cache manifests don't have a platform, which was breaking `regctl manifest get`.

Signed-off-by: Brandon Mitchell <git@bmitch.net>