### PR TITLE
Handle registries without HEAD support

### DIFF
--- a/cmd/regbot/config.go
+++ b/cmd/regbot/config.go
@@ -33,6 +33,7 @@ type ConfigCreds struct {
 	Mirrors    []string          `yaml:"mirrors" json:"mirrors"`
 	Priority   uint              `yaml:"priority" json:"priority"`
 	API        string            `yaml:"api" json:"api"`
+	APIOpts    map[string]string `yaml:"apiOpts" json:"apiOpts"`
 	BlobChunk  int64             `yaml:"blobChunk" json:"blobChunk"`
 	BlobMax    int64             `yaml:"blobMax" json:"blobMax"`
 }
@@ -50,6 +51,7 @@ func credsToRCHost(c ConfigCreds) regclient.ConfigHost {
 		Mirrors:    c.Mirrors,
 		Priority:   c.Priority,
 		API:        c.API,
+		APIOpts:    c.APIOpts,
 		BlobChunk:  c.BlobChunk,
 		BlobMax:    c.BlobMax,
 	}

--- a/cmd/regctl/config.go
+++ b/cmd/regctl/config.go
@@ -45,14 +45,37 @@ type ConfigHost struct {
 	Mirrors    []string          `json:"mirrors,omitempty"`    // list of other ConfigHost Names to use as mirrors
 	Priority   uint              `json:"priority,omitempty"`   // priority when sorting mirrors, higher priority attempted first
 	API        string            `json:"api,omitempty"`        // registry API to use
-	BlobChunk  int64             `json:"blobChunk,omitempty"`  // size of each blob chunk
-	BlobMax    int64             `json:"blobMax,omitempty"`    // threshold to switch to chunked upload, -1 to disable
+	APIOpts    map[string]string `json:"apiOpts,omitempty"`
+	BlobChunk  int64             `json:"blobChunk,omitempty"` // size of each blob chunk
+	BlobMax    int64             `json:"blobMax,omitempty"`   // threshold to switch to chunked upload, -1 to disable
+}
+
+func configHostToRCHost(name string, c ConfigHost) regclient.ConfigHost {
+	return regclient.ConfigHost{
+		Name:       name,
+		TLS:        c.TLS,
+		RegCert:    c.RegCert,
+		ClientCert: c.ClientCert,
+		ClientKey:  c.ClientKey,
+		Hostname:   c.Hostname,
+		User:       c.User,
+		Pass:       c.Pass,
+		Token:      c.Token,
+		PathPrefix: c.PathPrefix,
+		Mirrors:    c.Mirrors,
+		Priority:   c.Priority,
+		API:        c.API,
+		APIOpts:    c.APIOpts,
+		BlobChunk:  c.BlobChunk,
+		BlobMax:    c.BlobMax,
+	}
 }
 
 // ConfigHostNew creates a default ConfigHost entry
 func ConfigHostNew() *ConfigHost {
 	h := ConfigHost{
-		TLS: regclient.TLSEnabled,
+		TLS:     regclient.TLSEnabled,
+		APIOpts: map[string]string{},
 	}
 	return &h
 }

