### PR TITLE
Adding options to image copy

### DIFF
--- a/cmd/regctl/config_unix.go
+++ b/cmd/regctl/config_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package main

--- a/cmd/regctl/config_windows.go
+++ b/cmd/regctl/config_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package main

--- a/cmd/regsync/config.go
+++ b/cmd/regsync/config.go
@@ -75,6 +75,8 @@ type ConfigDefaults struct {
 	Schedule       string          `yaml:"schedule" json:"schedule"`
 	RateLimit      ConfigRateLimit `yaml:"ratelimit" json:"ratelimit"`
 	Parallel       int             `yaml:"parallel" json:"parallel"`
+	DigestTags     *bool           `yaml:"digestTags" json:"digestTags"`
+	ForceRecursive *bool           `yaml:"forceRecursive" json:"forceRecursive"`
 	MediaTypes     []string        `yaml:"mediaTypes" json:"mediaTypes"`
 	SkipDockerConf bool            `yaml:"skipDockerConfig" json:"skipDockerConfig"`
 	Hooks          ConfigHooks     `yaml:"hooks" json:"hooks"`
@@ -88,17 +90,20 @@ type ConfigRateLimit struct {
 
 // ConfigSync defines a source/target repository to sync
 type ConfigSync struct {
-	Source     string          `yaml:"source" json:"source"`
-	Target     string          `yaml:"target" json:"target"`
-	Type       string          `yaml:"type" json:"type"`
-	Tags       ConfigTags      `yaml:"tags" json:"tags"`
-	Platform   string          `yaml:"platform" json:"platform"`
-	Backup     string          `yaml:"backup" json:"backup"`
-	Interval   time.Duration   `yaml:"interval" json:"interval"`
-	Schedule   string          `yaml:"schedule" json:"schedule"`
-	RateLimit  ConfigRateLimit `yaml:"ratelimit" json:"ratelimit"`
-	MediaTypes []string        `yaml:"mediaTypes" json:"mediaTypes"`
-	Hooks      ConfigHooks     `yaml:"hooks" json:"hooks"`
+	Source         string          `yaml:"source" json:"source"`
+	Target         string          `yaml:"target" json:"target"`
+	Type           string          `yaml:"type" json:"type"`
+	Tags           ConfigTags      `yaml:"tags" json:"tags"`
+	DigestTags     *bool           `yaml:"digestTags" json:"digestTags"`
+	Platform       string          `yaml:"platform" json:"platform"`
+	Platforms      []string        `yaml:"platforms" json:"platforms"`
+	ForceRecursive *bool           `yaml:"forceRecursive" json:"forceRecursive"`
+	Backup         string          `yaml:"backup" json:"backup"`
+	Interval       time.Duration   `yaml:"interval" json:"interval"`
+	Schedule       string          `yaml:"schedule" json:"schedule"`
+	RateLimit      ConfigRateLimit `yaml:"ratelimit" json:"ratelimit"`
+	MediaTypes     []string        `yaml:"mediaTypes" json:"mediaTypes"`
+	Hooks          ConfigHooks     `yaml:"hooks" json:"hooks"`
 }
 
 // ConfigTags is an allow and deny list of tag regex strings
@@ -236,6 +241,14 @@ func syncSetDefaults(s *ConfigSync, d ConfigDefaults) {
 		} else {
 			s.MediaTypes = defaultMediaTypes
 		}
+	}
+	if s.DigestTags == nil {
+		b := (d.DigestTags != nil && *d.DigestTags == true)
+		s.DigestTags = &b
+	}
+	if s.ForceRecursive == nil {
+		b := (d.ForceRecursive != nil && *d.ForceRecursive == true)
+		s.ForceRecursive = &b
 	}
 	if s.Hooks.Pre == nil && d.Hooks.Pre != nil {
 		s.Hooks.Pre = d.Hooks.Pre

--- a/docs/regbot.md
+++ b/docs/regbot.md
@@ -227,6 +227,9 @@ The following additional functions are available:
 - `image.copy <src-ref> <tgt-ref>`:
   Copies an image.
   This may be retagging within the same repository, copying between repositories, or copying between registries.
+  There's an optional 3rd argument with a table of options:
+  - `{digestTags = true}`: copies digest specific tags in addition to the manifests.
+  - `{forceRecursive = true}`: forces a copy of all manifests and blobs even when the target parent manifest already exists.
 - `image.exportTar <src-ref> <tar-filename>`:
   Exports an image from the registry to a tar file.
 - `image.importTar <tgt-ref> <tar-filename>`:

--- a/docs/regsync.md
+++ b/docs/regsync.md
@@ -160,6 +160,8 @@ sync:
     Number of concurrent image copies to run.
     All sync steps may be started concurrently to check if a mirror is needed, but will wait on this limit when a copy is needed.
     Defaults to 1.
+  - `digestTags`: (bool) copies digest specific tags in addition to the manifests.
+  - `forceRecursive`: (bool) forces a copy of all manifests and blobs even when the target parent manifest already exists.
   - `mediaTypes`:
     Array of media types to include.
     These must also be supported by regclient.
@@ -180,15 +182,15 @@ sync:
   - `tags`:
     Implements filters on tags for "registry" and "repository" types, regex values are automatically bound to the beginning and ending of each string (`^` and `$`).
     - `allow`:
-      Array of regex strings to allow specific tags.
+      (array of strings) regex to allow specific tags.
     - `deny`:
-      Array of regex strings to deny specific tags.
+      (array of strings) regex to deny specific tags.
   - `platform`:
     Single platform to pull from a multi-platform image, e.g. `linux/amd64`.
     By default all platforms are copied along with the original upstream manifest list.
     Note that looking up the platform from a multi-platform image counts against the Docker Hub rate limit, and that rate limits are not checked prior to resolving the platform.
     When run with "server", the platform is only resolved once for each multi-platform digest seen.
-  - `backup`, `interval`, `schedule`, `ratelimit`, and `mediaTypes`:
+  - `backup`, `interval`, `schedule`, `ratelimit`, `digestTags`, `forceRecursive`, and `mediaTypes`:
     See description under `defaults`.
 
 - `x-*`:


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

n/a
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This adds additional options to the image copy:

- Digest tags: Triggers an additional copy of the tag `sha256-<digest>.*` with every manifest copy. These tags are used with tools like cosign.
-  Force recursive: Runs the copy command recursively through manifests and blobs even if the parent manifest already exists at the target. This can be used to repair a broken registry (deleting child manifest or blobs without deleting the parent) or updating digest tags.
- Platforms: Sparsely copies a multi-platform image with only specific platforms copied. This is currently experimental and untested since it requires registry support to disable validation of manifests.
 
### How to verify it

```
regctl image copy --digest-tags --force-recursive gcr.io/projectsigstore/cosign:v1.4.1 localhost:5000/projectsigstore/cosign:v1.4.1 -v info
regctl image config --platform linux/s390x localhost:5000/projectsigstore/cosign:v1.4.1 -v info
regctl tag ls localhost:5000/projectsigstore/cosign

digest_s390=$(regctl manifest digest --platform linux/s390x localhost:5000/projectsigstore/cosign:v1.4.1)
digest_tag="$(regctl manifest digest --list localhost:5000/projectsigstore/cosign:v1.4.1 | sed 's/\:/\-/').sig"
regctl manifest rm "localhost:5000/projectsigstore/cosign@${digest_s390}"
regctl manifest rm "localhost:5000/projectsigstore/cosign:${digest_tag}" --force-tag-dereference
regctl image config --platform linux/s390x localhost:5000/projectsigstore/cosign:v1.4.1 -v info
regctl tag ls localhost:5000/projectsigstore/cosign

regctl image copy gcr.io/projectsigstore/cosign:v1.4.1 localhost:5000/projectsigstore/cosign:v1.4.1 -v info
regctl image config --platform linux/s390x localhost:5000/projectsigstore/cosign:v1.4.1 -v info
regctl tag ls localhost:5000/projectsigstore/cosign

regctl image copy --digest-tags --force-recursive gcr.io/projectsigstore/cosign:v1.4.1 localhost:5000/projectsigstore/cosign:v1.4.1 -v info
regctl image config --platform linux/s390x localhost:5000/projectsigstore/cosign:v1.4.1 -v info
regctl tag ls localhost:5000/projectsigstore/cosign
```

### Changelog text

- Image copy: support added for digest tags used by tools like projectsigstore/cosign
- Image copy: support added to force a recursive copy when manifest already exists at target

### Please verify and check that the pull request fulfills the following requirements

Note: end-to-end tests were performed locally, end-to-end testing with Go are still needed at a project level.

- [ ] Tests have been added
- [X] Documentation has been added or updated
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
