### PR TITLE
Handle tag rm with auth on a remote blob host

### DIFF
--- a/scheme/reg/repo.go
+++ b/scheme/reg/repo.go
@@ -71,7 +71,7 @@ func (reg *Reg) RepoList(ctx context.Context, hostname string, opts ...scheme.Re
 	if err != nil {
 		reg.log.WithFields(logrus.Fields{
 			"err":  err,
-			"body": respBody,
+			"body": string(respBody),
 			"host": hostname,
 		}).Warn("Failed to unmarshal repo list")
 		return nil, fmt.Errorf("Failed to parse repo list for %s: %w", hostname, err)

--- a/scheme/reg/tag.go
+++ b/scheme/reg/tag.go
@@ -143,7 +143,7 @@ func (reg *Reg) TagDelete(ctx context.Context, r ref.Ref) error {
 	}).Debug("Sending dummy manifest to replace tag")
 
 	// push config
-	_, _, err = reg.BlobPut(ctx, r, confDigest, ioutil.NopCloser(bytes.NewReader(confB)), int64(len(confB)))
+	_, _, err = reg.BlobPut(ctx, r, confDigest, bytes.NewReader(confB), int64(len(confB)))
 	if err != nil {
 		return fmt.Errorf("Failed sending dummy config to delete %s: %w", r.CommonName(), err)
 	}

--- a/types/blob/blob_test.go
+++ b/types/blob/blob_test.go
@@ -81,7 +81,7 @@ func TestCommon(t *testing.T) {
 		},
 		{
 			name:    "reader",
-			opts:    []Opts{WithReader(io.NopCloser(bytes.NewReader(exBlob)))},
+			opts:    []Opts{WithReader(bytes.NewReader(exBlob))},
 			eBytes:  exBlob,
 			eDigest: exDigest,
 			eLen:    exLen,
@@ -89,7 +89,7 @@ func TestCommon(t *testing.T) {
 		{
 			name: "descriptor",
 			opts: []Opts{
-				WithReader(io.NopCloser(bytes.NewReader(exBlob))),
+				WithReader(bytes.NewReader(exBlob)),
 				WithDesc(ociv1.Descriptor{
 					MediaType: exMT,
 					Digest:    exDigest,
@@ -105,7 +105,7 @@ func TestCommon(t *testing.T) {
 		{
 			name: "headers",
 			opts: []Opts{
-				WithReader(io.NopCloser(bytes.NewReader(exBlob))),
+				WithReader(bytes.NewReader(exBlob)),
 				WithHeader(exHeaders),
 				WithRef(exRef),
 			},
@@ -229,7 +229,7 @@ func TestReader(t *testing.T) {
 	t.Run("ociconfig", func(t *testing.T) {
 		// create blob
 		b := NewReader(
-			WithReader(io.NopCloser(bytes.NewReader(exBlob))),
+			WithReader(bytes.NewReader(exBlob)),
 			WithDesc(ociv1.Descriptor{
 				MediaType: exMT,
 				Digest:    exDigest,
@@ -259,7 +259,7 @@ func TestReader(t *testing.T) {
 	t.Run("rawbytes", func(t *testing.T) {
 		// create blob
 		b := NewReader(
-			WithReader(io.NopCloser(bytes.NewReader(exBlob))),
+			WithReader(bytes.NewReader(exBlob)),
 		)
 		// test RawBytes on blob 3
 		bb, err := b.RawBody()


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

This should help with #143 

### Describe the change

Doing a tag rm with authentication when the blob server is remote resulted in a failure because the temporary blob didn't support seeking on the reader. This fixes the reader and adds tests to the blob calls to verify the auth is supported using the same credentials.

### How to verify it

Remote a tag on a registry that doesn't support the new API calls, where the blob upload location is on a different hostname.

### Changelog text

Fix for tag rm with authentication when the blob upload location is a different host

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added
- [ ] Documentation has been added or updated
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
