### PR TITLE
Refactoring manifest interface, adding SetOrig

### DIFF
--- a/cmd/regbot/sandbox/image.go
+++ b/cmd/regbot/sandbox/image.go
@@ -84,12 +84,12 @@ func (s *Sandbox) configGet(ls *lua.LState) int {
 		"script": s.name,
 		"image":  m.r.CommonName(),
 	}).Debug("Retrieve image config")
-	confDigest, err := m.m.GetConfigDigest()
+	confDesc, err := m.m.GetConfig()
 	if err != nil {
 		ls.RaiseError("Failed looking up \"%s\" config digest: %v", m.r.CommonName(), err)
 	}
 
-	confBlob, err := s.rc.BlobGetOCIConfig(s.ctx, m.r, confDigest)
+	confBlob, err := s.rc.BlobGetOCIConfig(s.ctx, m.r, confDesc.Digest)
 	if err != nil {
 		ls.RaiseError("Failed retrieving \"%s\" config: %v", m.r.CommonName(), err)
 	}
@@ -266,7 +266,7 @@ func (s *Sandbox) imageRateLimit(ls *lua.LState) int {
 		ls.RaiseError("Context error: %v", err)
 	}
 	m := s.checkManifest(ls, 1, false, true)
-	rl := go2lua.Export(ls, m.m.GetRateLimit())
+	rl := go2lua.Export(ls, manifest.GetRateLimit(m.m))
 	ls.Push(rl)
 	return 1
 }
@@ -310,7 +310,7 @@ func (s *Sandbox) imageRateLimitWait(ls *lua.LState) int {
 			return 0
 		}
 		// success if rate limit not set or remaining is above our limit
