### PR TITLE
Cache credential helpers in build

### DIFF
--- a/build/Dockerfile.regbot
+++ b/build/Dockerfile.regbot
@@ -2,7 +2,7 @@ ARG REGISTRY=docker.io
 ARG ALPINE_VER=3
 ARG GO_VER=1.14-alpine
 
-FROM ${REGISTRY}/library/golang:${GO_VER} as dev
+FROM ${REGISTRY}/library/golang:${GO_VER} as golang
 RUN apk add --no-cache \
       ca-certificates \
       git \
@@ -11,6 +11,8 @@ RUN adduser -D appuser \
  && mkdir -p /home/appuser/.docker \
  && chown -R appuser /home/appuser
 WORKDIR /src
+
+FROM golang as dev
 COPY . /src/
 ENV PATH=${PATH}:/src/bin
 CMD make bin/regbot && bin/regbot
@@ -20,14 +22,14 @@ RUN make bin/regbot
 USER appuser
 CMD [ "/src/bin/regbot" ]
 
-FROM dev as docker-cred-ecr-login
+FROM golang as docker-cred-ecr-login
 ARG TARGETOS
 ARG TARGETARCH
 RUN go get -u github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login \
  && ( cp "${GOPATH}/bin/docker-credential-ecr-login" /usr/local/bin/docker-credential-ecr-login \
    || cp "${GOPATH}/bin/${TARGETOS}_${TARGETARCH}/docker-credential-ecr-login" /usr/local/bin/docker-credential-ecr-login )
 
-FROM dev as docker-cred-gcr
+FROM golang as docker-cred-gcr
 ARG TARGETOS
 ARG TARGETARCH
 RUN go get -u github.com/GoogleCloudPlatform/docker-credential-gcr \

--- a/build/Dockerfile.regbot.buildkit
+++ b/build/Dockerfile.regbot.buildkit
@@ -4,7 +4,7 @@ ARG REGISTRY=docker.io
 ARG ALPINE_VER=3
 ARG GO_VER=1.14-alpine
 
-FROM --platform=$BUILDPLATFORM ${REGISTRY}/library/golang:${GO_VER} as dev
+FROM --platform=$BUILDPLATFORM ${REGISTRY}/library/golang:${GO_VER} as golang
 RUN apk add --no-cache \
       ca-certificates \
       git \
@@ -13,6 +13,8 @@ RUN adduser -D appuser \
  && mkdir -p /home/appuser/.docker \
  && chown -R appuser /home/appuser
 WORKDIR /src
+
+FROM --platform=$BUILDPLATFORM golang as dev
 COPY . /src/
 ENV PATH=${PATH}:/src/bin
 CMD make bin/regbot && bin/regbot
@@ -30,7 +32,7 @@ CMD [ "bin/regbot" ]
 FROM scratch as artifact
 COPY --from=build /src/bin/regbot /regbot
 
-FROM --platform=$BUILDPLATFORM dev as docker-cred-ecr-login
+FROM --platform=$BUILDPLATFORM golang as docker-cred-ecr-login
 ARG TARGETOS
 ARG TARGETARCH
 RUN --mount=type=cache,id=gomod,target=/go/pkg/mod/cache \
@@ -40,7 +42,7 @@ RUN --mount=type=cache,id=gomod,target=/go/pkg/mod/cache \
  && ( cp "${GOPATH}/bin/docker-credential-ecr-login" /usr/local/bin/docker-credential-ecr-login \
    || cp "${GOPATH}/bin/${TARGETOS}_${TARGETARCH}/docker-credential-ecr-login" /usr/local/bin/docker-credential-ecr-login )
 
-FROM --platform=$BUILDPLATFORM dev as docker-cred-gcr
+FROM --platform=$BUILDPLATFORM golang as docker-cred-gcr
 ARG TARGETOS
 ARG TARGETARCH
 RUN --mount=type=cache,id=gomod,target=/go/pkg/mod/cache \

