### PR TITLE
Updating docs and adding artifact strip-dirs flag

### DIFF
--- a/cmd/regctl/blob.go
+++ b/cmd/regctl/blob.go
@@ -31,7 +31,7 @@ registry. The blob or layer digest can be found in the image manifest.`,
 }
 var blobPutCmd = &cobra.Command{
 	Use:     "put <repository>",
-	Aliases: []string{"put", "push"},
+	Aliases: []string{"push"},
 	Short:   "upload a blob/layer",
 	Long: `Upload a blob to a repository. Stdin must be the blob contents. The output
 is the digest of the blob.`,

--- a/cmd/regctl/manifest.go
+++ b/cmd/regctl/manifest.go
@@ -56,7 +56,7 @@ var manifestGetCmd = &cobra.Command{
 
 var manifestPutCmd = &cobra.Command{
 	Use:               "put <image_ref>",
-	Aliases:           []string{"put", "push"},
+	Aliases:           []string{"push"},
 	Short:             "push manifest or manifest list",
 	Long:              `Pushes a manifest or manifest list to a repository.`,
 	Args:              cobra.ExactArgs(1),


### PR DESCRIPTION
The `regctl artifact get --strip-dirs` flag is useful for pulling ORAS tar artifacts that include the directory name in both the filename and inside the tar. This removes on layer of repetitiveness. Cobra commands were updated to remove redundant `put` aliases. And docs are also updated to add `regctl blob pub` and `regctl artifact`.

Signed-off-by: Brandon Mitchell <git@bmitch.net>