### PR TITLE
Only warn on regsync backup errors

### DIFF
--- a/cmd/regsync/root.go
+++ b/cmd/regsync/root.go
@@ -680,13 +680,13 @@ func (s ConfigSync) processRef(ctx context.Context, src, tgt types.Ref, action s
 		}).Info("Saving backup")
 		err = rc.ImageCopy(ctx, tgt, backupRef)
 		if err != nil {
+			// Possible registry corruption with existing image, only warn and continue/overwrite
 			log.WithFields(logrus.Fields{
 				"original": tgt.CommonName(),
 				"template": s.Backup,
 				"backup":   backupRef.CommonName(),
 				"error":    err,
-			}).Error("Failed to backup existing image")
-			return err
+			}).Warn("Failed to backup existing image")
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

### Fixes issue

n/a

### Describe the change

Bug fix: if a registry gets a corrupt image, due to a nested blob or manifest being deleted, the backup would fail and stop the image sync. This ignores those errors allowing the sync to recover from a broken image.

### How to verify it

On an image being synced, delete a nested manifest or blob and verify the sync only outputs a warning rather than a blocking error.

### Changelog text

Regsync no longer blocks on a failing backup

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [ ] Tests have been added
- [ ] Documentation has been added or updated
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
