### PR TITLE
Allow overriding the user-agent

### DIFF
--- a/cmd/regbot/config.go
+++ b/cmd/regbot/config.go
@@ -66,6 +66,7 @@ type ConfigDefaults struct {
 	Parallel       int           `yaml:"parallel" json:"parallel"`
 	SkipDockerConf bool          `yaml:"skipDockerConfig" json:"skipDockerConfig"`
 	Timeout        time.Duration `yaml:"timeout" json:"timeout"`
+	UserAgent      string        `yaml:"userAgent" json:"userAgent"`
 }
 
 // ConfigScript defines a source/target repository to sync

--- a/cmd/regbot/root.go
+++ b/cmd/regbot/root.go
@@ -264,7 +264,9 @@ func loadConf() error {
 	rcOpts := []regclient.Opt{
 		regclient.WithLog(log),
 	}
-	if VCSTag != "" {
+	if conf.Defaults.UserAgent != "" {
+		rcOpts = append(rcOpts, regclient.WithUserAgent(conf.Defaults.UserAgent))
+	} else if VCSTag != "" {
 		rcOpts = append(rcOpts, regclient.WithUserAgent(UserAgent+" ("+VCSTag+")"))
 	} else if VCSRef != "" {
 		rcOpts = append(rcOpts, regclient.WithUserAgent(UserAgent+" ("+VCSRef+")"))

--- a/cmd/regctl/root.go
+++ b/cmd/regctl/root.go
@@ -52,6 +52,7 @@ var rootOpts struct {
 	verbosity string
 	logopts   []string
 	format    string // for Go template formatting of various commands
+	userAgent string
 }
 
 func init() {
@@ -65,6 +66,8 @@ func init() {
 
 	rootCmd.PersistentFlags().StringVarP(&rootOpts.verbosity, "verbosity", "v", logrus.WarnLevel.String(), "Log level (debug, info, warn, error, fatal, panic)")
 	rootCmd.PersistentFlags().StringArrayVar(&rootOpts.logopts, "logopt", []string{}, "Log options")
+	rootCmd.PersistentFlags().StringVarP(&rootOpts.userAgent, "user-agent", "", "", "Override user agent")
+
 	rootCmd.RegisterFlagCompletionFunc("verbosity", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"debug", "info", "warn", "error", "fatal", "panic"}, cobra.ShellCompDirectiveNoFileComp
 	})
@@ -113,7 +116,9 @@ func newRegClient() *regclient.RegClient {
 	rcOpts := []regclient.Opt{
 		regclient.WithLog(log),
 	}
-	if VCSTag != "" {
+	if rootOpts.userAgent != "" {
+		rcOpts = append(rcOpts, regclient.WithUserAgent(rootOpts.userAgent))
+	} else if VCSTag != "" {
 		rcOpts = append(rcOpts, regclient.WithUserAgent(UserAgent+" ("+VCSTag+")"))
 	} else if VCSRef != "" {
 		rcOpts = append(rcOpts, regclient.WithUserAgent(UserAgent+" ("+VCSRef+")"))

--- a/cmd/regsync/config.go
+++ b/cmd/regsync/config.go
@@ -85,6 +85,7 @@ type ConfigDefaults struct {
 	MediaTypes     []string        `yaml:"mediaTypes" json:"mediaTypes"`
 	SkipDockerConf bool            `yaml:"skipDockerConfig" json:"skipDockerConfig"`
 	Hooks          ConfigHooks     `yaml:"hooks" json:"hooks"`
+	UserAgent      string          `yaml:"userAgent" json:"userAgent"`
 }
 
 // ConfigRateLimit is for rate limit settings

--- a/cmd/regsync/root.go
+++ b/cmd/regsync/root.go
@@ -311,7 +311,9 @@ func loadConf() error {
 	rcOpts := []regclient.Opt{
 		regclient.WithLog(log),
 	}
-	if VCSTag != "" {
+	if conf.Defaults.UserAgent != "" {
+		rcOpts = append(rcOpts, regclient.WithUserAgent(conf.Defaults.UserAgent))
+	} else if VCSTag != "" {
 		rcOpts = append(rcOpts, regclient.WithUserAgent(UserAgent+" ("+VCSTag+")"))
 	} else if VCSRef != "" {
 		rcOpts = append(rcOpts, regclient.WithUserAgent(UserAgent+" ("+VCSRef+")"))

--- a/docs/regbot.md
+++ b/docs/regbot.md
@@ -146,6 +146,8 @@ scripts:
     This timeout is enforced when calling various actions like an image copy.
   - `skipDockerConfig`:
     Do not read the user credentials in `${HOME}/.docker/config.json`.
+  - `userAgent`:
+    Override the user-agent for http requests.
 
 - `scripts`:
   Array of Lua scripts to run.

--- a/docs/regsync.md
+++ b/docs/regsync.md
@@ -172,6 +172,8 @@ sync:
     Defaults to: `["application/vnd.docker.distribution.manifest.v2+json", "application/vnd.docker.distribution.manifest.list.v2+json", "application/vnd.oci.image.manifest.v1+json", "application/vnd.oci.image.index.v1+json"]`
   - `skipDockerConfig`:
     Do not read the user credentials in `${HOME}/.docker/config.json`.
+  - `userAgent`:
+    Override the user-agent for http requests.
 
 - `sync`:
   Array of steps to run for copying images from the source to target repository.


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Fixes #145
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This adds options to override the user-agent header in `regctl`, `regsync`, and `regbot`.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

For `regctl`: `regctl --user-agent override/value ...`

For `regsync` and `regbot`:

```
defaults:
  userAgent: "override/value"
...
```

<!-- Include steps that can be taken to verify the change -->

### Changelog text

Allow the user-agent to be overridden.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [ ] Tests have been added or not applicable
- [x] Documentation has been added, updated, or not applicable
- [x] Changes have been rebased to main
- [x] Multiple commits to the same code have been squashed
