### PR TITLE
Adding a pretty printer for image manifests

### DIFF
--- a/internal/units/size.go
+++ b/internal/units/size.go
@@ -1,0 +1,123 @@
+// Package units is copied from https://github.com/docker/go-units
+package units
+
+// Copyright 2015 Docker, Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+// 		https://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// See: http://en.wikipedia.org/wiki/Binary_prefix
+const (
+	// Decimal
+
+	KB = 1000
+	MB = 1000 * KB
+	GB = 1000 * MB
+	TB = 1000 * GB
+	PB = 1000 * TB
+
+	// Binary
+
+	KiB = 1024
+	MiB = 1024 * KiB
+	GiB = 1024 * MiB
+	TiB = 1024 * GiB
+	PiB = 1024 * TiB
+)
+
+type unitMap map[string]int64
+
+var (
+	decimalMap = unitMap{"k": KB, "m": MB, "g": GB, "t": TB, "p": PB}
+	binaryMap  = unitMap{"k": KiB, "m": MiB, "g": GiB, "t": TiB, "p": PiB}
+	sizeRegex  = regexp.MustCompile(`^(\d+(\.\d+)*) ?([kKmMgGtTpP])?[iI]?[bB]?$`)
+)
+
+var decimapAbbrs = []string{"B", "kB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"}
+var binaryAbbrs = []string{"B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB"}
+
+func getSizeAndUnit(size float64, base float64, _map []string) (float64, string) {
+	i := 0
+	unitsLimit := len(_map) - 1
+	for size >= base && i < unitsLimit {
+		size = size / base
+		i++
+	}
+	return size, _map[i]
+}
+
+// CustomSize returns a human-readable approximation of a size
+// using custom format.
+func CustomSize(format string, size float64, base float64, _map []string) string {
+	size, unit := getSizeAndUnit(size, base, _map)
+	return fmt.Sprintf(format, size, unit)
+}
+
+// HumanSizeWithPrecision allows the size to be in any precision,
+// instead of 4 digit precision used in units.HumanSize.
+func HumanSizeWithPrecision(size float64, precision int) string {
+	size, unit := getSizeAndUnit(size, 1000.0, decimapAbbrs)
+	return fmt.Sprintf("%.*g%s", precision, size, unit)
+}
+
+// HumanSize returns a human-readable approximation of a size
+// capped at 4 valid numbers (eg. "2.746 MB", "796 KB").
+func HumanSize(size float64) string {
+	return HumanSizeWithPrecision(size, 4)
+}
+
+// BytesSize returns a human-readable size in bytes, kibibytes,
+// mebibytes, gibibytes, or tebibytes (eg. "44kiB", "17MiB").
+func BytesSize(size float64) string {
+	return CustomSize("%.4g%s", size, 1024.0, binaryAbbrs)
+}
+
+// FromHumanSize returns an integer from a human-readable specification of a
+// size using SI standard (eg. "44kB", "17MB").
+func FromHumanSize(size string) (int64, error) {
+	return parseSize(size, decimalMap)
+}
+
+// RAMInBytes parses a human-readable string representing an amount of RAM
+// in bytes, kibibytes, mebibytes, gibibytes, or tebibytes and
+// returns the number of bytes, or -1 if the string is unparseable.
+// Units are case-insensitive, and the 'b' suffix is optional.
+func RAMInBytes(size string) (int64, error) {
+	return parseSize(size, binaryMap)
+}
+
+// Parses the human-readable size string into the amount it represents.
+func parseSize(sizeStr string, uMap unitMap) (int64, error) {
+	matches := sizeRegex.FindStringSubmatch(sizeStr)
+	if len(matches) != 4 {
+		return -1, fmt.Errorf("invalid size: '%s'", sizeStr)
+	}
+
+	size, err := strconv.ParseFloat(matches[1], 64)
+	if err != nil {
+		return -1, err
+	}
+
+	unitPrefix := strings.ToLower(matches[3])
+	if mul, ok := uMap[unitPrefix]; ok {
+		size *= float64(mul)
+	}
+
+	return int64(size), nil
+}

--- a/types/descriptor.go
+++ b/types/descriptor.go
@@ -1,7 +1,12 @@
 package types
 
 import (
+	"fmt"
+	"strings"
+	"text/tabwriter"
+
 	"github.com/opencontainers/go-digest"
+	"github.com/regclient/regclient/internal/units"
 	"github.com/regclient/regclient/types/platform"
 )
 
