### PR TITLE
Fixing dirty version in docker builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,10 @@ vendor:
 	go mod vendor
 
 embed/version.json: .FORCE
-	echo "{\"VCSRef\": \"$(VCS_REF)\", \"VCSTag\": \"$(VCS_TAG)\"}" >embed/version.json
+	# docker builds will not have the .dockerignore inside the container
+	if [ -f ".dockerignore" -o ! -f "embed/version.json" ]; then \
+		echo "{\"VCSRef\": \"$(VCS_REF)\", \"VCSTag\": \"$(VCS_TAG)\"}" >embed/version.json; \
+	fi
 
 binaries: vendor $(BINARIES)
 
@@ -43,7 +46,7 @@ bin/%: embed/version.json .FORCE
 
 docker: $(IMAGES)
 
-docker-%: .FORCE
+docker-%: embed/version.json .FORCE
 	docker build -t regclient/$* -f build/Dockerfile.$*$(DOCKERFILE_EXT) $(DOCKER_ARGS) .
 	docker build -t regclient/$*:alpine -f build/Dockerfile.$*$(DOCKERFILE_EXT) --target release-alpine $(DOCKER_ARGS) .
 


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Fixes #139 for docker.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Docker builds were reporting the version as dirty because `.dockerignore` made it appear that multiple files were deleted. This moves the version check to the Makefile before calling `docker build` instead of from within the build container.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Docker images will show a commit without the `-dirty` tag when git repo is clean.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [ ] Tests have been added
- [ ] Documentation has been added or updated
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
