### PR TITLE
regctl defaults to manifest list

### DIFF
--- a/cmd/regctl/image.go
+++ b/cmd/regctl/image.go
@@ -115,22 +115,24 @@ func init() {
 
 	imageDeleteCmd.Flags().BoolVarP(&manifestOpts.forceTagDeref, "force-tag-dereference", "", false, "Dereference the a tag to a digest, this is unsafe")
 
-	imageDigestCmd.Flags().BoolVarP(&manifestOpts.list, "list", "", false, "Do not resolve platform from manifest list (recommended)")
-	imageDigestCmd.Flags().StringVarP(&manifestOpts.platform, "platform", "p", "", "Specify platform (e.g. linux/amd64)")
+	imageDigestCmd.Flags().BoolVarP(&manifestOpts.list, "list", "", true, "Do not resolve platform from manifest list (enabled by default)")
+	imageDigestCmd.Flags().StringVarP(&manifestOpts.platform, "platform", "p", "", "Specify platform (e.g. linux/amd64 or local)")
 	imageDigestCmd.Flags().BoolVarP(&manifestOpts.requireList, "require-list", "", false, "Fail if manifest list is not received")
 	imageDigestCmd.RegisterFlagCompletionFunc("platform", completeArgPlatform)
+	imageDigestCmd.Flags().MarkHidden("list")
 
-	imageInspectCmd.Flags().StringVarP(&imageOpts.platform, "platform", "p", "", "Specify platform (e.g. linux/amd64)")
+	imageInspectCmd.Flags().StringVarP(&imageOpts.platform, "platform", "p", "", "Specify platform (e.g. linux/amd64 or local)")
 	imageInspectCmd.Flags().StringVarP(&imageOpts.format, "format", "", "{{printPretty .}}", "Format output with go template syntax")
 	imageInspectCmd.RegisterFlagCompletionFunc("platform", completeArgPlatform)
 	imageInspectCmd.RegisterFlagCompletionFunc("format", completeArgNone)
 
-	imageManifestCmd.Flags().BoolVarP(&manifestOpts.list, "list", "", false, "Output manifest list if available")
-	imageManifestCmd.Flags().StringVarP(&manifestOpts.platform, "platform", "p", "", "Specify platform (e.g. linux/amd64)")
+	imageManifestCmd.Flags().BoolVarP(&manifestOpts.list, "list", "", true, "Output manifest list if available (enabled by default)")
+	imageManifestCmd.Flags().StringVarP(&manifestOpts.platform, "platform", "p", "", "Specify platform (e.g. linux/amd64 or local)")
 	imageManifestCmd.Flags().BoolVarP(&manifestOpts.requireList, "require-list", "", false, "Fail if manifest list is not received")
 	imageManifestCmd.Flags().StringVarP(&manifestOpts.format, "format", "", "{{printPretty .}}", "Format output with go template syntax")
 	imageManifestCmd.RegisterFlagCompletionFunc("platform", completeArgPlatform)
 	imageManifestCmd.RegisterFlagCompletionFunc("format", completeArgNone)
+	imageManifestCmd.Flags().MarkHidden("list")
 
 	imageRateLimitCmd.Flags().StringVarP(&imageOpts.format, "format", "", "{{printPretty .}}", "Format output with go template syntax")
 	imageRateLimitCmd.RegisterFlagCompletionFunc("format", completeArgNone)
@@ -240,7 +242,11 @@ func runImageInspect(cmd *cobra.Command, args []string) error {
 	}).Debug("Image inspect")
 
 	manifestOpts.platform = imageOpts.platform
-	m, err := getManifest(rc, r)
+	if !flagChanged(cmd, "list") {
+		manifestOpts.list = false
+	}
+
+	m, err := getManifest(ctx, rc, r)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Requiring `--list` on manifest digest and get commands could be confusing and hide multi-platform images. This defaults to list being enabled, and users can provide `--platform local` to resolve their local environment (or use `--list=false`).
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

The following now default to returning the manifest and digest of the list for multi-platform images:

```shell
regctl image digest
regctl image get
regctl manifest digest
regctl manifest get
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Default to displaying manifest lists in regctl
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [ ] Tests have been added or not applicable
- [ ] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