@@ -25,4 +30,40 @@ type Descriptor struct {
 	// Platform describes the platform which the image in the manifest runs on.
 	// This should only be used when referring to a manifest.
 	Platform *platform.Platform `json:"platform,omitempty"`
+}
+
+func (d Descriptor) MarshalPrettyTW(tw *tabwriter.Writer, prefix string) error {
+	fmt.Fprintf(tw, "%sDigest:\t%s\n", prefix, string(d.Digest))
+	fmt.Fprintf(tw, "%sMediaType:\t%s\n", prefix, d.MediaType)
+	switch d.MediaType {
+	case MediaTypeDocker1Manifest, MediaTypeDocker1ManifestSigned,
+		MediaTypeDocker2Manifest, MediaTypeDocker2ManifestList,
+		MediaTypeOCI1Manifest, MediaTypeOCI1ManifestList:
+		// skip printing size for descriptors to manifests
+	default:
+		if d.Size > 100000 {
+			fmt.Fprintf(tw, "%sSize:\t%s\n", prefix, units.HumanSize(float64(d.Size)))
+		} else {
+			fmt.Fprintf(tw, "%sSize:\t%dB\n", prefix, d.Size)
+		}
+	}
+	if p := d.Platform; p != nil && p.OS != "" {
+		fmt.Fprintf(tw, "%sPlatform:\t%s\n", prefix, p.String())
+		if p.OSVersion != "" {
+			fmt.Fprintf(tw, "%sOSVersion:\t%s\n", prefix, p.OSVersion)
+		}
+		if len(p.OSFeatures) > 0 {
+			fmt.Fprintf(tw, "%sOSFeatures:\t%s\n", prefix, strings.Join(p.OSFeatures, ", "))
+		}
+	}
+	if len(d.URLs) > 0 {
+		fmt.Fprintf(tw, "%sURLs:\t%s\n", prefix, strings.Join(d.URLs, ", "))
+	}
+	if d.Annotations != nil {
+		fmt.Fprintf(tw, "%sAnnotations:\t\n", prefix)
+		for k, v := range d.Annotations {
+			fmt.Fprintf(tw, "%s  %s:\t%s\n", prefix, k, v)
+		}
+	}
+	return nil
 }

--- a/types/manifest/docker2.go
+++ b/types/manifest/docker2.go
@@ -4,10 +4,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"strings"
 	"text/tabwriter"
 
 	digest "github.com/opencontainers/go-digest"
+	"github.com/regclient/regclient/internal/units"
 	"github.com/regclient/regclient/internal/wraperr"
 	"github.com/regclient/regclient/types"
 	"github.com/regclient/regclient/types/docker/schema2"
