### PR TITLE
Fix handling of schema v1 manifests

### DIFF
--- a/regclient/manifest/manifest_test.go
+++ b/regclient/manifest/manifest_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"testing"
 
+	dockerSchema1 "github.com/docker/distribution/manifest/schema1"
 	dockerSchema2 "github.com/docker/distribution/manifest/schema2"
 	"github.com/opencontainers/go-digest"
 	ociv1 "github.com/opencontainers/image-spec/specs-go/v1"
@@ -235,6 +236,47 @@ var (
 			]
 		}
 	`)
+	// signed schemas are white space sensitive, contents here must be indented with 3 spaces, no tabs
+	rawDockerSchema1Signed = []byte(`
+{
+   "schemaVersion": 1,
+   "name": "library/debian",
+   "tag": "6",
+   "architecture": "amd64",
+   "fsLayers": [
+      {
+         "blobSum": "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4"
+      },
+      {
+         "blobSum": "sha256:069873d23334d65630bbe5e303ced0c68181b694c7f5506b54bf5d8115b5af20"
+      }
+   ],
+   "history": [
+      {
+         "v1Compatibility": "{\"id\":\"ff11dd0897b8ded12196819a787b5bd6d5bf886d9a7836c21b070efb5d9e77e4\",\"parent\":\"4e507d091336a8ec91e1b0fd0e33f11625d8bf3494765d3dbec37ec17387cbf5\",\"created\":\"2016-02-16T21:25:24.035599122Z\",\"container\":\"0fd99658f7a77c1170f8ff325c14437eaced7bab6b3152264cb1946d8d018e2e\",\"container_config\":{\"Hostname\":\"71f62d8ce24c\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":[\"/bin/sh\",\"-c\",\"#(nop) CMD [\\\"/bin/bash\\\"]\"],\"Image\":\"4e507d091336a8ec91e1b0fd0e33f11625d8bf3494765d3dbec37ec17387cbf5\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"OnBuild\":null,\"Labels\":{}},\"docker_version\":\"1.9.1\",\"config\":{\"Hostname\":\"71f62d8ce24c\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":[\"/bin/bash\"],\"Image\":\"4e507d091336a8ec91e1b0fd0e33f11625d8bf3494765d3dbec37ec17387cbf5\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"OnBuild\":null,\"Labels\":{}},\"architecture\":\"amd64\",\"os\":\"linux\"}"
+      },
+      {
+         "v1Compatibility": "{\"id\":\"4e507d091336a8ec91e1b0fd0e33f11625d8bf3494765d3dbec37ec17387cbf5\",\"created\":\"2016-02-16T21:25:21.747984969Z\",\"container\":\"71f62d8ce24cd81b2835a2a4457e9e745f775a225cb2e75a5e76fc8b5f44874c\",\"container_config\":{\"Hostname\":\"71f62d8ce24c\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":[\"/bin/sh\",\"-c\",\"#(nop) ADD file:09d717d62608e18d79af6b6cd5aae36f675bd5c4f34452ab1693b56bfbfe2520 in /\"],\"Image\":\"\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"OnBuild\":null,\"Labels\":null},\"docker_version\":\"1.9.1\",\"config\":{\"Hostname\":\"71f62d8ce24c\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":null,\"Image\":\"\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"OnBuild\":null,\"Labels\":null},\"architecture\":\"amd64\",\"os\":\"linux\",\"Size\":76534288}"
+      }
+   ],
+   "signatures": [
+      {
+         "header": {
+            "jwk": {
+               "crv": "P-256",
+               "kid": "FD6K:7VOX:ZVOM:34T7:2ZT5:753N:ZM4C:RJIF:WPOO:NPC2:7VPJ:3TVM",
+               "kty": "EC",
+               "x": "kHg6ZEbadXH4gC5ggkduHEAeJP40vdudo7tekiigA00",
+               "y": "K5r269kJQV1ERenXMuEQbY7_hrbxy1JnTnSOBR0bvTg"
+            },
+            "alg": "ES256"
+         },
+         "signature": "mtuG3ORjrX8o7lqyx78tX_JIX-JuiBAWX2sEvf60t4zXzLB61gNecwasp56Mn3LT7fxmJzC3-IcHW-UryDm6uw",
+         "protected": "eyJmb3JtYXRMZW5ndGgiOjI3NDYsImZvcm1hdFRhaWwiOiJDbjAiLCJ0aW1lIjoiMjAyMS0xMi0xM1QxMzo0OTozNFoifQ"
+      }
+   ]
+} 
+`)
 )
 
 var ()
@@ -265,6 +307,13 @@ func TestNewManifest(t *testing.T) {
 				"Docker-Content-Digest": []string{digestML.String()},
 			},
 			raw:   rawDockerSchema2List,
+			ref:   ref,
+			wantE: nil,
+		},
+		{
+			name:  "Docker Schema 1 Signed",
+			mt:    MediaTypeDocker1ManifestSigned,
+			raw:   rawDockerSchema1Signed,
 			ref:   ref,
 			wantE: nil,
 		},
@@ -323,6 +372,10 @@ func TestNewManifest(t *testing.T) {
 func TestFromDescriptor(t *testing.T) {
 	digestInvalid := digest.FromString("invalid")
 	digestDockerSchema2 := digest.FromBytes(rawDockerSchema2)
+	digestDockerSchema1Signed, err := digest.Parse("sha256:f3ef067962554c3352dc0c659ca563f73cc396fe0dea2a2c23a7964c6290f782")
+	if err != nil {
+		t.Fatalf("failed to parse docker schema1 signed digest string: %v", err)
+	}
 	digestOCIImage := digest.FromBytes(rawOCIImage)
 	var tests = []struct {
 		name  string
@@ -338,6 +391,16 @@ func TestFromDescriptor(t *testing.T) {
 				Size:      int64(len(rawDockerSchema2)),
 			},
 			raw:   rawDockerSchema2,
+			wantE: nil,
+		},
+		{
+			name: "Docker Schema 1 Signed Manifest",
+			desc: ociv1.Descriptor{
+				MediaType: MediaTypeDocker1ManifestSigned,
+				Digest:    digestDockerSchema1Signed,
+				Size:      int64(len(rawDockerSchema1Signed)),
+			},
+			raw:   rawDockerSchema1Signed,
 			wantE: nil,
 		},
 		{
@@ -375,6 +438,7 @@ func TestFromDescriptor(t *testing.T) {
 
 func TestFromOrig(t *testing.T) {
 	var manifestDockerSchema2, manifestInvalid dockerSchema2.Manifest
+	var manifestDockerSchema1Signed dockerSchema1.SignedManifest
 	err := json.Unmarshal(rawDockerSchema2, &manifestDockerSchema2)
 	if err != nil {
 		t.Fatalf("failed to unmarshal docker schema2 json: %v", err)
@@ -384,6 +448,7 @@ func TestFromOrig(t *testing.T) {
 		t.Fatalf("failed to unmarshal docker schema2 json: %v", err)
 	}
 	manifestInvalid.MediaType = MediaTypeOCI1Manifest
+	err = json.Unmarshal(rawDockerSchema1Signed, &manifestDockerSchema1Signed)
 	var tests = []struct {
 		name  string
 		orig  interface{}
@@ -397,6 +462,11 @@ func TestFromOrig(t *testing.T) {
 		{
 			name:  "Docker Schema2",
 			orig:  manifestDockerSchema2,
+			wantE: nil,
+		},
+		{
+			name:  "Docker Schema1 Signed",
+			orig:  manifestDockerSchema1Signed,
 			wantE: nil,
 		},
 		{


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

n/a
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

One of the manifest refactors to eliminate duplication of digest calculations broke for the schema v1 manifests that compute their digest differently. This fixes that regression and adds some tests.

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Perform a `regctl image copy debian:6 localhost:5000/library/debian:6`.

<!-- Include steps that can be taken to verify the change -->

### Changelog text

n/a

<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added
- [ ] Documentation has been added or updated
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
