### PR TITLE
Fixing version injection in CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -112,7 +112,7 @@ jobs:
         cache-from: type=registry,ref=${{ steps.prep.outputs.regctl_cache_scratch }}
         cache-to: ${{ github.repository_owner == 'regclient' && format('type=registry,ref={0},mode=max', steps.prep.outputs.regctl_cache_scratch) || 'type=inline'}}
         build-args: |
-          LD_FLAGS=-X github.com/regclient/regclient/regclient.VCSRef=${{ github.sha }} -X main.VCSRef=${{ github.sha}} -X main.VCSTag=${{ steps.prep.outputs.version }}
+          VCS_REF=${{ github.sha }}
         labels: |
           org.opencontainers.image.created=${{ steps.prep.outputs.created }}
           org.opencontainers.image.source=${{ github.repositoryUrl }}
@@ -131,7 +131,7 @@ jobs:
         cache-from: type=registry,ref=${{ steps.prep.outputs.regctl_cache_alpine }}
         cache-to: ${{ github.repository_owner == 'regclient' && format('type=registry,ref={0},mode=max', steps.prep.outputs.regctl_cache_alpine) || 'type=inline'}}
         build-args: |
-          LD_FLAGS=-X github.com/regclient/regclient/regclient.VCSRef=${{ github.sha }} -X main.VCSRef=${{ github.sha}} -X main.VCSTag=${{ steps.prep.outputs.version }}
+          VCS_REF=${{ github.sha }}
         labels: |
           org.opencontainers.image.created=${{ steps.prep.outputs.created }}
           org.opencontainers.image.source=${{ github.repositoryUrl }}
@@ -150,7 +150,7 @@ jobs:
         cache-from: type=registry,ref=${{ steps.prep.outputs.regsync_cache_scratch }}
         cache-to: ${{ github.repository_owner == 'regclient' && format('type=registry,ref={0},mode=max', steps.prep.outputs.regsync_cache_scratch) || 'type=inline'}}
         build-args: |
-          LD_FLAGS=-X github.com/regclient/regclient/regclient.VCSRef=${{ github.sha }} -X main.VCSRef=${{ github.sha}} -X main.VCSTag=${{ steps.prep.outputs.version }}
+          VCS_REF=${{ github.sha }}
         labels: |
           org.opencontainers.image.created=${{ steps.prep.outputs.created }}
           org.opencontainers.image.source=${{ github.repositoryUrl }}
@@ -169,7 +169,7 @@ jobs:
         cache-from: type=registry,ref=${{ steps.prep.outputs.regsync_cache_alpine }}
         cache-to: ${{ github.repository_owner == 'regclient' && format('type=registry,ref={0},mode=max', steps.prep.outputs.regsync_cache_alpine) || 'type=inline'}}
         build-args: |
-          LD_FLAGS=-X github.com/regclient/regclient/regclient.VCSRef=${{ github.sha }} -X main.VCSRef=${{ github.sha}} -X main.VCSTag=${{ steps.prep.outputs.version }}
+          VCS_REF=${{ github.sha }}
         labels: |
           org.opencontainers.image.created=${{ steps.prep.outputs.created }}
           org.opencontainers.image.source=${{ github.repositoryUrl }}
@@ -188,7 +188,7 @@ jobs:
         cache-from: type=registry,ref=${{ steps.prep.outputs.regbot_cache_scratch }}
         cache-to: ${{ github.repository_owner == 'regclient' && format('type=registry,ref={0},mode=max', steps.prep.outputs.regbot_cache_scratch) || 'type=inline'}}
         build-args: |
-          LD_FLAGS=-X github.com/regclient/regclient/regclient.VCSRef=${{ github.sha }} -X main.VCSRef=${{ github.sha}} -X main.VCSTag=${{ steps.prep.outputs.version }}
+          VCS_REF=${{ github.sha }}
         labels: |
           org.opencontainers.image.created=${{ steps.prep.outputs.created }}
           org.opencontainers.image.source=${{ github.repositoryUrl }}
@@ -207,7 +207,7 @@ jobs:
         cache-from: type=registry,ref=${{ steps.prep.outputs.regbot_cache_alpine }}
         cache-to: ${{ github.repository_owner == 'regclient' && format('type=registry,ref={0},mode=max', steps.prep.outputs.regbot_cache_alpine) || 'type=inline'}}
         build-args: |
-          LD_FLAGS=-X github.com/regclient/regclient/regclient.VCSRef=${{ github.sha }} -X main.VCSRef=${{ github.sha}} -X main.VCSTag=${{ steps.prep.outputs.version }}
+          VCS_REF=${{ github.sha }}
         labels: |
           org.opencontainers.image.created=${{ steps.prep.outputs.created }}
           org.opencontainers.image.source=${{ github.repositoryUrl }}

--- a/Makefile
+++ b/Makefile
@@ -35,9 +35,9 @@ vendor:
 embed/version.json: .FORCE
 	echo "{\"VCSRef\": \"$(VCS_REF)\", \"VCSTag\": \"$(VCS_TAG)\"}" >embed/version.json
 
-binaries: vendor embed/version.json $(BINARIES)
+binaries: vendor $(BINARIES)
 
-bin/%: .FORCE
+bin/%: embed/version.json .FORCE
 	if [ -f embed/version.json -a -d "cmd/$*/embed" ]; then cp embed/version.json "cmd/$*/embed/"; fi
 	CGO_ENABLED=0 go build ${GO_BUILD_FLAGS} -o bin/$* ./cmd/$*
 
@@ -58,7 +58,7 @@ artifacts: $(ARTIFACTS)
 artifact-pre:
 	mkdir -p artifacts
 
-artifacts/%: artifact-pre .FORCE
+artifacts/%: artifact-pre embed/version.json .FORCE
 	@target="$*"; \
 	command="$${target%%-*}"; \
 	platform_ext="$${target#*-}"; \
@@ -68,6 +68,7 @@ artifacts/%: artifact-pre .FORCE
 	echo export GOOS=$${GOOS}; \
 	echo export GOARCH=$${GOARCH}; \
 	echo go build ${GO_BUILD_FLAGS} -o "$@" ./cmd/$${command}/; \
+	if [ -f embed/version.json -a -d "cmd/$${command}/embed" ]; then cp embed/version.json "cmd/$${command}/embed/"; fi; \
 	CGO_ENABLED=0 go build ${GO_BUILD_FLAGS} -o "$@" ./cmd/$${command}/
 
 plugin-user:


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Fixes #139 
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

The version injection wasn't being triggered with the CI builds. This moves the prereq in the Makefile and cleans up the GHA.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

CI builds should have version information in both the built binaries and docker images once merged.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [ ] Tests have been added
- [ ] Documentation has been added or updated
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
