### PR TITLE
Add blob size limits to commands

### DIFF
--- a/cmd/regbot/config.go
+++ b/cmd/regbot/config.go
@@ -25,7 +25,7 @@ type ConfigCreds struct {
 	Hostname   string            `yaml:"hostname" json:"hostname"`
 	User       string            `yaml:"user" json:"user"`
 	Pass       string            `yaml:"pass" json:"pass"`
-	Token      string            `json:"token,omitempty"`
+	Token      string            `yaml:"token" json:"token"`
 	TLS        regclient.TLSConf `yaml:"tls" json:"tls"`
 	Scheme     string            `yaml:"scheme" json:"scheme"` // TODO: delete
 	RegCert    string            `yaml:"regcert" json:"regcert"`
@@ -33,6 +33,26 @@ type ConfigCreds struct {
 	Mirrors    []string          `yaml:"mirrors" json:"mirrors"`
 	Priority   uint              `yaml:"priority" json:"priority"`
 	API        string            `yaml:"api" json:"api"`
+	BlobChunk  int64             `yaml:"blobChunk" json:"blobChunk"`
+	BlobMax    int64             `yaml:"blobMax" json:"blobMax"`
+}
+
+func credsToRCHost(c ConfigCreds) regclient.ConfigHost {
+	return regclient.ConfigHost{
+		Name:       c.Registry,
+		Hostname:   c.Hostname,
+		User:       c.User,
+		Pass:       c.Pass,
+		Token:      c.Token,
+		TLS:        c.TLS,
+		RegCert:    c.RegCert,
+		PathPrefix: c.PathPrefix,
+		Mirrors:    c.Mirrors,
+		Priority:   c.Priority,
+		API:        c.API,
+		BlobChunk:  c.BlobChunk,
+		BlobMax:    c.BlobMax,
+	}
 }
 
 // ConfigDefaults is uses for general options and defaults for ConfigScript entries

--- a/cmd/regbot/root.go
+++ b/cmd/regbot/root.go
@@ -266,19 +266,7 @@ func loadConf() error {
 				"name": host.Registry,
 			}).Warn("Scheme is deprecated, for http set TLS to disabled")
 		}