-		rl := mh.GetRateLimit()
+		rl := manifest.GetRateLimit(mh)
 		if !rl.Set || rl.Remain >= limit {
 			ls.Push(lua.LBool(true))
 			return 1

--- a/cmd/regctl/artifact.go
+++ b/cmd/regctl/artifact.go
@@ -127,11 +127,11 @@ func runArtifactGet(cmd *cobra.Command, args []string) error {
 
 	// if config-file defined, create file as writer, perform a blob get
 	if artifactOpts.configFile != "" {
-		d, err := mm.GetConfigDigest()
+		d, err := mm.GetConfig()
 		if err != nil {
 			return err
 		}
-		rdr, err := rc.BlobGet(ctx, r, d)
+		rdr, err := rc.BlobGet(ctx, r, d.Digest)
 		if err != nil {
 			return err
 		}

--- a/cmd/regctl/image.go
+++ b/cmd/regctl/image.go
@@ -244,12 +244,12 @@ func runImageInspect(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	cd, err := m.GetConfigDigest()
+	cd, err := m.GetConfig()
 	if err != nil {
 		return err
 	}
 
-	blobConfig, err := rc.BlobGetOCIConfig(ctx, r, cd)
+	blobConfig, err := rc.BlobGetOCIConfig(ctx, r, cd.Digest)
 	if err != nil {
 		return err
 	}

--- a/cmd/regctl/manifest.go
+++ b/cmd/regctl/manifest.go
@@ -155,9 +155,9 @@ func getPlatformDesc(rc *regclient.RegClient, m manifest.Manifest) (*ociv1.Descr
 	if plat.OS == "" {
 		plat = platforms.DefaultSpec()
 	}
-	desc, err = m.GetPlatformDesc(&plat)
+	desc, err = manifest.GetPlatformDesc(m, &plat)
 	if err != nil {
-		pl, _ := m.GetPlatformList()
+		pl, _ := manifest.GetPlatformList(m)
 		var ps []string
 		for _, p := range pl {
 			ps = append(ps, platforms.Format(*p))
@@ -190,7 +190,7 @@ func runManifestDelete(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		r.Digest = m.GetDigest().String()
+		r.Digest = manifest.GetDigest(m).String()
 		log.WithFields(logrus.Fields{
 			"tag":    r.Tag,
 			"digest": r.Digest,
@@ -251,7 +251,7 @@ func runManifestDigest(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	fmt.Println(m.GetDigest().String())
+	fmt.Println(manifest.GetDigest(m).String())
 	return nil
 }
 

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/regclient/regclient/config"
 	"github.com/regclient/regclient/internal/reqresp"
 	"github.com/regclient/regclient/types"
+	"github.com/regclient/regclient/types/manifest"
 	"github.com/regclient/regclient/types/ref"
 	"github.com/sirupsen/logrus"
 )
@@ -160,11 +161,11 @@ func TestManifest(t *testing.T) {
 			t.Errorf("Failed running ManifestGet: %v", err)
 			return
 		}
-		if mGet.GetMediaType() != types.MediaTypeDocker2Manifest {
-			t.Errorf("Unexpected media type: %s", mGet.GetMediaType())
+		if manifest.GetMediaType(mGet) != types.MediaTypeDocker2Manifest {
+			t.Errorf("Unexpected media type: %s", manifest.GetMediaType(mGet))
 		}
-		if mGet.GetDigest() != mDigest {
-			t.Errorf("Unexpected digest: %s", mGet.GetDigest().String())
+		if mGet.GetDescriptor().Digest != mDigest {
+			t.Errorf("Unexpected digest: %s", mGet.GetDescriptor().Digest.String())
 		}
 	})
 	t.Run("Head", func(t *testing.T) {
@@ -177,11 +178,11 @@ func TestManifest(t *testing.T) {
 			t.Errorf("Failed running ManifestHead: %v", err)
 			return
 		}
-		if mHead.GetMediaType() != types.MediaTypeDocker2Manifest {
-			t.Errorf("Unexpected media type: %s", mHead.GetMediaType())
+		if manifest.GetMediaType(mHead) != types.MediaTypeDocker2Manifest {
+			t.Errorf("Unexpected media type: %s", manifest.GetMediaType(mHead))
 		}
-		if mHead.GetDigest() != mDigest {
-			t.Errorf("Unexpected digest: %s", mHead.GetDigest().String())
+		if mHead.GetDescriptor().Digest != mDigest {
+			t.Errorf("Unexpected digest: %s", mHead.GetDescriptor().Digest.String())
 		}
 	})
 	t.Run("Head No Head", func(t *testing.T) {
@@ -206,11 +207,11 @@ func TestManifest(t *testing.T) {
 			t.Errorf("Failed running ManifestGet: %v", err)
 			return
 		}
-		if mNohead.GetMediaType() != types.MediaTypeDocker2Manifest {
-			t.Errorf("Unexpected media type: %s", mNohead.GetMediaType())
+		if manifest.GetMediaType(mNohead) != types.MediaTypeDocker2Manifest {
+			t.Errorf("Unexpected media type: %s", manifest.GetMediaType(mNohead))
 		}
-		if mNohead.GetDigest() != mDigest {
-			t.Errorf("Unexpected digest: %s", mNohead.GetDigest().String())
+		if mNohead.GetDescriptor().Digest != mDigest {
+			t.Errorf("Unexpected digest: %s", mNohead.GetDescriptor().Digest.String())
 		}
 	})
 	t.Run("Missing", func(t *testing.T) {

--- a/scheme/ocidir/blob_test.go
+++ b/scheme/ocidir/blob_test.go
@@ -32,7 +32,7 @@ func TestBlob(t *testing.T) {
 		t.Errorf("expected manifest list")
 		return
 	}
-	dl, err := ml.GetDescriptorList()
+	dl, err := ml.GetManifestList()
 	if err != nil || len(dl) < 1 {
 		t.Errorf("descriptor list (%d): %v", len(dl), err)
 		return

--- a/scheme/ocidir/close.go
+++ b/scheme/ocidir/close.go
@@ -76,7 +76,7 @@ func (o *OCIDir) Close(ctx context.Context, r ref.Ref) error {
 func (o *OCIDir) closeProcManifest(ctx context.Context, r ref.Ref, m manifest.Manifest, dl *map[string]bool) error {
 	if m.IsList() {
 		// go through manifest list, updating dl, and recursively processing nested manifests
-		ml, err := m.GetDescriptorList()
+		ml, err := m.GetManifestList()
 		if err != nil {
 			return err
 		}
@@ -88,6 +88,10 @@ func (o *OCIDir) closeProcManifest(ctx context.Context, r ref.Ref, m manifest.Ma
 			cm, err := o.ManifestGet(ctx, cr)
 			if err != nil {
 				// ignore errors in case a manifest has been deleted or sparse copy
+				o.log.WithFields(logrus.Fields{
+					"ref": cr.CommonName(),
+					"err": err,
+				}).Debug("could not retrieve manifest")
 				continue
 			}
 			err = o.closeProcManifest(ctx, cr, cm, dl)
@@ -97,7 +101,7 @@ func (o *OCIDir) closeProcManifest(ctx context.Context, r ref.Ref, m manifest.Ma
 		}
 	} else {
 		// get config from manifest if it exists
-		cd, err := m.GetConfigDescriptor()
+		cd, err := m.GetConfig()
 		if err == nil {
 			(*dl)[cd.Digest.String()] = true
 		}

--- a/scheme/ocidir/manifest_test.go
+++ b/scheme/ocidir/manifest_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/regclient/regclient/internal/rwfs"
 	"github.com/regclient/regclient/types"
+	"github.com/regclient/regclient/types/manifest"
 	"github.com/regclient/regclient/types/ref"
 )
 
@@ -34,14 +35,14 @@ func TestManifest(t *testing.T) {
 	if err != nil {
 		t.Errorf("manifest get: %v", err)
 	}
-	if ml.GetMediaType() != types.MediaTypeDocker2ManifestList {
-		t.Errorf("manifest mt, expected %s, received %s", types.MediaTypeDocker2ManifestList, ml.GetMediaType())
+	if manifest.GetMediaType(ml) != types.MediaTypeDocker2ManifestList {
+		t.Errorf("manifest mt, expected %s, received %s", types.MediaTypeDocker2ManifestList, manifest.GetMediaType(ml))
 	}
 	if !ml.IsList() {
 		t.Errorf("expected manifest list")
 		return
 	}
-	dl, err := ml.GetDescriptorList()
+	dl, err := ml.GetManifestList()
 	if err != nil || len(dl) < 1 {
 		t.Errorf("descriptor list (%d): %v", len(dl), err)
 		return
@@ -58,9 +59,9 @@ func TestManifest(t *testing.T) {
 		t.Errorf("manifest get: %v", err)
 		return
 	}
-	_, err = m.GetConfigDigest()
+	_, err = m.GetConfig()
 	if err != nil {
-		t.Errorf("config digest: %v", err)
+		t.Errorf("config: %v", err)
 		return
 	}
 	// test manifest put to a memfs

--- a/scheme/reg/manifest.go
+++ b/scheme/reg/manifest.go
@@ -176,7 +176,7 @@ func (reg *Reg) ManifestPut(ctx context.Context, r ref.Ref, m manifest.Manifest,
 
 	// build/send request
 	headers := http.Header{
-		"Content-Type": []string{m.GetMediaType()},
+		"Content-Type": []string{manifest.GetMediaType(m)},
 	}
 	req := &reghttp.Req{
 		Host:      r.Registry,

--- a/scheme/reg/manifest_test.go
+++ b/scheme/reg/manifest_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/regclient/regclient/config"
 	"github.com/regclient/regclient/internal/reqresp"
 	"github.com/regclient/regclient/types"
+	"github.com/regclient/regclient/types/manifest"
 	"github.com/regclient/regclient/types/ref"
 	"github.com/sirupsen/logrus"
 )
@@ -161,11 +162,11 @@ func TestManifest(t *testing.T) {
 			t.Errorf("Failed running ManifestGet: %v", err)
 			return
 		}
-		if mGet.GetMediaType() != types.MediaTypeDocker2Manifest {
-			t.Errorf("Unexpected media type: %s", mGet.GetMediaType())
+		if manifest.GetMediaType(mGet) != types.MediaTypeDocker2Manifest {
+			t.Errorf("Unexpected media type: %s", manifest.GetMediaType(mGet))
 		}
-		if mGet.GetDigest() != mDigest {
-			t.Errorf("Unexpected digest: %s", mGet.GetDigest().String())
+		if mGet.GetDescriptor().Digest != mDigest {
+			t.Errorf("Unexpected digest: %s", mGet.GetDescriptor().Digest.String())
 		}
 	})
 	t.Run("Head", func(t *testing.T) {
@@ -178,11 +179,11 @@ func TestManifest(t *testing.T) {
 			t.Errorf("Failed running ManifestHead: %v", err)
 			return
 		}
-		if mHead.GetMediaType() != types.MediaTypeDocker2Manifest {
-			t.Errorf("Unexpected media type: %s", mHead.GetMediaType())
+		if manifest.GetMediaType(mHead) != types.MediaTypeDocker2Manifest {
+			t.Errorf("Unexpected media type: %s", manifest.GetMediaType(mHead))
 		}
-		if mHead.GetDigest() != mDigest {
-			t.Errorf("Unexpected digest: %s", mHead.GetDigest().String())
+		if mHead.GetDescriptor().Digest != mDigest {
+			t.Errorf("Unexpected digest: %s", mHead.GetDescriptor().Digest.String())
 		}
 	})
 	t.Run("Head No Head", func(t *testing.T) {
@@ -207,11 +208,11 @@ func TestManifest(t *testing.T) {
 			t.Errorf("Failed running ManifestGet: %v", err)
 			return
 		}
-		if mNohead.GetMediaType() != types.MediaTypeDocker2Manifest {
-			t.Errorf("Unexpected media type: %s", mNohead.GetMediaType())
+		if manifest.GetMediaType(mNohead) != types.MediaTypeDocker2Manifest {
+			t.Errorf("Unexpected media type: %s", manifest.GetMediaType(mNohead))
 		}
-		if mNohead.GetDigest() != mDigest {
-			t.Errorf("Unexpected digest: %s", mNohead.GetDigest().String())
+		if mNohead.GetDescriptor().Digest != mDigest {
+			t.Errorf("Unexpected digest: %s", mNohead.GetDescriptor().Digest.String())
 		}
 	})
 	t.Run("Missing", func(t *testing.T) {

--- a/scheme/reg/tag.go
+++ b/scheme/reg/tag.go
@@ -104,7 +104,7 @@ func (reg *Reg) TagDelete(ctx context.Context, r ref.Ref) error {
 	confDigest := digester.Digest()
 
 	// create manifest with config, matching the original tag manifest type
-	switch curManifest.GetMediaType() {
+	switch manifest.GetMediaType(curManifest) {
 	case types.MediaTypeOCI1Manifest, types.MediaTypeOCI1ManifestList:
 		tempManifest, err = manifest.New(manifest.WithOrig(ociv1.Manifest{
 			Versioned: ociv1Specs.Versioned{
@@ -154,7 +154,7 @@ func (reg *Reg) TagDelete(ctx context.Context, r ref.Ref) error {
 		return fmt.Errorf("failed sending dummy manifest to delete %s: %w", r.CommonName(), err)
 	}
 
-	r.Digest = tempManifest.GetDigest().String()
+	r.Digest = tempManifest.GetDescriptor().Digest.String()
 
 	// delete manifest by digest
 	reg.log.WithFields(logrus.Fields{

--- a/types/manifest/common.go
+++ b/types/manifest/common.go
@@ -25,6 +25,11 @@ func (m *common) GetDigest() digest.Digest {
 	return m.desc.Digest
 }
 
+// GetDescriptor returns the descriptor
+func (m *common) GetDescriptor() ociv1.Descriptor {
+	return m.desc
+}
+
 // GetMediaType returns the media type
 func (m *common) GetMediaType() string {
 	return m.desc.MediaType


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This is a lot of refactoring to cleanup the interface and handle a new SetOrig interface.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Tests have been added, and further commits for blob and modification methods are coming.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Refactored the manifest type. This results in breaking changes to exported methods.
Added the ability to modify a manifest type.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added
- [ ] Documentation has been added or updated
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