--- a/cmd/regctl/root.go
+++ b/cmd/regctl/root.go
@@ -114,21 +114,7 @@ func newRegClient() regclient.RegClient {
 
 	rcHosts := []regclient.ConfigHost{}
 	for name, host := range config.Hosts {
-		rcHosts = append(rcHosts, regclient.ConfigHost{
-			Name:       name,
-			TLS:        host.TLS,
-			RegCert:    host.RegCert,
-			Hostname:   host.Hostname,
-			User:       host.User,
-			Pass:       host.Pass,
-			Token:      host.Token,
-			PathPrefix: host.PathPrefix,
-			Mirrors:    host.Mirrors,
-			Priority:   host.Priority,
-			API:        host.API,
-			BlobChunk:  host.BlobChunk,
-			BlobMax:    host.BlobMax,
-		})
+		rcHosts = append(rcHosts, configHostToRCHost(name, *host))
 	}
 	if len(rcHosts) > 0 {
 		rcOpts = append(rcOpts, regclient.WithConfigHosts(rcHosts))

--- a/cmd/regsync/config.go
+++ b/cmd/regsync/config.go
@@ -46,6 +46,7 @@ type ConfigCreds struct {
 	Mirrors    []string          `yaml:"mirrors" json:"mirrors"`
 	Priority   uint              `yaml:"priority" json:"priority"`
 	API        string            `yaml:"api" json:"api"`
+	APIOpts    map[string]string `yaml:"apiOpts" json:"apiOpts"`
 	BlobChunk  int64             `yaml:"blobChunk" json:"blobChunk"`
 	BlobMax    int64             `yaml:"blobMax" json:"blobMax"`
 }
@@ -63,6 +64,7 @@ func credsToRCHost(c ConfigCreds) regclient.ConfigHost {
 		Mirrors:    c.Mirrors,
 		Priority:   c.Priority,
 		API:        c.API,
+		APIOpts:    c.APIOpts,
 		BlobChunk:  c.BlobChunk,
 		BlobMax:    c.BlobMax,
 	}

--- a/regclient/config_test.go
+++ b/regclient/config_test.go
@@ -1,0 +1,216 @@
+package regclient
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+func TestConfig(t *testing.T) {
+	// generate new/blank
+	blankHostP := ConfigHostNew()
+
+	// generate new/hostname
+	emptyHostP := ConfigHostNewName("host.example.org")
+
+	// parse json
+	exJson := `
+	{
+	  "tls": "enabled",
+		"hostname": "host.example.com",
+		"user": "user-ex",
+		"pass": "secret",
+		"pathPrefix": "hub",
+		"mirrors": ["host1.example.com","host2.example.com"],
+		"priority": 42,
+		"apiOpts": {"disableHead": "true"},
+		"blobChunk": 123456,
+		"blobMax": 999999
+	}
+	`
+	exJson2 := `
+	{
+	  "tls": "disabled",
+		"hostname": "host2.example.com",
+		"user": "user-ex3",
+		"pass": "secret3",
+		"pathPrefix": "hub3",
+		"mirrors": ["host3.example.com"],
+		"priority": 42,
+		"apiOpts": {"disableHead": "false", "unknownOpt": "3"},
+		"blobChunk": 333333,
+		"blobMax": 333333
+	}
+	`
+	var exHost, exHost2 ConfigHost
+	err := json.Unmarshal([]byte(exJson), &exHost)
+	if err != nil {
+		t.Errorf("failed unmarshaling exJson: %v", err)
+	}
+	err = json.Unmarshal([]byte(exJson2), &exHost2)
+	if err != nil {
+		t.Errorf("failed unmarshaling exJson2: %v", err)
+	}
+
+	// merge blank with json
+	var rc = &regClient{
+		certPaths:     []string{},
+		hosts:         map[string]*regClientHost{},
+		retryLimit:    DefaultRetryLimit,
+		userAgent:     DefaultUserAgent,
+		blobChunkSize: DefaultBlobChunk,
+		blobMaxPut:    DefaultBlobMax,
+		// logging is disabled by default
+		log: &logrus.Logger{Out: ioutil.Discard},
+	}
+	exMergeBlank := rc.mergeConfigHost(*blankHostP, exHost, false)
+	exMergeHost2 := rc.mergeConfigHost(exHost, exHost2, false)
+
+	// verify fields in each
+	tests := []struct {
+		name       string
+		host       ConfigHost
+		hostExpect ConfigHost
+	}{
+		{
+			name: "blank",
+			host: *blankHostP,
+			hostExpect: ConfigHost{
+				TLS:     TLSEnabled,
+				APIOpts: map[string]string{},
+			},
+		},
+		{
+			name: "empty",
+			host: *emptyHostP,
+			hostExpect: ConfigHost{
+				TLS:      TLSEnabled,
+				Hostname: "host.example.org",
+				APIOpts:  map[string]string{},
+			},
+		},
+		{
+			name: "exHost",
+			host: exHost,
+			hostExpect: ConfigHost{
+				TLS:        TLSEnabled,
+				Hostname:   "host.example.com",
+				User:       "user-ex",
+				Pass:       "secret",
+				Priority:   42,
+				BlobChunk:  123456,
+				BlobMax:    999999,
+				APIOpts:    map[string]string{"disableHead": "true"},
+				PathPrefix: "hub",
+				Mirrors:    []string{"host1.example.com", "host2.example.com"},
+			},
+		},
+		{
+			name: "exHost2",
+			host: exHost2,
+			hostExpect: ConfigHost{
+				TLS:        TLSDisabled,
+				Hostname:   "host2.example.com",
+				User:       "user-ex3",
+				Pass:       "secret3",
+				PathPrefix: "hub3",
+				Mirrors:    []string{"host3.example.com"},
+				Priority:   42,
+				APIOpts:    map[string]string{"disableHead": "false", "unknownOpt": "3"},
+				BlobChunk:  333333,
+				BlobMax:    333333,
+			},
+		},
+		{
+			name: "mergeBlank",
+			host: exMergeBlank,
+			hostExpect: ConfigHost{
+				TLS:        TLSEnabled,
+				Hostname:   "host.example.com",
+				User:       "user-ex",
+				Pass:       "secret",
+				Priority:   42,
+				BlobChunk:  123456,
+				BlobMax:    999999,
+				APIOpts:    map[string]string{"disableHead": "true"},
+				PathPrefix: "hub",
+				Mirrors:    []string{"host1.example.com", "host2.example.com"},
+			},
+		},
+		{
+			name: "mergeHost2",
+			host: exMergeHost2,
+			hostExpect: ConfigHost{
+				TLS:        TLSDisabled,
+				Hostname:   "host2.example.com",
+				User:       "user-ex3",
+				Pass:       "secret3",
+				PathPrefix: "hub3",
+				Mirrors:    []string{"host3.example.com"},
+				Priority:   42,
+				APIOpts:    map[string]string{"disableHead": "false", "unknownOpt": "3"},
+				BlobChunk:  333333,
+				BlobMax:    333333,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// check each field
+			if tt.host.TLS != tt.hostExpect.TLS {
+				expect, _ := tt.hostExpect.TLS.MarshalText()
+				found, _ := tt.host.TLS.MarshalText()
+				t.Errorf("tls field mismatch, expected %s, found %s", expect, found)
+			}
+			if tt.host.RegCert != tt.hostExpect.RegCert {
+				t.Errorf("regCert field mismatch, expected %s, found %s", tt.hostExpect.RegCert, tt.host.RegCert)
+			}
+			if tt.host.Hostname != tt.hostExpect.Hostname {
+				t.Errorf("hostname field mismatch, expected %s, found %s", tt.hostExpect.Hostname, tt.host.Hostname)
+			}
+			if tt.host.User != tt.hostExpect.User {
+				t.Errorf("user field mismatch, expected %s, found %s", tt.hostExpect.User, tt.host.User)
+			}
+			if tt.host.Pass != tt.hostExpect.Pass {
+				t.Errorf("pass field mismatch, expected %s, found %s", tt.hostExpect.Pass, tt.host.Pass)
+			}
+			if tt.host.Token != tt.hostExpect.Token {
+				t.Errorf("token field mismatch, expected %s, found %s", tt.hostExpect.Token, tt.host.Token)
+			}
+			if tt.host.PathPrefix != tt.hostExpect.PathPrefix {
+				t.Errorf("pathPrefix field mismatch, expected %s, found %s", tt.hostExpect.PathPrefix, tt.host.PathPrefix)
+			}
+			if tt.host.Priority != tt.hostExpect.Priority {
+				t.Errorf("priority field mismatch, expected %d, found %d", tt.hostExpect.Priority, tt.host.Priority)
+			}
+			if tt.host.BlobChunk != tt.hostExpect.BlobChunk {
+				t.Errorf("blobChunk field mismatch, expected %d, found %d", tt.hostExpect.BlobChunk, tt.host.BlobChunk)
+			}
+			if tt.host.BlobMax != tt.hostExpect.BlobMax {
+				t.Errorf("blobMax field mismatch, expected %d, found %d", tt.hostExpect.BlobMax, tt.host.BlobMax)
+			}
+			if len(tt.host.Mirrors) != len(tt.hostExpect.Mirrors) {
+				t.Errorf("mirrors length mismatch, expected %v, found %v", tt.hostExpect.Mirrors, tt.host.Mirrors)
+			} else {
+				for i := range tt.host.Mirrors {
+					if tt.host.Mirrors[i] != tt.hostExpect.Mirrors[i] {
+						t.Errorf("mirrors field %d mismatch, expected %s, found %s", i, tt.hostExpect.Mirrors[i], tt.host.Mirrors[i])
+					}
+				}
+			}
+			if len(tt.host.APIOpts) != len(tt.hostExpect.APIOpts) {
+				t.Errorf("apiOpts length mismatch, expected %v, found %v", tt.hostExpect.APIOpts, tt.host.APIOpts)
+			} else {
+				for i := range tt.host.APIOpts {
+					if tt.host.APIOpts[i] != tt.hostExpect.APIOpts[i] {
+						t.Errorf("apiOpts field %s mismatch, expected %s, found %s", i, tt.hostExpect.APIOpts[i], tt.host.APIOpts[i])
+					}
+				}
+			}
+		})
+	}
+
+}

--- a/regclient/error.go
+++ b/regclient/error.go
@@ -33,6 +33,8 @@ var (
 	ErrUnavailable = errors.New("Unavailable")
 	// ErrUnauthorized when authentication fails
 	ErrUnauthorized = errors.New("Unauthorized")
+	// ErrUnsupportedAPI happens when an API is not supported on a registry
+	ErrUnsupportedAPI = errors.New("Unsupported API")
 	// ErrUnsupportedConfigVersion happens when config file version is greater than this command supports
 	ErrUnsupportedConfigVersion = errors.New("Unsupported config version")
 	// ErrUnsupportedMediaType returned when media type is unknown or unsupported

--- a/regclient/http.go
+++ b/regclient/http.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -75,6 +76,15 @@ func (rc *regClient) httpDo(ctx context.Context, req httpReq) (httpResp, error) 
 		if !ok {
 			err = fmt.Errorf("Failed looking up api \"%s\" for host \"%s\": %w", h.API, h.Name, ErrAPINotFound)
 			continue
+		}
+
+		if api.method == "HEAD" {
+			var disableHead bool
+			disableHead, err = strconv.ParseBool(h.APIOpts["disableHead"])
+			if err == nil && disableHead {
+				err = fmt.Errorf("head requests disabled for host \"%s\": %w", h.Name, ErrUnsupportedAPI)
+				continue
+			}
 		}
 
 		// build the url

--- a/regclient/manifest_test.go
+++ b/regclient/manifest_test.go
@@ -1,0 +1,217 @@
+package regclient
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"testing"
+
+	"github.com/docker/distribution"
+	dockerSchema2 "github.com/docker/distribution/manifest/schema2"
+	"github.com/opencontainers/go-digest"
+	"github.com/regclient/regclient/regclient/types"
+	"github.com/sirupsen/logrus"
+)
+
+func TestManifest(t *testing.T) {
+	repoPath := "/proj"
+	getTag := "get"
+	headTag := "head"
+	noheadTag := "nohead"
+	missingTag := "missing"
+	digest1 := digest.FromString("example1")
+	digest2 := digest.FromString("example2")
+	m := dockerSchema2.Manifest{
+		Config: distribution.Descriptor{
+			MediaType: MediaTypeDocker2ImageConfig,
+			Size:      8,
+			Digest:    digest1,
+		},
+		Layers: []distribution.Descriptor{
+			{
+				MediaType: MediaTypeDocker2Layer,
+				Size:      8,
+				Digest:    digest2,
+			},
+		},
+	}
+	mBody, err := json.Marshal(m)
+	if err != nil {
+		t.Errorf("Failed to marshal manifest: %v", err)
+	}
+	mDigest := digest.FromBytes(mBody)
+	mLen := len(mBody)
+	ctx := context.Background()
+	rrs := []ReqResp{
+		{
+			ReqEntry: ReqEntry{
+				Name:   "Get",
+				Method: "GET",
+				Path:   "/v2" + repoPath + "/manifests/" + getTag,
+			},
+			RespEntry: RespEntry{
+				Status: http.StatusOK,
+				Headers: http.Header{
+					"Content-Length":        {fmt.Sprintf("%d", mLen)},
+					"Content-Type":          []string{MediaTypeDocker2Manifest},
+					"Docker-Content-Digest": []string{mDigest.String()},
+				},
+				Body: mBody,
+			},
+		},
+		{
+			ReqEntry: ReqEntry{
+				Name:   "Head",
+				Method: "HEAD",
+				Path:   "/v2" + repoPath + "/manifests/" + headTag,
+			},
+			RespEntry: RespEntry{
+				Status: http.StatusOK,
+				Headers: http.Header{
+					"Content-Length":        {fmt.Sprintf("%d", mLen)},
+					"Content-Type":          []string{MediaTypeDocker2Manifest},
+					"Docker-Content-Digest": []string{mDigest.String()},
+				},
+			},
+		},
+		{
+			ReqEntry: ReqEntry{
+				Name:   "Get nohead",
+				Method: "GET",
+				Path:   "/v2" + repoPath + "/manifests/" + noheadTag,
+			},
+			RespEntry: RespEntry{
+				Status: http.StatusOK,
+				Headers: http.Header{
+					"Content-Length":        {fmt.Sprintf("%d", mLen)},
+					"Content-Type":          []string{MediaTypeDocker2Manifest},
+					"Docker-Content-Digest": []string{mDigest.String()},
+				},
+				Body: mBody,
+			},
+		},
+		{
+			ReqEntry: ReqEntry{
+				Name:   "Missing",
+				Method: "GET",
+				Path:   "/v2" + repoPath + "/manifests/" + missingTag,
+			},
+			RespEntry: RespEntry{
+				Status: http.StatusNotFound,
+			},
+		},
+	}
+	rrs = append(rrs, rrBaseEntries...)
+	// create a server
+	ts := httptest.NewServer(NewHandler(t, rrs))
+	defer ts.Close()
+	// setup the regclient
+	tsURL, _ := url.Parse(ts.URL)
+	tsHost := tsURL.Host
+	rcHosts := []ConfigHost{
+		{
+			Name:     tsHost,
+			Hostname: tsHost,
+			TLS:      TLSDisabled,
+		},
+		{
+			Name:     "missing." + tsHost,
+			Hostname: tsHost,
+			TLS:      TLSDisabled,
+		},
+		{
+			Name:     "nohead." + tsHost,
+			Hostname: tsHost,
+			TLS:      TLSDisabled,
+			APIOpts: map[string]string{
+				"disableHead": "true",
+			},
+		},
+	}
+	log := &logrus.Logger{
+		Out:       os.Stderr,
+		Formatter: new(logrus.TextFormatter),
+		Hooks:     make(logrus.LevelHooks),
+		Level:     logrus.WarnLevel,
+	}
+	rc := NewRegClient(WithConfigHosts(rcHosts), WithLog(log))
+	t.Run("Get", func(t *testing.T) {
+		getRef, err := types.NewRef(tsURL.Host + repoPath + ":" + getTag)
+		if err != nil {
+			t.Errorf("Failed creating getRef: %v", err)
+		}
+		mGet, err := rc.ManifestGet(ctx, getRef)
+		if err != nil {
+			t.Errorf("Failed running ManifestGet: %v", err)
+			return
+		}
+		if mGet.GetMediaType() != MediaTypeDocker2Manifest {
+			t.Errorf("Unexpected media type: %s", mGet.GetMediaType())
+		}
+		if mGet.GetDigest() != mDigest {
+			t.Errorf("Unexpected digest: %s", mGet.GetDigest().String())
+		}
+	})
+	t.Run("Head", func(t *testing.T) {
+		headRef, err := types.NewRef(tsURL.Host + repoPath + ":" + headTag)
+		if err != nil {
+			t.Errorf("Failed creating getRef: %v", err)
+		}
+		mHead, err := rc.ManifestHead(ctx, headRef)
+		if err != nil {
+			t.Errorf("Failed running ManifestHead: %v", err)
+			return
+		}
+		if mHead.GetMediaType() != MediaTypeDocker2Manifest {
+			t.Errorf("Unexpected media type: %s", mHead.GetMediaType())
+		}
+		if mHead.GetDigest() != mDigest {
+			t.Errorf("Unexpected digest: %s", mHead.GetDigest().String())
+		}
+	})
+	t.Run("Head No Head", func(t *testing.T) {
+		noheadRef, err := types.NewRef("nohead." + tsURL.Host + repoPath + ":" + noheadTag)
+		if err != nil {
+			t.Errorf("Failed creating getRef: %v", err)
+		}
+		mNohead, err := rc.ManifestHead(ctx, noheadRef)
+		if err == nil {
+			t.Errorf("Unexpected successful head on \"no head\" registry: %v", mNohead)
+		} else if !errors.Is(err, ErrUnsupportedAPI) {
+			t.Errorf("Expected error, expected %v, received %v", ErrUnsupportedAPI, err)
+		}
+	})
+	t.Run("Get No Head", func(t *testing.T) {
+		noheadRef, err := types.NewRef("nohead." + tsURL.Host + repoPath + ":" + noheadTag)
+		if err != nil {
+			t.Errorf("Failed creating getRef: %v", err)
+		}
+		mNohead, err := rc.ManifestGet(ctx, noheadRef)
+		if err != nil {
+			t.Errorf("Failed running ManifestGet: %v", err)
+			return
+		}
+		if mNohead.GetMediaType() != MediaTypeDocker2Manifest {
+			t.Errorf("Unexpected media type: %s", mNohead.GetMediaType())
+		}
+		if mNohead.GetDigest() != mDigest {
+			t.Errorf("Unexpected digest: %s", mNohead.GetDigest().String())
+		}
+	})
+	t.Run("Missing", func(t *testing.T) {
+		missingRef, err := types.NewRef("missing." + tsURL.Host + repoPath + ":" + missingTag)
+		if err != nil {
+			t.Errorf("Failed creating missingRef: %v", err)
+		}
+		mMissing, err := rc.ManifestGet(ctx, missingRef)
+		if err == nil {
+			t.Errorf("Success running ManifestGet on missing ref: %v", mMissing)
+			return
+		}
+	})
+}

--- a/regclient/tag.go
+++ b/regclient/tag.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -115,6 +116,9 @@ func (rc *regClient) TagDelete(ctx context.Context, ref types.Ref) error {
 
 	// lookup the current manifest media type
 	curManifest, err := rc.ManifestHead(ctx, ref)
+	if err != nil && errors.Is(err, ErrUnsupportedAPI) {
+		curManifest, err = rc.ManifestGet(ctx, ref)
+	}
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Fixes #125 
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This adds a new host setting, 'APIOpts' with a key value map for injecting specific options into various parts of the API. Currently the only option is "disableHead" which can be set to "true" to disable HEAD requests on registries that don't support them.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

For regctl:

```
regctl registry set --api-opts disableHead=true ...
```

And for regsync:

```yaml
creds:
  - registry: localhost:5000
    tls: disabled
    apiOpts:
      disableHead: "true"
```

With that setting, images can be copied to or from a registry that doesn't have support for HEAD requests.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Handle registries without HEAD support
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

Holding off on documentation to ensure I want to support this feature long-term.
<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added
- [ ] Documentation has been added or updated
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