-		rcHosts = append(rcHosts, regclient.ConfigHost{
-			Name:       host.Registry,
-			Hostname:   host.Hostname,
-			User:       host.User,
-			Pass:       host.Pass,
-			Token:      host.Token,
-			TLS:        host.TLS,
-			RegCert:    host.RegCert,
-			PathPrefix: host.PathPrefix,
-			Mirrors:    host.Mirrors,
-			Priority:   host.Priority,
-			API:        host.API,
-		})
+		rcHosts = append(rcHosts, credsToRCHost(host))
 	}
 	if len(rcHosts) > 0 {
 		rcOpts = append(rcOpts, regclient.WithConfigHosts(rcHosts))

--- a/cmd/regctl/config.go
+++ b/cmd/regctl/config.go
@@ -45,6 +45,8 @@ type ConfigHost struct {
 	Mirrors    []string          `json:"mirrors,omitempty"`    // list of other ConfigHost Names to use as mirrors
 	Priority   uint              `json:"priority,omitempty"`   // priority when sorting mirrors, higher priority attempted first
 	API        string            `json:"api,omitempty"`        // registry API to use
+	BlobChunk  int64             `json:"blobChunk,omitempty"`  // size of each blob chunk
+	BlobMax    int64             `json:"blobMax,omitempty"`    // threshold to switch to chunked upload, -1 to disable
 }
 
 // ConfigHostNew creates a default ConfigHost entry

--- a/cmd/regctl/registry.go
+++ b/cmd/regctl/registry.go
@@ -59,6 +59,7 @@ var registryOpts struct {
 	cacert, tls          string // set opts
 	mirrors              []string
 	priority             uint
+	blobChunk, blobMax   int64
 	scheme               string   // TODO: remove
 	dns                  []string // TODO: remove
 }
@@ -75,6 +76,8 @@ func init() {
 	registrySetCmd.Flags().StringVarP(&registryOpts.pathPrefix, "path-prefix", "", "", "Prefix to all repositories")
 	registrySetCmd.Flags().StringArrayVarP(&registryOpts.mirrors, "mirror", "", nil, "List of mirrors (registry names)")
 	registrySetCmd.Flags().UintVarP(&registryOpts.priority, "priority", "", 0, "Priority (for sorting mirrors)")
+	registrySetCmd.Flags().Int64VarP(&registryOpts.blobChunk, "blob-chunk", "", 0, "Blob chunk size")
+	registrySetCmd.Flags().Int64VarP(&registryOpts.blobMax, "blob-max", "", 0, "Blob size before switching to chunked push, -1 to disable")
 	registrySetCmd.RegisterFlagCompletionFunc("cacert", completeArgNone)
 	registrySetCmd.RegisterFlagCompletionFunc("tls", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{
@@ -87,6 +90,8 @@ func init() {
 	registrySetCmd.RegisterFlagCompletionFunc("path-prefix", completeArgNone)
 	registrySetCmd.RegisterFlagCompletionFunc("mirror", completeArgNone)
 	registrySetCmd.RegisterFlagCompletionFunc("priority", completeArgNone)
+	registrySetCmd.RegisterFlagCompletionFunc("blob-chunk", completeArgNone)
+	registrySetCmd.RegisterFlagCompletionFunc("blob-max", completeArgNone)
 
 	// TODO: eventually remove
 	registrySetCmd.Flags().StringVarP(&registryOpts.scheme, "scheme", "", "", "[Deprecated] Scheme (http, https)")
@@ -295,6 +300,12 @@ func runRegistrySet(cmd *cobra.Command, args []string) error {
 	}
 	if registryOpts.priority != 0 {
 		h.Priority = registryOpts.priority
+	}
+	if registryOpts.blobChunk != 0 {
+		h.BlobChunk = registryOpts.blobChunk
+	}
+	if registryOpts.blobMax != 0 {
+		h.BlobMax = registryOpts.blobMax
 	}
 
 	err = c.ConfigSave()

--- a/cmd/regctl/root.go
+++ b/cmd/regctl/root.go
@@ -126,6 +126,8 @@ func newRegClient() regclient.RegClient {
 			Mirrors:    host.Mirrors,
 			Priority:   host.Priority,
 			API:        host.API,
+			BlobChunk:  host.BlobChunk,
+			BlobMax:    host.BlobMax,
 		})
 	}
 	if len(rcHosts) > 0 {

--- a/cmd/regsync/config.go
+++ b/cmd/regsync/config.go
@@ -38,7 +38,7 @@ type ConfigCreds struct {
 	Hostname   string            `yaml:"hostname" json:"hostname"`
 	User       string            `yaml:"user" json:"user"`
 	Pass       string            `yaml:"pass" json:"pass"`
-	Token      string            `json:"token,omitempty"`
+	Token      string            `yaml:"token" json:"token"`
 	TLS        regclient.TLSConf `yaml:"tls" json:"tls"`
 	Scheme     string            `yaml:"scheme" json:"scheme"` // TODO: eventually delete
 	RegCert    string            `yaml:"regcert" json:"regcert"`
@@ -46,6 +46,26 @@ type ConfigCreds struct {
 	Mirrors    []string          `yaml:"mirrors" json:"mirrors"`
 	Priority   uint              `yaml:"priority" json:"priority"`
 	API        string            `yaml:"api" json:"api"`
+	BlobChunk  int64             `yaml:"blobChunk" json:"blobChunk"`
+	BlobMax    int64             `yaml:"blobMax" json:"blobMax"`
+}
+
+func credsToRCHost(c ConfigCreds) regclient.ConfigHost {
+	return regclient.ConfigHost{
+		Name:       c.Registry,
+		Hostname:   c.Hostname,
+		User:       c.User,
+		Pass:       c.Pass,
+		Token:      c.Token,
+		TLS:        c.TLS,
+		RegCert:    c.RegCert,
+		PathPrefix: c.PathPrefix,
+		Mirrors:    c.Mirrors,
+		Priority:   c.Priority,
+		API:        c.API,
+		BlobChunk:  c.BlobChunk,
+		BlobMax:    c.BlobMax,
+	}
 }
 
 // ConfigDefaults is uses for general options and defaults for ConfigSync entries

--- a/cmd/regsync/root.go
+++ b/cmd/regsync/root.go
@@ -312,19 +312,7 @@ func loadConf() error {
 				"name": host.Registry,
 			}).Warn("Scheme is deprecated, for http set TLS to disabled")
 		}
-		rcHosts = append(rcHosts, regclient.ConfigHost{
-			Name:       host.Registry,
-			Hostname:   host.Hostname,
-			User:       host.User,
-			Pass:       host.Pass,
-			Token:      host.Token,
-			TLS:        host.TLS,
-			RegCert:    host.RegCert,
-			PathPrefix: host.PathPrefix,
-			Mirrors:    host.Mirrors,
-			Priority:   host.Priority,
-			API:        host.API,
-		})
+		rcHosts = append(rcHosts, credsToRCHost(host))
 	}
 	if len(rcHosts) > 0 {
 		rcOpts = append(rcOpts, regclient.WithConfigHosts(rcHosts))

--- a/docs/regbot.md
+++ b/docs/regbot.md
@@ -118,6 +118,14 @@ scripts:
   - `priority`:
     Non-negative integer priority used for sorting mirrors.
     This defaults to 0.
+  - `blobChunk`:
+    Chunk size for pushing blobs.
+    Each chunk is a separate http request, incurring network overhead.
+    The entire chunk is stored in memory, so chunks should be small enough not to exhaust RAM.
+  - `blobMax`:
+    Blob size which skips the single put request in favor of the chunked upload.
+    Note that a failed blob put will fall back to a chunked upload in most cases.
+    Disable with -1 to always try a single put regardless of blob size.
 
 - `defaults`:
   Global settings and default values applied to each sync entry:

--- a/docs/regsync.md
+++ b/docs/regsync.md
@@ -128,6 +128,14 @@ sync:
   - `priority`:
     Non-negative integer priority used for sorting mirrors.
     This defaults to 0.
+  - `blobChunk`:
+    Chunk size for pushing blobs.
+    Each chunk is a separate http request, incurring network overhead.
+    The entire chunk is stored in memory, so chunks should be small enough not to exhaust RAM.
+  - `blobMax`:
+    Blob size which skips the single put request in favor of the chunked upload.
+    Note that a failed blob put will fall back to a chunked upload in most cases.
+    Disable with -1 to always try a single put regardless of blob size.
 
 - `defaults`:
   Global settings and default values applied to each sync entry:

--- a/regclient/blob_test.go
+++ b/regclient/blob_test.go
@@ -471,9 +471,12 @@ func TestBlobPut(t *testing.T) {
 	tsHost := tsURL.Host
 	rcHosts := []ConfigHost{
 		{
-			Name:     tsHost,
-			Hostname: tsHost,
-			TLS:      TLSDisabled,
+			Name:      tsHost,
+			Hostname:  tsHost,
+			TLS:       TLSDisabled,
+			BlobChunk: int64(blobChunk),
+			// BlobMax:   int64(blobLen * 10),
+			BlobMax: int64(-1),
 		},
 	}
 	log := &logrus.Logger{
@@ -487,7 +490,7 @@ func TestBlobPut(t *testing.T) {
 	rc := NewRegClient(
 		WithConfigHosts(rcHosts),
 		WithLog(log),
-		WithBlobSize(int64(blobChunk), int64(blobLen*10)),
+		// WithBlobSize(int64(blobChunk), int64(blobLen*10)),
 		WithRetryDelay(delayInit, delayMax),
 	)
 

--- a/regclient/config.go
+++ b/regclient/config.go
@@ -90,6 +90,8 @@ type ConfigHost struct {
 	Mirrors    []string `json:"mirrors,omitempty"`    // list of other ConfigHost Names to use as mirrors
 	Priority   uint     `json:"priority,omitempty"`   // priority when sorting mirrors, higher priority attempted first
 	API        string   `json:"api,omitempty"`        // registry API to use
+	BlobChunk  int64    `json:"blobChunk,omitempty"`  // size of each blob chunk
+	BlobMax    int64    `json:"blobMax,omitempty"`    // threshold to switch to chunked upload, -1 to disable, 0 for regclient.blobMaxPut
 }
 
 // ConfigHostNew creates a default ConfigHost entry
@@ -245,6 +247,28 @@ func (rc *regClient) mergeConfigHost(curHost, newHost ConfigHost, warn bool) Con
 			}).Warn("Changing API settings for registry")
 		}
 		curHost.API = newHost.API
+	}
+
+	if newHost.BlobChunk > 0 {
+		if warn && curHost.BlobChunk != 0 && curHost.BlobChunk != newHost.BlobChunk {
+			rc.log.WithFields(logrus.Fields{
+				"orig": curHost.BlobChunk,
+				"new":  newHost.BlobChunk,
+				"host": name,
+			}).Warn("Changing blobChunk settings for registry")
+		}
+		curHost.BlobChunk = newHost.BlobChunk
+	}
+
+	if newHost.BlobMax != 0 {
+		if warn && curHost.BlobMax != 0 && curHost.BlobMax != newHost.BlobMax {
+			rc.log.WithFields(logrus.Fields{
+				"orig": curHost.BlobMax,
+				"new":  newHost.BlobMax,
+				"host": name,
+			}).Warn("Changing blobMax settings for registry")
+		}
+		curHost.BlobMax = newHost.BlobMax
 	}
 
 	return curHost

--- a/regclient/regclient.go
+++ b/regclient/regclient.go
@@ -24,6 +24,10 @@ import (
 )
 
 const (
+	// DefaultBlobChunk 1M chunks, this is allocated in a memory buffer
+	DefaultBlobChunk = 1024 * 1024
+	// DefaultBlobMax 100M, switch to chunked above this threshold to avoid timeouts
+	DefaultBlobMax = 100 * 1024 * 1024
 	// DefaultRetryLimit sets how many retry attempts are made for non-fatal errors
 	DefaultRetryLimit = 3
 	// DefaultUserAgent sets the header on http requests
@@ -104,8 +108,8 @@ func NewRegClient(opts ...Opt) RegClient {
 		hosts:         map[string]*regClientHost{},
 		retryLimit:    DefaultRetryLimit,
 		userAgent:     DefaultUserAgent,
-		blobChunkSize: 1024 * 1024,       // 1M chunks, this is allocated in a memory buffer
-		blobMaxPut:    100 * 1024 * 1024, // 100M, switch to chunked above this threshold to avoid timeouts
+		blobChunkSize: DefaultBlobChunk,
+		blobMaxPut:    DefaultBlobMax,
 		// logging is disabled by default
 		log: &logrus.Logger{Out: ioutil.Discard},
 	}
@@ -181,6 +185,8 @@ func WithConfigHosts(configHosts []ConfigHost) Opt {
 				"pathPrefix": configHost.PathPrefix,
 				"mirrors":    configHost.Mirrors,
 				"api":        configHost.API,
+				"blobMax":    configHost.BlobMax,
+				"blobChunk":  configHost.BlobChunk,
 			}).Debug("Loading host config")
 			err := rc.hostSet(configHost)
 			if err != nil {


### PR DESCRIPTION
This adds the ability to configure chunk sizes per registry, and the ability to disable the automatic chunking of large blobs. Set the blob max to `-1` to disable. By default, pushing a blob over 100MB will switch to sending as 1MB chunks.

In regctl, `regctl registry set` has options for `--blob-chunk` and `--blob-max`.

In regsync and regbot, the creds section for each registry supports the `blobMax` and `blobChunk` options.

Signed-off-by: Brandon Mitchell <git@bmitch.net>