--- a/build/Dockerfile.regctl
+++ b/build/Dockerfile.regctl
@@ -2,7 +2,7 @@ ARG REGISTRY=docker.io
 ARG ALPINE_VER=3
 ARG GO_VER=1.14-alpine
 
-FROM ${REGISTRY}/library/golang:${GO_VER} as dev
+FROM ${REGISTRY}/library/golang:${GO_VER} as golang
 RUN apk add --no-cache \
       ca-certificates \
       git \
@@ -11,6 +11,8 @@ RUN adduser -D appuser \
  && mkdir -p /home/appuser/.regctl \
  && chown -R appuser /home/appuser/.regctl
 WORKDIR /src
+
+FROM golang as dev
 COPY . /src/
 ENV PATH=${PATH}:/src/bin
 CMD make bin/regctl && bin/regctl
@@ -20,14 +22,14 @@ RUN make bin/regctl
 USER appuser
 CMD [ "bin/regctl" ]
 
-FROM dev as docker-cred-ecr-login
+FROM golang as docker-cred-ecr-login
 ARG TARGETOS
 ARG TARGETARCH
 RUN go get -u github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login \
  && ( cp "${GOPATH}/bin/docker-credential-ecr-login" /usr/local/bin/docker-credential-ecr-login \
    || cp "${GOPATH}/bin/${TARGETOS}_${TARGETARCH}/docker-credential-ecr-login" /usr/local/bin/docker-credential-ecr-login )
 
-FROM dev as docker-cred-gcr
+FROM golang as docker-cred-gcr
 ARG TARGETOS
 ARG TARGETARCH
 RUN go get -u github.com/GoogleCloudPlatform/docker-credential-gcr \

--- a/build/Dockerfile.regctl.buildkit
+++ b/build/Dockerfile.regctl.buildkit
@@ -4,7 +4,7 @@ ARG REGISTRY=docker.io
 ARG ALPINE_VER=3
 ARG GO_VER=1.14-alpine
 
-FROM --platform=$BUILDPLATFORM ${REGISTRY}/library/golang:${GO_VER} as dev
+FROM --platform=$BUILDPLATFORM ${REGISTRY}/library/golang:${GO_VER} as golang
 RUN apk add --no-cache \
       ca-certificates \
       git \
@@ -13,6 +13,8 @@ RUN adduser -D appuser \
  && mkdir -p /home/appuser/.regctl \
  && chown -R appuser /home/appuser/.regctl
 WORKDIR /src
+
+FROM --platform=$BUILDPLATFORM golang as dev
 COPY . /src/
 ENV PATH=${PATH}:/src/bin
 CMD make bin/regctl && bin/regctl
@@ -30,7 +32,7 @@ CMD [ "bin/regctl" ]
 FROM scratch as artifact
 COPY --from=build /src/bin/regctl /regctl
 
-FROM --platform=$BUILDPLATFORM dev as docker-cred-ecr-login
+FROM --platform=$BUILDPLATFORM golang as docker-cred-ecr-login
 ARG TARGETOS
 ARG TARGETARCH
 RUN --mount=type=cache,id=gomod,target=/go/pkg/mod/cache \
@@ -40,7 +42,7 @@ RUN --mount=type=cache,id=gomod,target=/go/pkg/mod/cache \
  && ( cp "${GOPATH}/bin/docker-credential-ecr-login" /usr/local/bin/docker-credential-ecr-login \
    || cp "${GOPATH}/bin/${TARGETOS}_${TARGETARCH}/docker-credential-ecr-login" /usr/local/bin/docker-credential-ecr-login )
 
-FROM --platform=$BUILDPLATFORM dev as docker-cred-gcr
+FROM --platform=$BUILDPLATFORM golang as docker-cred-gcr
 ARG TARGETOS
 ARG TARGETARCH
 RUN --mount=type=cache,id=gomod,target=/go/pkg/mod/cache \

