### PR TITLE
Ref should to store original value

### DIFF
--- a/types/ref/ref.go
+++ b/types/ref/ref.go
@@ -79,13 +79,12 @@ func New(parse string) (Ref, error) {
 			}
 			return Ref{}, fmt.Errorf("invalid reference \"%s\"", path)
 		}
-		ret = Ref{
-			Scheme:     "reg",
-			Registry:   matchRef[1],
-			Repository: matchRef[2],
-			Tag:        matchRef[3],
-			Digest:     matchRef[4],
-		}
+		ret.Registry = matchRef[1]
+		ret.Repository = matchRef[2]
+		ret.Tag = matchRef[3]
+		ret.Digest = matchRef[4]
+
+		// handle localhost use case since it matches the regex for a repo path entry
 		repoPath := strings.Split(ret.Repository, "/")
 		if ret.Registry == "" && repoPath[0] == "localhost" {
 			ret.Registry = repoPath[0]

--- a/types/ref/ref_test.go
+++ b/types/ref/ref_test.go
@@ -343,6 +343,9 @@ func TestRef(t *testing.T) {
 			} else if tt.wantE != nil {
 				return
 			}
+			if tt.ref != ref.Reference {
+				t.Errorf("reference mismatch for %s, received %s", tt.ref, ref.Reference)
+			}
 			if tt.scheme != ref.Scheme {
 				t.Errorf("scheme mismatch for %s, expected %s, received %s", tt.ref, tt.scheme, ref.Scheme)
 			}


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

After reworking the Ref parsing for registry types, the original reference was not stored. Fix fixes the issue.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Do not replace the ref struct being returned, instead edit the struct.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

`regctl manifest get` on a manifest list will show the original name.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
