### PR TITLE
Refactor blob like manifests, add SetConfig

### DIFF
--- a/blob.go
+++ b/blob.go
@@ -59,7 +59,7 @@ func (rc *RegClient) BlobCopy(ctx context.Context, refSrc ref.Ref, refTgt ref.Re
 		return err
 	}
 	defer blobIO.Close()
-	if _, _, err := rc.BlobPut(ctx, refTgt, d, blobIO, blobIO.Length()); err != nil {
+	if _, _, err := rc.BlobPut(ctx, refTgt, d, blobIO, blobIO.GetDescriptor().Size); err != nil {
 		rc.log.WithFields(logrus.Fields{
 			"err": err,
 			"src": refSrc.Reference,

--- a/blob_test.go
+++ b/blob_test.go
@@ -208,7 +208,7 @@ func TestBlobGet(t *testing.T) {
 			return
 		}
 		defer br.Close()
-		if br.Length() != int64(blobLen) {
+		if br.GetDescriptor().Size != int64(blobLen) {
 			t.Errorf("Failed comparing blob length")
 		}
 	})

--- a/scheme/reg/blob_test.go
+++ b/scheme/reg/blob_test.go
@@ -210,7 +210,7 @@ func TestBlobGet(t *testing.T) {
 			return
 		}
 		defer br.Close()
-		if br.Length() != int64(blobLen) {
+		if br.GetDescriptor().Size != int64(blobLen) {
 			t.Errorf("Failed comparing blob length")
 		}
 	})

--- a/types/blob/blob.go
+++ b/types/blob/blob.go
@@ -16,12 +16,13 @@ type Blob interface {
 }
 
 type blobConfig struct {
-	desc   ociv1.Descriptor
-	header http.Header
-	image  ociv1.Image
-	r      ref.Ref
-	rdr    io.Reader
-	resp   *http.Response
+	desc    ociv1.Descriptor
+	header  http.Header
+	image   *ociv1.Image
+	r       ref.Ref
+	rdr     io.Reader
+	resp    *http.Response
+	rawBody []byte
 }
 
 type Opts func(*blobConfig)
@@ -43,7 +44,14 @@ func WithHeader(header http.Header) Opts {
 // WithImage provides the OCI Image config needed for config blobs
 func WithImage(image ociv1.Image) Opts {
 	return func(bc *blobConfig) {
-		bc.image = image
+		bc.image = &image
+	}
+}
+
+// WithRawBody defines the raw blob contents for OCIConfig
+func WithRawBody(raw []byte) Opts {
+	return func(bc *blobConfig) {
+		bc.rawBody = raw
 	}
 }
 
@@ -65,7 +73,7 @@ func WithRef(r ref.Ref) Opts {
 func WithResp(resp *http.Response) Opts {
 	return func(bc *blobConfig) {
 		bc.resp = resp
-		if bc.header == nil {
+		if bc.header == nil && resp != nil {
 			bc.header = resp.Header
 		}
 	}

--- a/types/blob/common.go
+++ b/types/blob/common.go
@@ -10,11 +10,13 @@ import (
 
 // Common interface is provided by all Blob implementations
 type Common interface {
-	Digest() digest.Digest
-	Length() int64
-	MediaType() string
+	GetDescriptor() ociv1.Descriptor
 	Response() *http.Response
 	RawHeaders() http.Header
+
+	Digest() digest.Digest // TODO: deprecate
+	Length() int64         // TODO: deprecate
+	MediaType() string     // TODO: deprecate
 }
 
 type common struct {
@@ -23,6 +25,11 @@ type common struct {
 	blobSet   bool
 	rawHeader http.Header
 	resp      *http.Response
+}
+
+// GetDescriptor returns the descriptor associated with the blob
+func (b *common) GetDescriptor() ociv1.Descriptor {
+	return b.desc
 }
 
 // Digest returns the provided or calculated digest of the blob

--- a/types/blob/reader.go
+++ b/types/blob/reader.go
@@ -1,14 +1,12 @@
 package blob
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"strconv"
 
 	"github.com/opencontainers/go-digest"
-	ociv1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // Reader is an unprocessed Blob with an available ReadCloser for reading the Blob
@@ -153,11 +151,11 @@ func (b *reader) ToOCIConfig() (OCIConfig, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error reading image config for %s: %w", b.r.CommonName(), err)
 	}
-	var ociImage ociv1.Image
-	err = json.Unmarshal(blobBody, &ociImage)
-	if err != nil {
-		return nil, fmt.Errorf("error parsing image config for %s: %w", b.r.CommonName(), err)
-	}
-	// return the resulting blobOCIConfig, reuse blobCommon, setting rawBody read above, and the unmarshaled OCI image config
-	return &ociConfig{common: b.common, rawBody: blobBody, Image: ociImage}, nil
+	return NewOCIConfig(
+		WithDesc(b.desc),
+		WithHeader(b.rawHeader),
+		WithRawBody(blobBody),
+		WithRef(b.r),
+		WithResp(b.resp),
+	), nil
 }


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This refactors the blob type to have a similar interface to the manifest type. It also adds a SetConfig method to allow modifying an OCI config blob.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Tests have been added.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Blob methods have been refactored with breaking changes to exported APIs.
Blob SetConfig method added to allow modifying an OCI config.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added
- [ ] Documentation has been added or updated
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
