### PR TITLE
Generate embed/version.json in docker GHA

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -79,6 +79,9 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v2
 
+    - name: Set embed/version.json
+      run: make embed/version.json
+
     # - name: Set up QEMU
     #   uses: docker/setup-qemu-action@v1
 


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Fixes #139 
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Docker builds from the Makefile are good, but GHA skips the Makefile, so this includes the embed/version.json set in the GHA.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Docker images from GHA will have a version.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [ ] Tests have been added
- [ ] Documentation has been added or updated
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
