### PR TITLE
Reset auth handler for host after empty challenge

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -217,6 +217,7 @@ func (a *auth) HandleResponse(resp *http.Response) error {
 		"challenge": cl,
 	}).Debug("Auth request parsed")
 	if len(cl) < 1 {
+		a.hs[host] = map[string]Handler{}
 		return ErrEmptyChallenge
 	}
 	goodChallenge := false


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

Fixes #149.

### Describe the change

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

This commit updates the `HandleResponse` method of `auth` to reset the handler for given hostname
if it encounters a 401 error with an empty `WWW-Authenticate` header. [According to the registry spec](https://github.com/distribution/distribution/blob/main/docs/spec/auth/token.md#docker-registry-v2-authentication-via-central-service),
the registry should always return this header, but it seems GCR fails to include the header if you make
a request with a Bearer token which has a scope that doesn't permit the action being performed (e.g.
the scope gives permissions for image A but the request is made for image B). Requests made without
a Bearer token will include the `WWW-Authenticate` header so this change will ensure that the next retry
will get a new Bearer token.

### How to verify it

<!-- Include steps that can be taken to verify the change -->

I was able to verify this locally against the GCR registry that I've been using but since the registry is
private I was unable to come up with a publicly reproducible way to verify the change works.

### Changelog text

<!-- If the release changelog should have an entry for this, include it here -->

Auth handler will reset tokens when a 401 response fails to include a challenge.

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [ ] Tests have been added
- [ ] Documentation has been added or updated
- [ ] Changes have been rebased to main
- [ ] Multiple commits to the same code have been squashed
