### PR TITLE
Adding repoAuth for gcr.io

### DIFF
--- a/cmd/regbot/config.go
+++ b/cmd/regbot/config.go
@@ -26,6 +26,7 @@ type ConfigCreds struct {
 	User       string            `yaml:"user" json:"user"`
 	Pass       string            `yaml:"pass" json:"pass"`
 	Token      string            `yaml:"token" json:"token"`
+	RepoAuth   bool              `yaml:"repoAuth" json:"repoAuth"`
 	TLS        config.TLSConf    `yaml:"tls" json:"tls"`
 	Scheme     string            `yaml:"scheme" json:"scheme"` // TODO: delete
 	RegCert    string            `yaml:"regcert" json:"regcert"`
@@ -45,6 +46,7 @@ func credsToRCHost(c ConfigCreds) config.Host {
 		User:       c.User,
 		Pass:       c.Pass,
 		Token:      c.Token,
+		RepoAuth:   c.RepoAuth,
 		TLS:        c.TLS,
 		RegCert:    c.RegCert,
 		PathPrefix: c.PathPrefix,

--- a/cmd/regctl/config.go
+++ b/cmd/regctl/config.go
@@ -44,7 +44,8 @@ type ConfigHost struct {
 	PathPrefix string            `json:"pathPrefix,omitempty"` // used for mirrors defined within a repository namespace
 	Mirrors    []string          `json:"mirrors,omitempty"`    // list of other Host names to use as mirrors
 	Priority   uint              `json:"priority,omitempty"`   // priority when sorting mirrors, higher priority attempted first
-	API        string            `json:"api,omitempty"`        // registry API to use
+	RepoAuth   bool              `json:"repoAuth,omitempty"`
+	API        string            `json:"api,omitempty"` // registry API to use
 	APIOpts    map[string]string `json:"apiOpts,omitempty"`
 	BlobChunk  int64             `json:"blobChunk,omitempty"` // size of each blob chunk
 	BlobMax    int64             `json:"blobMax,omitempty"`   // threshold to switch to chunked upload, -1 to disable
@@ -64,6 +65,7 @@ func configHostToRCHost(name string, c config.Host) config.Host {
 		PathPrefix: c.PathPrefix,
 		Mirrors:    c.Mirrors,
 		Priority:   c.Priority,
+		RepoAuth:   c.RepoAuth,
 		API:        c.API,
 		APIOpts:    c.APIOpts,
 		BlobChunk:  c.BlobChunk,

--- a/cmd/regctl/root.go
+++ b/cmd/regctl/root.go
@@ -163,3 +163,11 @@ func setupVCSVars() {
 		VCSTag = verS.VCSTag
 	}
 }
+
+func flagChanged(cmd *cobra.Command, name string) bool {
+	flag := cmd.Flags().Lookup(name)
+	if flag == nil {
+		return false
+	}
+	return flag.Changed
+}

--- a/cmd/regsync/config.go
+++ b/cmd/regsync/config.go
@@ -46,6 +46,7 @@ type ConfigCreds struct {
 	PathPrefix string            `yaml:"pathPrefix" json:"pathPrefix"`
 	Mirrors    []string          `yaml:"mirrors" json:"mirrors"`
 	Priority   uint              `yaml:"priority" json:"priority"`
+	RepoAuth   bool              `yaml:"repoAuth" json:"repoAuth"`
 	API        string            `yaml:"api" json:"api"`
 	APIOpts    map[string]string `yaml:"apiOpts" json:"apiOpts"`
 	BlobChunk  int64             `yaml:"blobChunk" json:"blobChunk"`
@@ -64,6 +65,7 @@ func credsToRCHost(c ConfigCreds) config.Host {
 		PathPrefix: c.PathPrefix,
 		Mirrors:    c.Mirrors,
 		Priority:   c.Priority,
+		RepoAuth:   c.RepoAuth,
 		API:        c.API,
 		APIOpts:    c.APIOpts,
 		BlobChunk:  c.BlobChunk,

--- a/config/host.go
+++ b/config/host.go
@@ -100,6 +100,7 @@ type Host struct {
 	PathPrefix string            `json:"pathPrefix,omitempty"` // used for mirrors defined within a repository namespace
 	Mirrors    []string          `json:"mirrors,omitempty"`    // list of other Host Names to use as mirrors
 	Priority   uint              `json:"priority,omitempty"`   // priority when sorting mirrors, higher priority attempted first
+	RepoAuth   bool              `json:"repoAuth,omitempty"`   // tracks a separate auth per repo
 	API        string            `json:"api,omitempty"`        // experimental: registry API to use
 	APIOpts    map[string]string `json:"apiOpts,omitempty"`    // options for APIs
 	BlobChunk  int64             `json:"blobChunk,omitempty"`  // size of each blob chunk
@@ -262,6 +263,10 @@ func (host *Host) Merge(newHost Host, log *logrus.Logger) error {
 			}).Warn("Changing priority settings for registry")
 		}
 		host.Priority = newHost.Priority
+	}
+
+	if newHost.RepoAuth {
+		host.RepoAuth = newHost.RepoAuth
 	}
 
 	if newHost.API != "" {

--- a/docs/README.md
+++ b/docs/README.md
@@ -81,7 +81,7 @@ The following functions have been added in addition to the defaults available in
      /etc/docker/registry/config.yml
    ```
 
-2. Q: Can I delete images from Docker Hub?
+1. Q: Can I delete images from Docker Hub?
 
    A: Officially, Hub does not support the manifest delete API, you'll get an access denied.
    For now, I'm waiting to see if Docker will provide support for distribution-spec API's or at least provide tokens that can be used to manage images.
@@ -104,7 +104,7 @@ The following functions have been added in addition to the defaults available in
    Similar API and Token fields are available in regbot, but this remains experimental.
    Note that no other APIs are currently expected to work against `hub.docker.com`, query `docker.io` for the tag list and inspecting images.
 
-3. Q: Can I use docker credential helpers?
+1. Q: Can I use docker credential helpers?
 
    A: If your `$HOME/.docker/config.json` includes a section like the following:
 
@@ -121,3 +121,17 @@ The following functions have been added in addition to the defaults available in
    Note that the `gcloud` helper is not included since it results in a significant increase in the alpine image size (40M vs over 500M).
    Instead you can switch to `gcr` and copy your key to `$HOME/.config/gcloud/application_default_credentials.json`.
    For more details on the gcr helper, see <https://github.com/GoogleCloudPlatform/docker-credential-gcr>.
+
+1. Q: Actions against multiple `gcr.io` repositories fail with authentication errors.
+
+   A: Authentication on `gcr.io` does not handle multiple scopes like other registries do.
+   This can be solved to limiting the authentication to a single since repository on those registries.
+   Set the `repoAuth` flag to true in yaml configurations to enable this:
+
+   ```yaml
+   creds:
+   - registry: gcr.io
+     repoAuth: true
+   ```
+
+   For `regctl`, use `regctl registry set --repo-auth gcr.io`.

--- a/docs/regbot.md
+++ b/docs/regbot.md
@@ -118,6 +118,10 @@ scripts:
   - `priority`:
     Non-negative integer priority used for sorting mirrors.
     This defaults to 0.
+  - `repoAuth`:
+    Configures authentication requests per repository instead of for the registry.
+    This is required for some registry providers, specifically `gcr.io`.
+    This defaults to `false`.
   - `blobChunk`:
     Chunk size for pushing blobs.
     Each chunk is a separate http request, incurring network overhead.

--- a/docs/regsync.md
+++ b/docs/regsync.md
@@ -128,6 +128,10 @@ sync:
   - `priority`:
     Non-negative integer priority used for sorting mirrors.
     This defaults to 0.
+  - `repoAuth`:
+    Configures authentication requests per repository instead of for the registry.
+    This is required for some registry providers, specifically `gcr.io`.
+    This defaults to `false`.
   - `blobChunk`:
     Chunk size for pushing blobs.
     Each chunk is a separate http request, incurring network overhead.

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -1,6 +1,16 @@
 package auth
 
-import "testing"
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/regclient/regclient/internal/reqresp"
+)
 
 func TestParseAuthHeader(t *testing.T) {
 	var tests = []struct {
@@ -69,4 +79,212 @@ func TestParseAuthHeader(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestAuth checks the auth interface using a mock http server
+func TestAuth(t *testing.T) {
+	token1Resp, _ := json.Marshal(BearerToken{
+		Token:     "token1",
+		ExpiresIn: 900,
+		IssuedAt:  time.Now(),
+		Scope:     "repository:reponame:pull",
+	})
+	token2Resp, _ := json.Marshal(BearerToken{
+		Token:     "token2",
+		ExpiresIn: 900,
+		IssuedAt:  time.Now(),
+		Scope:     "repository:reponame:pull,push",
+	})
+	rrs := []reqresp.ReqResp{
+		{
+			ReqEntry: reqresp.ReqEntry{
+				Name:   "req token1",
+				Method: "POST",
+				Path:   "/token1",
+			},
+			RespEntry: reqresp.RespEntry{
+				Status: 200,
+				Body:   token1Resp,
+			},
+		},
+		{
+			ReqEntry: reqresp.ReqEntry{
+				Name:   "req token2 POST",
+				Method: "POST",
+				Path:   "/token2",
+			},
+			RespEntry: reqresp.RespEntry{
+				Status: http.StatusNotFound,
+			},
+		},
+		{
+			ReqEntry: reqresp.ReqEntry{
+				Name:   "req token2 GET",
+				Method: "GET",
+				Path:   "/token2",
+				Headers: http.Header{
+					"Authorization": {"Basic dXNlcjpwYXNz"},
+				},
+				Query: map[string][]string{
+					"scope": {"repository:reponame:pull,push"},
+				},
+			},
+			RespEntry: reqresp.RespEntry{
+				Status: 200,
+				Body:   token2Resp,
+			},
+		},
+	}
+	ts := httptest.NewServer(reqresp.NewHandler(t, rrs))
+	defer ts.Close()
+	tsURL, _ := url.Parse(ts.URL)
+	tsHost := tsURL.Host
+
+	tests := []struct {
+		name           string
+		auth           Auth
+		addScopeHost   string
+		addScopeScope  string
+		handleResponse *http.Response
+		handleRequest  *http.Request
+		wantErrScope   error
+		wantErrResp    error
+		wantErrReq     error
+		wantAuthHeader string
+	}{
+		{
+			name: "empty",
+			auth: NewAuth(),
+			handleResponse: &http.Response{
+				Request: &http.Request{
+					URL: tsURL,
+				},
+				StatusCode: http.StatusUnauthorized,
+				Header: http.Header{
+					"WWW-Authenticate": []string{},
+				},
+			},
+			wantErrResp: ErrEmptyChallenge,
+		},
+		{
+			name: "basic",
+			auth: NewAuth(
+				WithCreds(func(s string) Cred {
+					return Cred{User: "user", Password: "pass"}
+				}),
+			),
+			handleResponse: &http.Response{
+				Request: &http.Request{
+					URL: tsURL,
+				},
+				StatusCode: http.StatusUnauthorized,
+				Header: http.Header{
+					http.CanonicalHeaderKey("WWW-Authenticate"): []string{`Basic realm="test server"`},
+				},
+			},
+			handleRequest: &http.Request{
+				URL:    tsURL,
+				Header: http.Header{},
+			},
+			wantAuthHeader: "Basic dXNlcjpwYXNz",
+		},
+		{
+			name: "bearer1",
+			auth: NewAuth(
+				WithCreds(func(s string) Cred {
+					return Cred{User: "user", Password: "pass"}
+				}),
+			),
+			handleResponse: &http.Response{
+				Request: &http.Request{
+					URL: tsURL,
+				},
+				StatusCode: http.StatusUnauthorized,
+				Header: http.Header{
+					http.CanonicalHeaderKey("WWW-Authenticate"): []string{
+						`Bearer realm="` + tsURL.String() + `/token1",service="` + tsHost + `",scope="repository:reponame:pull"`,
+					},
+				},
+			},
+			handleRequest: &http.Request{
+				URL:    tsURL,
+				Header: http.Header{},
+			},
+			wantAuthHeader: "Bearer token1",
+		},
+		{
+			name: "bearer2",
+			auth: NewAuth(
+				WithCreds(func(s string) Cred {
+					return Cred{User: "user", Password: "pass"}
+				}),
+			),
+			handleResponse: &http.Response{
+				Request: &http.Request{
+					URL: tsURL,
+				},
+				StatusCode: http.StatusUnauthorized,
+				Header: http.Header{
+					http.CanonicalHeaderKey("WWW-Authenticate"): []string{
+						`Bearer realm="` + tsURL.String() + `/token2",service="` + tsHost + `",scope="repository:reponame:pull"`,
+					},
+				},
+			},
+			addScopeHost:  tsHost,
+			addScopeScope: "repository:reponame:pull,push",
+			handleRequest: &http.Request{
+				URL:    tsURL,
+				Header: http.Header{},
+			},
+			wantAuthHeader: "Bearer token2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.handleResponse != nil {
+				err := tt.auth.HandleResponse(tt.handleResponse)
+				if tt.wantErrResp != nil {
+					if err == nil {
+						t.Errorf("HandleResponse did not receive error")
+					} else if !errors.Is(err, tt.wantErrResp) && err.Error() != tt.wantErrResp.Error() {
+						t.Errorf("HandleResponse unexpected error, expected %v, received %v", tt.wantErrResp, err)
+					}
+				} else if err != nil {
+					t.Errorf("HandleResponse error: %v", err)
+				}
+			}
+			if tt.addScopeScope != "" {
+				err := tt.auth.AddScope(tt.addScopeHost, tt.addScopeScope)
+				if tt.wantErrScope != nil {
+					if err == nil {
+						t.Errorf("AddScope did not receive error")
+					} else if !errors.Is(err, tt.wantErrScope) && err.Error() != tt.wantErrScope.Error() {
+						t.Errorf("AddScope unexpected error, expected %v, received %v", tt.wantErrScope, err)
+					}
+				} else if err != nil {
+					t.Errorf("AddScope error: %v", err)
+				}
+			}
+			if tt.handleRequest != nil {
+				err := tt.auth.UpdateRequest(tt.handleRequest)
+				if tt.wantErrReq != nil {
+					if err == nil {
+						t.Errorf("UpdateRequest did not receive error")
+					} else if !errors.Is(err, tt.wantErrReq) && err.Error() != tt.wantErrReq.Error() {
+						t.Errorf("UpdateRequest unexpected error, expected %v, received %v", tt.wantErrReq, err)
+					}
+				} else if err != nil {
+					t.Errorf("UpdateRequest error: %v", err)
+				}
+			}
+			if tt.wantAuthHeader != "" && tt.handleRequest != nil {
+				ah := tt.handleRequest.Header.Get("Authorization")
+				if ah != tt.wantAuthHeader {
+					t.Errorf("Authorization header, expected %s, received %s", tt.wantAuthHeader, ah)
+				}
+			}
+		})
+	}
+
 }

--- a/regclient.go
+++ b/regclient.go
@@ -171,6 +171,7 @@ func WithConfigHosts(configHosts []config.Host) Opt {
 				"name":       configHost.Name,
 				"user":       configHost.User,
 				"hostname":   configHost.Hostname,
+				"repoAuth":   configHost.RepoAuth,
 				"tls":        string(tls),
 				"pathPrefix": configHost.PathPrefix,
 				"mirrors":    configHost.Mirrors,


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Fixes #149 
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This adds a new `repoAuth` option (`repo-auth` in regctl) to setup a separate auth per repository instead of for the entire registry.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Use regsync to concurrently copy multiple repositories. Without the `repoAuth` option, it will fail:

```yaml
version: 1
creds:
  - registry: gcr.io
    repoAuth: true
  - registry: docker.io
defaults:
  ratelimit:
    min: 50
    retry: 15m
  parallel: 2
  interval: 30m
  backup: "bkup-{{.Ref.Tag}}"
sync:
  - source: "regclient/regctl:edge"
    target: "gcr.io/project-name/regctl:edge"
    type: image
  - source: "regclient/regsync:edge"
    target: "gcr.io/project-name/regsync:edge"
    type: image
```

<!-- Include steps that can be taken to verify the change -->

### Changelog text

Added repoAuth option for gcr.io support.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added
- [X] Documentation has been added or updated
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