@@ -106,11 +106,37 @@ func (m *docker2ManifestList) MarshalJSON() ([]byte, error) {
 }
 
 func (m *docker2Manifest) MarshalPretty() ([]byte, error) {
+	if m == nil {
+		return []byte{}, nil
+	}
 	buf := &bytes.Buffer{}
-	enc := json.NewEncoder(buf)
-	enc.SetEscapeHTML(false)
-	enc.SetIndent("", "  ")
-	enc.Encode(m.Manifest)
+	tw := tabwriter.NewWriter(buf, 0, 0, 1, ' ', 0)
+	if m.r.Reference != "" {
+		fmt.Fprintf(tw, "Name:\t%s\n", m.r.Reference)
+	}
+	fmt.Fprintf(tw, "MediaType:\t%s\n", m.desc.MediaType)
+	fmt.Fprintf(tw, "Digest:\t%s\n", m.desc.Digest.String())
+	var total int64
+	for _, d := range m.Layers {
+		total += d.Size
+	}
+	fmt.Fprintf(tw, "Total Size:\t%s\n", units.HumanSize(float64(total)))
+	fmt.Fprintf(tw, "\t\n")
+	fmt.Fprintf(tw, "Config:\t\n")
+	err := m.Config.MarshalPrettyTW(tw, "  ")
+	if err != nil {
+		return []byte{}, err
+	}
+	fmt.Fprintf(tw, "\t\n")
+	fmt.Fprintf(tw, "Layers:\t\n")
+	for _, d := range m.Layers {
+		fmt.Fprintf(tw, "\t\n")
+		err := d.MarshalPrettyTW(tw, "  ")
+		if err != nil {
+			return []byte{}, err
+		}
+	}
+	tw.Flush()
 	return buf.Bytes(), nil
 }
 func (m *docker2ManifestList) MarshalPretty() ([]byte, error) {
@@ -132,27 +158,10 @@ func (m *docker2ManifestList) MarshalPretty() ([]byte, error) {
 		if dRef.Reference != "" {
 			dRef.Digest = d.Digest.String()
 			fmt.Fprintf(tw, "  Name:\t%s\n", dRef.CommonName())
-		} else {
-			fmt.Fprintf(tw, "  Digest:\t%s\n", string(d.Digest))
 		}
-		fmt.Fprintf(tw, "  MediaType:\t%s\n", d.MediaType)
-		if p := d.Platform; p.OS != "" {
-			fmt.Fprintf(tw, "  Platform:\t%s\n", p.String())
-			if p.OSVersion != "" {
-				fmt.Fprintf(tw, "  OSVersion:\t%s\n", p.OSVersion)
-			}
-			if len(p.OSFeatures) > 0 {
-				fmt.Fprintf(tw, "  OSFeatures:\t%s\n", strings.Join(p.OSFeatures, ", "))
-			}
-		}
-		if len(d.URLs) > 0 {
-			fmt.Fprintf(tw, "  URLs:\t%s\n", strings.Join(d.URLs, ", "))
-		}
-		if d.Annotations != nil {
-			fmt.Fprintf(tw, "  Annotations:\t\n")
-			for k, v := range d.Annotations {
-				fmt.Fprintf(tw, "    %s:\t%s\n", k, v)
-			}
+		err := d.MarshalPrettyTW(tw, "  ")
+		if err != nil {
+			return []byte{}, err
 		}
 	}
 	tw.Flush()

--- a/types/manifest/manifest_test.go
+++ b/types/manifest/manifest_test.go
@@ -514,6 +514,15 @@ func TestNew(t *testing.T) {
 				t.Errorf("failed running New: %v", err)
 				return
 			}
+			mp, ok := m.(interface{ MarshalPretty() ([]byte, error) })
+			if ok {
+				pretty, err := mp.MarshalPretty()
+				if err != nil {
+					t.Errorf("marshal pretty: %v", err)
+				} else {
+					t.Logf("marshal pretty:\n%s", string(pretty))
+				}
+			}
 			if tt.wantR.Scheme != "" && m.GetRef().CommonName() != tt.wantR.CommonName() {
 				t.Errorf("ref mismatch, expected %s, received %s", tt.wantR.CommonName(), m.GetRef().CommonName())
 			}


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This adds a pretty printer for image manifests.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
$ regctl manifest get --platform local regclient/regctl:latest
Name:        regclient/regctl:latest
MediaType:   application/vnd.docker.distribution.manifest.v2+json
Digest:      sha256:41770c110431b0ffc5f577aa44968bfbfd79e92eb0929e37f006179fd4aeddcc
Total Size:  3.67MB
             
Config:      
  Digest:    sha256:3615d1937a8fe8708e041e94f4abb544196380e12628bacdcde0a7eaf1a693ba
  MediaType: application/vnd.docker.container.image.v1+json
  Size:      3024B
             
Layers:      
             
  Digest:    sha256:f6e2d7fa40092cf3d9817bf6ff54183d68d108a47fdf5a5e476c612626c80e14
  MediaType: application/vnd.docker.image.rootfs.diff.tar.gzip
  Size:      941B
             
  Digest:    sha256:92365f35877078c3e558e9a66ac083fe9a8d44bdb3150bdac058380054b05972
  MediaType: application/vnd.docker.image.rootfs.diff.tar.gzip
  Size:      122.4kB
             
  Digest:    sha256:fa98de7a23a1c3debba4398c982decfd8b31bcfad1ac6e5e7d800375cefbd42f
  MediaType: application/vnd.docker.image.rootfs.diff.tar.gzip
  Size:      146B
             
  Digest:    sha256:03b338938455d6f6e4b92abc8076f24a8e88a9c87afdb9066ebabf81bda93670
  MediaType: application/vnd.docker.image.rootfs.diff.tar.gzip
  Size:      3.546MB
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Image manifests now display with a pretty printer by default.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