--- a/build/Dockerfile.regsync
+++ b/build/Dockerfile.regsync
@@ -2,7 +2,7 @@ ARG REGISTRY=docker.io
 ARG ALPINE_VER=3
 ARG GO_VER=1.14-alpine
 
-FROM ${REGISTRY}/library/golang:${GO_VER} as dev
+FROM ${REGISTRY}/library/golang:${GO_VER} as golang
 RUN apk add --no-cache \
       ca-certificates \
       git \
@@ -11,6 +11,8 @@ RUN adduser -D appuser \
  && mkdir -p /home/appuser/.docker \
  && chown -R appuser /home/appuser
 WORKDIR /src
+
+FROM golang as dev
 COPY . /src/
 ENV PATH=${PATH}:/src/bin
 CMD make bin/regsync && bin/regsync
@@ -21,14 +23,14 @@ RUN make bin/regsync
 USER appuser
 CMD [ "bin/regsync" ]
 
-FROM dev as docker-cred-ecr-login
+FROM golang as docker-cred-ecr-login
 ARG TARGETOS
 ARG TARGETARCH
 RUN go get -u github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login \
  && ( cp "${GOPATH}/bin/docker-credential-ecr-login" /usr/local/bin/docker-credential-ecr-login \
    || cp "${GOPATH}/bin/${TARGETOS}_${TARGETARCH}/docker-credential-ecr-login" /usr/local/bin/docker-credential-ecr-login )
 
-FROM dev as docker-cred-gcr
+FROM golang as docker-cred-gcr
 ARG TARGETOS
 ARG TARGETARCH
 RUN go get -u github.com/GoogleCloudPlatform/docker-credential-gcr \

--- a/build/Dockerfile.regsync.buildkit
+++ b/build/Dockerfile.regsync.buildkit
@@ -4,7 +4,7 @@ ARG REGISTRY=docker.io
 ARG ALPINE_VER=3
 ARG GO_VER=1.14-alpine
 
-FROM --platform=$BUILDPLATFORM ${REGISTRY}/library/golang:${GO_VER} as dev
+FROM --platform=$BUILDPLATFORM ${REGISTRY}/library/golang:${GO_VER} as golang
 RUN apk add --no-cache \
       ca-certificates \
       git \
@@ -13,6 +13,8 @@ RUN adduser -D appuser \
  && mkdir -p /home/appuser/.docker \
  && chown -R appuser /home/appuser
 WORKDIR /src
+
+FROM --platform=$BUILDPLATFORM golang as dev
 COPY . /src/
 ENV PATH=${PATH}:/src/bin
 CMD make bin/regsync && bin/regsync
@@ -30,7 +32,7 @@ CMD [ "bin/regsync" ]
 FROM scratch as artifact
 COPY --from=build /src/bin/regsync /regsync
 
-FROM --platform=$BUILDPLATFORM dev as docker-cred-ecr-login
+FROM --platform=$BUILDPLATFORM golang as docker-cred-ecr-login
 ARG TARGETOS
 ARG TARGETARCH
 RUN --mount=type=cache,id=gomod,target=/go/pkg/mod/cache \
@@ -40,7 +42,7 @@ RUN --mount=type=cache,id=gomod,target=/go/pkg/mod/cache \
  && ( cp "${GOPATH}/bin/docker-credential-ecr-login" /usr/local/bin/docker-credential-ecr-login \
    || cp "${GOPATH}/bin/${TARGETOS}_${TARGETARCH}/docker-credential-ecr-login" /usr/local/bin/docker-credential-ecr-login )
 
-FROM --platform=$BUILDPLATFORM dev as docker-cred-gcr
+FROM --platform=$BUILDPLATFORM golang as docker-cred-gcr
 ARG TARGETOS
 ARG TARGETARCH
 RUN --mount=type=cache,id=gomod,target=/go/pkg/mod/cache \


### PR DESCRIPTION
Cache for the helper builds were being broken by changes to the regclient source. This splits the setup of a golang builder target from the regclient dev target.

Signed-off-by: Brandon Mitchell <git@bmitch.net>