### PR TITLE
Fix delete of tags to OCI manifests

### DIFF
--- a/regclient/tag.go
+++ b/regclient/tag.go
@@ -158,8 +158,9 @@ func (rc *regClient) TagDelete(ctx context.Context, ref types.Ref) error {
 	case MediaTypeOCI1Manifest, MediaTypeOCI1ManifestList:
 		tempManifest, err = manifest.FromOrig(ociv1.Manifest{
 			Versioned: ociv1Specs.Versioned{
-				SchemaVersion: 1,
+				SchemaVersion: 2,
 			},
+			MediaType: MediaTypeOCI1Manifest,
 			Config: ociv1.Descriptor{
 				MediaType: MediaTypeOCI1ImageConfig,
 				Digest:    confDigest,


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

n/a
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Bug fix for deleting OCI manifests on registries without the tag delete API. This corrects the schema version and adds a media type to the temporary manifest that is pushed.

### How to verify it

On a registry where deletes for manifests are enabled by the tag delete API isn't available yet, run a `regctl tag rm` on an OCI manifest (I've been testing with cosign signatures since they are an OCI image media type). Before the fix, a registry would reject the bad temporary manifest with a 500 code.

### Changelog text

Fix for deleting tags pointing to an OCI manifest
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [ ] Tests have been added
- [ ] Documentation has been added or updated
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
