### PR TITLE
Updating blob methods to use descriptors

### DIFF
--- a/blob.go
+++ b/blob.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/opencontainers/go-digest"
+	"github.com/regclient/regclient/types"
 	"github.com/regclient/regclient/types/blob"
 	"github.com/regclient/regclient/types/ref"
 	"github.com/sirupsen/logrus"
@@ -13,13 +13,13 @@ import (
 // BlobCopy copies a blob between two locations
 // If the blob already exists in the target, the copy is skipped
 // A server side cross repository blob mount is attempted
-func (rc *RegClient) BlobCopy(ctx context.Context, refSrc ref.Ref, refTgt ref.Ref, d digest.Digest) error {
+func (rc *RegClient) BlobCopy(ctx context.Context, refSrc ref.Ref, refTgt ref.Ref, d types.Descriptor) error {
 	// for the same repository, there's nothing to copy
 	if ref.EqualRepository(refSrc, refTgt) {
 		rc.log.WithFields(logrus.Fields{
 			"src":    refTgt.Reference,
 			"tgt":    refTgt.Reference,
-			"digest": d,
+			"digest": d.Digest,
 		}).Debug("Blob copy skipped, same repo")
 		return nil
 	}
@@ -59,7 +59,7 @@ func (rc *RegClient) BlobCopy(ctx context.Context, refSrc ref.Ref, refTgt ref.Re
 		return err
 	}
 	defer blobIO.Close()
-	if _, _, err := rc.BlobPut(ctx, refTgt, d, blobIO, blobIO.GetDescriptor().Size); err != nil {
+	if _, err := rc.BlobPut(ctx, refTgt, blobIO.GetDescriptor(), blobIO); err != nil {
 		rc.log.WithFields(logrus.Fields{
 			"err": err,
 			"src": refSrc.Reference,
@@ -73,7 +73,7 @@ func (rc *RegClient) BlobCopy(ctx context.Context, refSrc ref.Ref, refTgt ref.Re
 // BlobDelete removes a blob from the registry
 // This method should only be used to repair a damaged registry
 // Typically a server side garbage collection should be used to purge unused blobs
-func (rc *RegClient) BlobDelete(ctx context.Context, r ref.Ref, d digest.Digest) error {
+func (rc *RegClient) BlobDelete(ctx context.Context, r ref.Ref, d types.Descriptor) error {
 	schemeAPI, err := rc.schemeGet(r.Scheme)
 	if err != nil {
 		return err
@@ -82,7 +82,7 @@ func (rc *RegClient) BlobDelete(ctx context.Context, r ref.Ref, d digest.Digest)
 }
 
 // BlobGet retrieves a blob, returning a reader
-func (rc *RegClient) BlobGet(ctx context.Context, r ref.Ref, d digest.Digest) (blob.Reader, error) {
+func (rc *RegClient) BlobGet(ctx context.Context, r ref.Ref, d types.Descriptor) (blob.Reader, error) {
 	schemeAPI, err := rc.schemeGet(r.Scheme)
 	if err != nil {
 		return nil, err
@@ -91,7 +91,7 @@ func (rc *RegClient) BlobGet(ctx context.Context, r ref.Ref, d digest.Digest) (b
 }
 
 // BlobGetOCIConfig retrieves an OCI config from a blob, automatically extracting the JSON
-func (rc *RegClient) BlobGetOCIConfig(ctx context.Context, ref ref.Ref, d digest.Digest) (blob.OCIConfig, error) {
+func (rc *RegClient) BlobGetOCIConfig(ctx context.Context, ref ref.Ref, d types.Descriptor) (blob.OCIConfig, error) {
 	b, err := rc.BlobGet(ctx, ref, d)
 	if err != nil {
 		return nil, err
@@ -100,7 +100,7 @@ func (rc *RegClient) BlobGetOCIConfig(ctx context.Context, ref ref.Ref, d digest
 }
 
 // BlobHead is used to verify if a blob exists and is accessible
-func (rc *RegClient) BlobHead(ctx context.Context, r ref.Ref, d digest.Digest) (blob.Reader, error) {
+func (rc *RegClient) BlobHead(ctx context.Context, r ref.Ref, d types.Descriptor) (blob.Reader, error) {
 	schemeAPI, err := rc.schemeGet(r.Scheme)
 	if err != nil {
 		return nil, err
@@ -109,7 +109,7 @@ func (rc *RegClient) BlobHead(ctx context.Context, r ref.Ref, d digest.Digest) (
 }
 
 // BlobMount attempts to perform a server side copy/mount of the blob between repositories
-func (rc *RegClient) BlobMount(ctx context.Context, refSrc ref.Ref, refTgt ref.Ref, d digest.Digest) error {
+func (rc *RegClient) BlobMount(ctx context.Context, refSrc ref.Ref, refTgt ref.Ref, d types.Descriptor) error {
 	schemeAPI, err := rc.schemeGet(refSrc.Scheme)
 	if err != nil {
 		return err
@@ -121,10 +121,10 @@ func (rc *RegClient) BlobMount(ctx context.Context, refSrc ref.Ref, refTgt ref.R
 // This will attempt an anonymous blob mount first which some registries may support.
 // It will then try doing a full put of the blob without chunking (most widely supported).
 // If the full put fails, it will fall back to a chunked upload (useful for flaky networks).
-func (rc *RegClient) BlobPut(ctx context.Context, ref ref.Ref, d digest.Digest, rdr io.Reader, cl int64) (digest.Digest, int64, error) {
+func (rc *RegClient) BlobPut(ctx context.Context, ref ref.Ref, d types.Descriptor, rdr io.Reader) (types.Descriptor, error) {
 	schemeAPI, err := rc.schemeGet(ref.Scheme)
 	if err != nil {
-		return "", 0, err
+		return types.Descriptor{}, err
 	}
-	return schemeAPI.BlobPut(ctx, ref, d, rdr, cl)
+	return schemeAPI.BlobPut(ctx, ref, d, rdr)
 }

--- a/blob_test.go
+++ b/blob_test.go
@@ -181,7 +181,7 @@ func TestBlobGet(t *testing.T) {
 		if err != nil {
 			t.Errorf("Failed creating ref: %v", err)
 		}
-		br, err := rc.BlobGet(ctx, ref, d1)
+		br, err := rc.BlobGet(ctx, ref, types.Descriptor{Digest: d1})
 		if err != nil {
 			t.Errorf("Failed running BlobGet: %v", err)
 			return
@@ -202,7 +202,7 @@ func TestBlobGet(t *testing.T) {
 		if err != nil {
 			t.Errorf("Failed creating ref: %v", err)
 		}
-		br, err := rc.BlobHead(ctx, ref, d1)
+		br, err := rc.BlobHead(ctx, ref, types.Descriptor{Digest: d1})
 		if err != nil {
 			t.Errorf("Failed running BlobHead: %v", err)
 			return
@@ -218,7 +218,7 @@ func TestBlobGet(t *testing.T) {
 		if err != nil {
 			t.Errorf("Failed creating ref: %v", err)
 		}
-		br, err := rc.BlobGet(ctx, ref, dMissing)
+		br, err := rc.BlobGet(ctx, ref, types.Descriptor{Digest: dMissing})
 		if err == nil {
 			defer br.Close()
 			t.Errorf("Unexpected success running BlobGet")
@@ -234,7 +234,7 @@ func TestBlobGet(t *testing.T) {
 		if err != nil {
 			t.Errorf("Failed creating ref: %v", err)
 		}
-		br, err := rc.BlobGet(ctx, ref, d2)
+		br, err := rc.BlobGet(ctx, ref, types.Descriptor{Digest: d2})
 		if err != nil {
 			t.Errorf("Failed running BlobGet: %v", err)
 			return
@@ -255,7 +255,7 @@ func TestBlobGet(t *testing.T) {
 		if err != nil {
 			t.Errorf("Failed creating ref: %v", err)
 		}
-		br, err := rc.BlobGet(ctx, ref, d1)
+		br, err := rc.BlobGet(ctx, ref, types.Descriptor{Digest: d1})
 		if err == nil {
 			defer br.Close()
 			t.Errorf("Unexpected success running BlobGet")
@@ -654,16 +654,16 @@ func TestBlobPut(t *testing.T) {
 			t.Errorf("Failed creating ref: %v", err)
 		}
 		br := bytes.NewReader(blob1)
-		dp, clp, err := rc.BlobPut(ctx, ref, d1, br, int64(len(blob1)))
+		dp, err := rc.BlobPut(ctx, ref, types.Descriptor{Digest: d1, Size: int64(len(blob1))}, br)
 		if err != nil {
 			t.Errorf("Failed running BlobPut: %v", err)
 			return
 		}
-		if dp.String() != d1.String() {
-			t.Errorf("Digest mismatch, expected %s, received %s", d1.String(), dp.String())
+		if dp.Digest.String() != d1.String() {
+			t.Errorf("Digest mismatch, expected %s, received %s", d1.String(), dp.Digest.String())
 		}
-		if clp != int64(len(blob1)) {
-			t.Errorf("Content length mismatch, expected %d, received %d", len(blob1), clp)
+		if dp.Size != int64(len(blob1)) {
+			t.Errorf("Content length mismatch, expected %d, received %d", len(blob1), dp.Size)
 		}
 
 	})
@@ -674,16 +674,16 @@ func TestBlobPut(t *testing.T) {
 			t.Errorf("Failed creating ref: %v", err)
 		}
 		br := bytes.NewReader(blob2)
-		dp, clp, err := rc.BlobPut(ctx, ref, d2, br, int64(len(blob2)))
+		dp, err := rc.BlobPut(ctx, ref, types.Descriptor{Digest: d2, Size: int64(len(blob2))}, br)
 		if err != nil {
 			t.Errorf("Failed running BlobPut: %v", err)
 			return
 		}
-		if dp.String() != d2.String() {
-			t.Errorf("Digest mismatch, expected %s, received %s", d2.String(), dp.String())
+		if dp.Digest.String() != d2.String() {
+			t.Errorf("Digest mismatch, expected %s, received %s", d2.String(), dp.Digest.String())
 		}
-		if clp != int64(len(blob2)) {
-			t.Errorf("Content length mismatch, expected %d, received %d", len(blob2), clp)
+		if dp.Size != int64(len(blob2)) {
+			t.Errorf("Content length mismatch, expected %d, received %d", len(blob2), dp.Size)
 		}
 
 	})
@@ -694,16 +694,16 @@ func TestBlobPut(t *testing.T) {
 			t.Errorf("Failed creating ref: %v", err)
 		}
 		br := bytes.NewReader(blob3)
-		dp, clp, err := rc.BlobPut(ctx, ref, d3, br, int64(len(blob3)))
+		dp, err := rc.BlobPut(ctx, ref, types.Descriptor{Digest: d3, Size: int64(len(blob3))}, br)
 		if err != nil {
 			t.Errorf("Failed running BlobPut: %v", err)
 			return
 		}
-		if dp.String() != d3.String() {
-			t.Errorf("Digest mismatch, expected %s, received %s", d3.String(), dp.String())
+		if dp.Digest.String() != d3.String() {
+			t.Errorf("Digest mismatch, expected %s, received %s", d3.String(), dp.Digest.String())
 		}
-		if clp != int64(len(blob3)) {
-			t.Errorf("Content length mismatch, expected %d, received %d", len(blob3), clp)
+		if dp.Size != int64(len(blob3)) {
+			t.Errorf("Content length mismatch, expected %d, received %d", len(blob3), dp.Size)
 		}
 
 	})

--- a/cmd/regbot/sandbox/blob.go
+++ b/cmd/regbot/sandbox/blob.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/opencontainers/go-digest"
+	"github.com/regclient/regclient/types"
 	"github.com/regclient/regclient/types/blob"
 	"github.com/regclient/regclient/types/ref"
 	"github.com/sirupsen/logrus"
@@ -107,7 +108,7 @@ func (s *Sandbox) blobGet(ls *lua.LState) int {
 		"ref":    r.r.CommonName(),
 		"digest": d,
 	}).Debug("Retrieve blob")
-	b, err := s.rc.BlobGet(s.ctx, r.r, digest.Digest(d))
+	b, err := s.rc.BlobGet(s.ctx, r.r, types.Descriptor{Digest: digest.Digest(d)})
 	if err != nil {
 		ls.RaiseError("Failed retrieving \"%s\" blob \"%s\": %v", r.r.CommonName(), d, err)
 	}
@@ -135,7 +136,7 @@ func (s *Sandbox) blobHead(ls *lua.LState) int {
 		"ref":    r.r.CommonName(),
 		"digest": d,
 	}).Debug("Retrieve blob")
-	b, err := s.rc.BlobHead(s.ctx, r.r, digest.Digest(d))
+	b, err := s.rc.BlobHead(s.ctx, r.r, types.Descriptor{Digest: digest.Digest(d)})
 	if err != nil {
 		ls.RaiseError("Failed retrieving \"%s\" blob \"%s\": %v", r.r.CommonName(), d, err)
 	}
@@ -186,13 +187,13 @@ func (s *Sandbox) blobPut(ls *lua.LState) int {
 		ls.ArgError(2, "blob content expected")
 	}
 
-	d, size, err := s.rc.BlobPut(s.ctx, r.r, d, rdr, 0)
+	dOut, err := s.rc.BlobPut(s.ctx, r.r, types.Descriptor{Digest: d}, rdr)
 	if err != nil {
 		ls.RaiseError("Failed to put blob: %v", err)
 	}
 
-	ls.Push(lua.LString(d.String()))
-	ls.Push(lua.LNumber(size))
+	ls.Push(lua.LString(dOut.Digest.String()))
+	ls.Push(lua.LNumber(dOut.Size))
 
 	return 2
 }

--- a/cmd/regbot/sandbox/image.go
+++ b/cmd/regbot/sandbox/image.go
@@ -89,7 +89,7 @@ func (s *Sandbox) configGet(ls *lua.LState) int {
 		ls.RaiseError("Failed looking up \"%s\" config digest: %v", m.r.CommonName(), err)
 	}
 
-	confBlob, err := s.rc.BlobGetOCIConfig(s.ctx, m.r, confDesc.Digest)
+	confBlob, err := s.rc.BlobGetOCIConfig(s.ctx, m.r, confDesc)
 	if err != nil {
 		ls.RaiseError("Failed retrieving \"%s\" config: %v", m.r.CommonName(), err)
 	}

--- a/cmd/regctl/artifact.go
+++ b/cmd/regctl/artifact.go
@@ -132,7 +132,7 @@ func runArtifactGet(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		rdr, err := rc.BlobGet(ctx, r, d.Digest)
+		rdr, err := rc.BlobGet(ctx, r, d)
 		if err != nil {
 			return err
 		}
@@ -196,7 +196,7 @@ func runArtifactGet(cmd *cobra.Command, args []string) error {
 			// wrap in a closure to trigger defer on each step, avoiding open file handles
 			err = func() error {
 				// perform blob get
-				rdr, err := rc.BlobGet(ctx, r, l.Digest)
+				rdr, err := rc.BlobGet(ctx, r, l)
 				if err != nil {
 					return err
 				}
@@ -263,7 +263,7 @@ func runArtifactGet(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("more than one matching layer found, add filters or specify output dir")
 		}
 		// pull blob, write to stdout
-		rdr, err := rc.BlobGet(ctx, r, layers[0].Digest)
+		rdr, err := rc.BlobGet(ctx, r, layers[0])
 		if err != nil {
 			return err
 		}
@@ -326,7 +326,7 @@ func runArtifactPut(cmd *cobra.Command, args []string) error {
 	}
 	configDigest := digest.FromBytes(configBytes)
 	// push config to registry
-	_, _, err = rc.BlobPut(ctx, r, configDigest, bytes.NewReader(configBytes), int64(len(configBytes)))
+	_, err = rc.BlobPut(ctx, r, types.Descriptor{Digest: configDigest, Size: int64(len(configBytes))}, bytes.NewReader(configBytes))
 	if err != nil {
 		return err
 	}
@@ -398,7 +398,7 @@ func runArtifactPut(cmd *cobra.Command, args []string) error {
 					},
 				})
 				// if blob already exists, skip Put
-				bRdr, err := rc.BlobHead(ctx, r, d)
+				bRdr, err := rc.BlobHead(ctx, r, types.Descriptor{Digest: d})
 				if err == nil {
 					bRdr.Close()
 					return nil
@@ -408,7 +408,7 @@ func runArtifactPut(cmd *cobra.Command, args []string) error {
 				if err != nil {
 					return err
 				}
-				_, _, err = rc.BlobPut(ctx, r, d, rdr, l)
+				_, err = rc.BlobPut(ctx, r, types.Descriptor{Digest: d, Size: l}, rdr)
 				if err != nil {
 					return err
 				}
@@ -424,15 +424,12 @@ func runArtifactPut(cmd *cobra.Command, args []string) error {
 		if len(artifactOpts.artifactMT) > 0 {
 			mt = artifactOpts.artifactMT[0]
 		}
-		d, l, err := rc.BlobPut(ctx, r, "", os.Stdin, 0)
+		d, err := rc.BlobPut(ctx, r, types.Descriptor{}, os.Stdin)
 		if err != nil {
 			return err
 		}
-		m.Layers = append(m.Layers, types.Descriptor{
-			MediaType: mt,
-			Digest:    d,
-			Size:      l,
-		})
+		d.MediaType = mt
+		m.Layers = append(m.Layers, d)
 	}
 
 	// generate manifest

--- a/cmd/regctl/blob.go
+++ b/cmd/regctl/blob.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/opencontainers/go-digest"
 	"github.com/regclient/regclient/pkg/template"
+	"github.com/regclient/regclient/types"
 	"github.com/regclient/regclient/types/ref"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -93,7 +94,7 @@ func runBlobGet(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	blob, err := rc.BlobGet(ctx, r, d)
+	blob, err := rc.BlobGet(ctx, r, types.Descriptor{Digest: d})
 	if err != nil {
 		return err
 	}
@@ -134,7 +135,7 @@ func runBlobPut(cmd *cobra.Command, args []string) error {
 		"repository": r.Repository,
 		"digest":     blobOpts.digest,
 	}).Debug("Pushing blob")
-	dOut, size, err := rc.BlobPut(ctx, r, digest.Digest(blobOpts.digest), os.Stdin, 0)
+	dOut, err := rc.BlobPut(ctx, r, types.Descriptor{Digest: digest.Digest(blobOpts.digest)}, os.Stdin)
 	if err != nil {
 		return err
 	}
@@ -143,8 +144,8 @@ func runBlobPut(cmd *cobra.Command, args []string) error {
 		Digest digest.Digest
 		Size   int64
 	}{
-		Digest: dOut,
-		Size:   size,
+		Digest: dOut.Digest,
+		Size:   dOut.Size,
 	}
 
 	return template.Writer(os.Stdout, blobOpts.format, result)

--- a/cmd/regctl/image.go
+++ b/cmd/regctl/image.go
@@ -255,7 +255,7 @@ func runImageInspect(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	blobConfig, err := rc.BlobGetOCIConfig(ctx, r, cd.Digest)
+	blobConfig, err := rc.BlobGetOCIConfig(ctx, r, cd)
 	if err != nil {
 		return err
 	}

--- a/scheme/ocidir/blob.go
+++ b/scheme/ocidir/blob.go
@@ -18,29 +18,29 @@ import (
 )
 
 // BlobDelete removes a blob from the repository
-func (o *OCIDir) BlobDelete(ctx context.Context, r ref.Ref, d digest.Digest) error {
+func (o *OCIDir) BlobDelete(ctx context.Context, r ref.Ref, d types.Descriptor) error {
 	return types.ErrNotImplemented
 }
 
 // BlobGet retrieves a blob, returning a reader
-func (o *OCIDir) BlobGet(ctx context.Context, r ref.Ref, d digest.Digest) (blob.Reader, error) {
-	file := path.Join(r.Path, "blobs", d.Algorithm().String(), d.Encoded())
+func (o *OCIDir) BlobGet(ctx context.Context, r ref.Ref, d types.Descriptor) (blob.Reader, error) {
+	file := path.Join(r.Path, "blobs", d.Digest.Algorithm().String(), d.Digest.Encoded())
 	fd, err := o.fs.Open(file)
 	if err != nil {
 		return nil, err
 	}
-	fi, err := fd.Stat()
-	if err != nil {
-		fd.Close()
-		return nil, err
+	if d.Size <= 0 {
+		fi, err := fd.Stat()
+		if err != nil {
+			fd.Close()
+			return nil, err
+		}
+		d.Size = fi.Size()
 	}
 	br := blob.NewReader(
 		blob.WithRef(r),
 		blob.WithReader(fd),
-		blob.WithDesc(types.Descriptor{
-			Digest: d,
-			Size:   fi.Size(),
-		}),
+		blob.WithDesc(d),
 	)
 	o.log.WithFields(logrus.Fields{
 		"ref":  r.CommonName(),
@@ -50,75 +50,83 @@ func (o *OCIDir) BlobGet(ctx context.Context, r ref.Ref, d digest.Digest) (blob.
 }
 
 // BlobHead verifies the existence of a blob, the reader contains the headers but no body to read
-func (o *OCIDir) BlobHead(ctx context.Context, r ref.Ref, d digest.Digest) (blob.Reader, error) {
-	file := path.Join(r.Path, "blobs", d.Algorithm().String(), d.Encoded())
+func (o *OCIDir) BlobHead(ctx context.Context, r ref.Ref, d types.Descriptor) (blob.Reader, error) {
+	file := path.Join(r.Path, "blobs", d.Digest.Algorithm().String(), d.Digest.Encoded())
 	fd, err := o.fs.Open(file)
 	if err != nil {
 		return nil, err
 	}
 	defer fd.Close()
-	fi, err := fd.Stat()
-	if err != nil {
-		return nil, err
+	if d.Size <= 0 {
+		fi, err := fd.Stat()
+		if err != nil {
+			return nil, err
+		}
+		d.Size = fi.Size()
 	}
 	br := blob.NewReader(
 		blob.WithRef(r),
-		blob.WithDesc(types.Descriptor{
-			Digest: d,
-			Size:   fi.Size(),
-		}),
+		blob.WithDesc(d),
 	)
 	return br, nil
 }
 
 // BlobMount attempts to perform a server side copy of the blob
-func (o *OCIDir) BlobMount(ctx context.Context, refSrc ref.Ref, refTgt ref.Ref, d digest.Digest) error {
+func (o *OCIDir) BlobMount(ctx context.Context, refSrc ref.Ref, refTgt ref.Ref, d types.Descriptor) error {
 	return types.ErrUnsupported
 }
 
 // BlobPut sends a blob to the repository, returns the digest and size when successful
-func (o *OCIDir) BlobPut(ctx context.Context, r ref.Ref, d digest.Digest, rdr io.Reader, cl int64) (digest.Digest, int64, error) {
+func (o *OCIDir) BlobPut(ctx context.Context, r ref.Ref, d types.Descriptor, rdr io.Reader) (types.Descriptor, error) {
 	digester := digest.Canonical.Digester()
 	rdr = io.TeeReader(rdr, digester.Hash())
 	// if digest unavailable, read into a []byte+digest, and replace rdr
-	if d == "" {
+	if d.Digest == "" || d.Size <= 0 {
 		b, err := io.ReadAll(rdr)
 		if err != nil {
-			return "", 0, err
+			return d, err
 		}
-		d = digester.Digest()
-		cl = int64(len(b))
+		if d.Digest == "" {
+			d.Digest = digester.Digest()
+		} else if d.Digest != digester.Digest() {
+			return d, fmt.Errorf("unexpected digest, expected %s, computed %s", d.Digest, digester.Digest())
+		}
+		if d.Size <= 0 {
+			d.Size = int64(len(b))
+		} else if d.Size != int64(len(b)) {
+			return d, fmt.Errorf("unexpected blob length, expected %d, received %d", d.Size, int64(len(b)))
+		}
 		rdr = bytes.NewReader(b)
 		digester = nil // no need to recompute or validate digest
 	}
 	// write the blob to the CAS file
-	dir := path.Join(r.Path, "blobs", d.Algorithm().String())
+	dir := path.Join(r.Path, "blobs", d.Digest.Algorithm().String())
 	err := rwfs.MkdirAll(o.fs, dir, 0777)
 	if err != nil && !errors.Is(err, fs.ErrExist) {
-		return "", 0, fmt.Errorf("failed creating %s: %w", dir, err)
+		return d, fmt.Errorf("failed creating %s: %w", dir, err)
 	}
-	file := path.Join(r.Path, "blobs", d.Algorithm().String(), d.Encoded())
+	file := path.Join(r.Path, "blobs", d.Digest.Algorithm().String(), d.Digest.Encoded())
 	fd, err := o.fs.Create(file)
 	if err != nil {
-		return "", 0, fmt.Errorf("failed creating %s: %w", file, err)
+		return d, fmt.Errorf("failed creating %s: %w", file, err)
 	}
 	defer fd.Close()
 	i, err := io.Copy(fd, rdr)
 	if err != nil {
-		return "", 0, err
+		return d, err
 	}
 	// validate result
-	if digester != nil && d != digester.Digest() {
-		return "", 0, fmt.Errorf("unexpected digest, expected %s, computed %s", d, digester.Digest())
+	if digester != nil && d.Digest != digester.Digest() {
+		return d, fmt.Errorf("unexpected digest, expected %s, computed %s", d.Digest, digester.Digest())
 	}
-	if cl > 0 && i != cl {
-		return "", 0, fmt.Errorf("unexpected blob length, expected %d, received %d", cl, i)
+	if d.Size > 0 && i != d.Size {
+		return d, fmt.Errorf("unexpected blob length, expected %d, received %d", d.Size, i)
 	}
-	cl = i
+	d.Size = i
 	o.log.WithFields(logrus.Fields{
 		"ref":  r.CommonName(),
 		"file": file,
 	}).Debug("pushed blob")
 	o.refMod(r)
-	return d, cl, nil
+	return d, nil
 }

--- a/scheme/ocidir/blob_test.go
+++ b/scheme/ocidir/blob_test.go
@@ -54,7 +54,7 @@ func TestBlob(t *testing.T) {
 		return
 	}
 	// blob head
-	bh, err := o.BlobHead(ctx, r, cd.Digest)
+	bh, err := o.BlobHead(ctx, r, cd)
 	if err != nil {
 		t.Errorf("blob head: %v", err)
 		return
@@ -64,7 +64,7 @@ func TestBlob(t *testing.T) {
 		t.Errorf("blob head close: %v", err)
 	}
 	// blob get
-	bg, err := o.BlobGet(ctx, r, cd.Digest)
+	bg, err := o.BlobGet(ctx, r, cd)
 	if err != nil {
 		t.Errorf("blob get: %v", err)
 		return
@@ -90,7 +90,7 @@ func TestBlob(t *testing.T) {
 	}
 
 	// toOCIConfig
-	bg, err = o.BlobGet(ctx, r, cd.Digest)
+	bg, err = o.BlobGet(ctx, r, cd)
 	if err != nil {
 		t.Errorf("blob get 2: %v", err)
 		return
@@ -107,16 +107,16 @@ func TestBlob(t *testing.T) {
 	fm := rwfs.MemNew()
 	om := New(WithFS(fm))
 	bRdr := bytes.NewReader(bBytes)
-	bpd, bpl, err := om.BlobPut(ctx, r, cd.Digest, bRdr, int64(len(bBytes)))
+	bpd, err := om.BlobPut(ctx, r, cd, bRdr)
 	if err != nil {
 		t.Errorf("blob put: %v", err)
 		return
 	}
-	if bpl != int64(len(bBytes)) {
-		t.Errorf("blob put length, expected %d, received %d", len(bBytes), bpl)
+	if bpd.Size != int64(len(bBytes)) {
+		t.Errorf("blob put length, expected %d, received %d", len(bBytes), bpd.Size)
 	}
-	if bpd != cd.Digest {
-		t.Errorf("blob put digest, expected %s, received %s", cd.Digest, bpd)
+	if bpd.Digest != cd.Digest {
+		t.Errorf("blob put digest, expected %s, received %s", cd.Digest, bpd.Digest)
 	}
 	fd, err := fm.Open(fmt.Sprintf("testdata/regctl/blobs/%s/%s", cd.Digest.Algorithm().String(), cd.Digest.Encoded()))
 	if err != nil {

--- a/scheme/reg/blob.go
+++ b/scheme/reg/blob.go
@@ -18,29 +18,29 @@ import (
 )
 
 // BlobDelete removes a blob from the repository
-func (reg *Reg) BlobDelete(ctx context.Context, r ref.Ref, d digest.Digest) error {
+func (reg *Reg) BlobDelete(ctx context.Context, r ref.Ref, d types.Descriptor) error {
 	req := &reghttp.Req{
 		Host: r.Registry,
 		APIs: map[string]reghttp.ReqAPI{
 			"": {
 				Method:     "DELETE",
 				Repository: r.Repository,
-				Path:       "blobs/" + d.String(),
+				Path:       "blobs/" + d.Digest.String(),
 			},
 		},
 	}
 	resp, err := reg.reghttp.Do(ctx, req)
 	if err != nil {
-		return fmt.Errorf("failed to delete blob, digest %s, ref %s: %w", d, r.CommonName(), err)
+		return fmt.Errorf("failed to delete blob, digest %s, ref %s: %w", d.Digest.String(), r.CommonName(), err)
 	}
 	if resp.HTTPResponse().StatusCode != 202 {
-		return fmt.Errorf("failed to delete blob, digest %s, ref %s: %w", d, r.CommonName(), reghttp.HTTPError(resp.HTTPResponse().StatusCode))
+		return fmt.Errorf("failed to delete blob, digest %s, ref %s: %w", d.Digest.String(), r.CommonName(), reghttp.HTTPError(resp.HTTPResponse().StatusCode))
 	}
 	return nil
 }
 
 // BlobGet retrieves a blob from the repository, returning a blob reader
-func (reg *Reg) BlobGet(ctx context.Context, r ref.Ref, d digest.Digest) (blob.Reader, error) {
+func (reg *Reg) BlobGet(ctx context.Context, r ref.Ref, d types.Descriptor) (blob.Reader, error) {
 	// build/send request
 	req := &reghttp.Req{
 		Host: r.Registry,
@@ -48,23 +48,23 @@ func (reg *Reg) BlobGet(ctx context.Context, r ref.Ref, d digest.Digest) (blob.R
 			"": {
 				Method:     "GET",
 				Repository: r.Repository,
-				Path:       "blobs/" + d.String(),
+				Path:       "blobs/" + d.Digest.String(),
 			},
 		},
 	}
 	resp, err := reg.reghttp.Do(ctx, req)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get blob, digest %s, ref %s: %w", d, r.CommonName(), err)
+		return nil, fmt.Errorf("failed to get blob, digest %s, ref %s: %w", d.Digest.String(), r.CommonName(), err)
 	}
 	if resp.HTTPResponse().StatusCode != 200 {
-		return nil, fmt.Errorf("failed to get blob, digest %s, ref %s: %w", d, r.CommonName(), reghttp.HTTPError(resp.HTTPResponse().StatusCode))
+		return nil, fmt.Errorf("failed to get blob, digest %s, ref %s: %w", d.Digest.String(), r.CommonName(), reghttp.HTTPError(resp.HTTPResponse().StatusCode))
 	}
 
 	b := blob.NewReader(
 		blob.WithRef(r),
 		blob.WithReader(resp),
 		blob.WithDesc(types.Descriptor{
-			Digest: d,
+			Digest: d.Digest,
 		}),
 		blob.WithResp(resp.HTTPResponse()),
 	)
@@ -72,7 +72,7 @@ func (reg *Reg) BlobGet(ctx context.Context, r ref.Ref, d digest.Digest) (blob.R
 }
 
 // BlobHead is used to verify if a blob exists and is accessible
-func (reg *Reg) BlobHead(ctx context.Context, r ref.Ref, d digest.Digest) (blob.Reader, error) {
+func (reg *Reg) BlobHead(ctx context.Context, r ref.Ref, d types.Descriptor) (blob.Reader, error) {
 	// build/send request
 	req := &reghttp.Req{
 		Host: r.Registry,
@@ -80,23 +80,23 @@ func (reg *Reg) BlobHead(ctx context.Context, r ref.Ref, d digest.Digest) (blob.
 			"": {
 				Method:     "HEAD",
 				Repository: r.Repository,
-				Path:       "blobs/" + d.String(),
+				Path:       "blobs/" + d.Digest.String(),
 			},
 		},
 	}
 	resp, err := reg.reghttp.Do(ctx, req)
 	if err != nil {
-		return nil, fmt.Errorf("failed to request blob head, digest %s, ref %s: %w", d, r.CommonName(), err)
+		return nil, fmt.Errorf("failed to request blob head, digest %s, ref %s: %w", d.Digest.String(), r.CommonName(), err)
 	}
 	defer resp.Close()
 	if resp.HTTPResponse().StatusCode != 200 {
-		return nil, fmt.Errorf("failed to request blob head, digest %s, ref %s: %w", d, r.CommonName(), reghttp.HTTPError(resp.HTTPResponse().StatusCode))
+		return nil, fmt.Errorf("failed to request blob head, digest %s, ref %s: %w", d.Digest.String(), r.CommonName(), reghttp.HTTPError(resp.HTTPResponse().StatusCode))
 	}
 
 	b := blob.NewReader(
 		blob.WithRef(r),
 		blob.WithDesc(types.Descriptor{
-			Digest: d,
+			Digest: d.Digest,
 		}),
 		blob.WithResp(resp.HTTPResponse()),
 	)
@@ -104,7 +104,7 @@ func (reg *Reg) BlobHead(ctx context.Context, r ref.Ref, d digest.Digest) (blob.
 }
 
 // BlobMount attempts to perform a server side copy/mount of the blob between repositories
-func (reg *Reg) BlobMount(ctx context.Context, rSrc ref.Ref, rTgt ref.Ref, d digest.Digest) error {
+func (reg *Reg) BlobMount(ctx context.Context, rSrc ref.Ref, rTgt ref.Ref, d types.Descriptor) error {
 	_, uuid, err := reg.blobMount(ctx, rTgt, d, rSrc)
 	// if mount fails and returns an upload location, cancel that upload
 	if err != nil {
@@ -117,19 +117,19 @@ func (reg *Reg) BlobMount(ctx context.Context, rSrc ref.Ref, rTgt ref.Ref, d dig
 // This will attempt an anonymous blob mount first which some registries may support.
 // It will then try doing a full put of the blob without chunking (most widely supported).
 // If the full put fails, it will fall back to a chunked upload (useful for flaky networks).
-func (reg *Reg) BlobPut(ctx context.Context, r ref.Ref, d digest.Digest, rdr io.Reader, cl int64) (digest.Digest, int64, error) {
+func (reg *Reg) BlobPut(ctx context.Context, r ref.Ref, d types.Descriptor, rdr io.Reader) (types.Descriptor, error) {
 	var putURL *url.URL
 	var err error
 	// defaults for content-type and length
-	if cl == 0 {
-		cl = -1
+	if d.Size == 0 {
+		d.Size = -1
 	}
 
 	// attempt an anonymous blob mount
-	if d != "" && cl > 0 {
+	if d.Digest != "" && d.Size > 0 {
 		putURL, _, err = reg.blobMount(ctx, r, d, ref.Ref{})
 		if err == nil {
-			return digest.Digest(d), cl, nil
+			return d, nil
 		}
 		if err != types.ErrMountReturnedLocation {
 			putURL = nil
@@ -139,35 +139,35 @@ func (reg *Reg) BlobPut(ctx context.Context, r ref.Ref, d digest.Digest, rdr io.
 	if putURL == nil {
 		putURL, err = reg.blobGetUploadURL(ctx, r)
 		if err != nil {
-			return "", 0, err
+			return d, err
 		}
 	}
 
 	// send upload as one-chunk
-	tryPut := bool(d != "" && cl > 0)
+	tryPut := bool(d.Digest != "" && d.Size > 0)
 	if tryPut {
 		host := reg.hostGet(r.Registry)
 		maxPut := host.BlobMax
 		if maxPut == 0 {
 			maxPut = reg.blobMaxPut
 		}
-		if maxPut > 0 && cl > maxPut {
+		if maxPut > 0 && d.Size > maxPut {
 			tryPut = false
 		}
 	}
 	if tryPut {
-		err = reg.blobPutUploadFull(ctx, r, d, putURL, rdr, cl)
+		err = reg.blobPutUploadFull(ctx, r, d, putURL, rdr)
 		if err == nil {
-			return digest.Digest(d), cl, nil
+			return d, nil
 		}
 		// on failure, attempt to seek back to start to perform a chunked upload
 		rdrSeek, ok := rdr.(io.ReadSeeker)
 		if !ok {
-			return digest.Digest(d), cl, err
+			return d, err
 		}
 		offset, errR := rdrSeek.Seek(0, io.SeekStart)
 		if errR != nil || offset != 0 {
-			return digest.Digest(d), cl, err
+			return d, err
 		}
 	}
 
@@ -218,10 +218,10 @@ func (reg *Reg) blobGetUploadURL(ctx context.Context, r ref.Ref) (*url.URL, erro
 	return putURL, nil
 }
 
-func (reg *Reg) blobMount(ctx context.Context, rTgt ref.Ref, d digest.Digest, rSrc ref.Ref) (*url.URL, string, error) {
+func (reg *Reg) blobMount(ctx context.Context, rTgt ref.Ref, d types.Descriptor, rSrc ref.Ref) (*url.URL, string, error) {
 	// build/send request
 	query := url.Values{}
-	query.Set("mount", d.String())
+	query.Set("mount", d.Digest.String())
 	if rSrc.Registry == rTgt.Registry && rSrc.Repository != "" {
 		query.Set("from", rSrc.Repository)
 	}
@@ -240,7 +240,7 @@ func (reg *Reg) blobMount(ctx context.Context, rTgt ref.Ref, d digest.Digest, rS
 	}
 	resp, err := reg.reghttp.Do(ctx, req)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to mount blob, digest %s, ref %s: %w", d, rTgt.CommonName(), err)
+		return nil, "", fmt.Errorf("failed to mount blob, digest %s, ref %s: %w", d.Digest.String(), rTgt.CommonName(), err)
 	}
 	defer resp.Close()
 	// 201 indicates the blob mount succeeded
@@ -265,15 +265,15 @@ func (reg *Reg) blobMount(ctx context.Context, rTgt ref.Ref, d digest.Digest, rS
 		}
 	}
 	// all other responses unhandled
-	return nil, "", fmt.Errorf("failed to mount blob, digest %s, ref %s: %w", d, rTgt.CommonName(), reghttp.HTTPError(resp.HTTPResponse().StatusCode))
+	return nil, "", fmt.Errorf("failed to mount blob, digest %s, ref %s: %w", d.Digest.String(), rTgt.CommonName(), reghttp.HTTPError(resp.HTTPResponse().StatusCode))
 }
 
-func (reg *Reg) blobPutUploadFull(ctx context.Context, r ref.Ref, d digest.Digest, putURL *url.URL, rdr io.Reader, cl int64) error {
+func (reg *Reg) blobPutUploadFull(ctx context.Context, r ref.Ref, d types.Descriptor, putURL *url.URL, rdr io.Reader) error {
 	// append digest to request to use the monolithic upload option
 	if putURL.RawQuery != "" {
-		putURL.RawQuery = putURL.RawQuery + "&digest=" + url.QueryEscape(d.String())
+		putURL.RawQuery = putURL.RawQuery + "&digest=" + url.QueryEscape(d.Digest.String())
 	} else {
-		putURL.RawQuery = "digest=" + url.QueryEscape(d.String())
+		putURL.RawQuery = "digest=" + url.QueryEscape(d.Digest.String())
 	}
 
 	// make a reader function for the blob
@@ -306,7 +306,7 @@ func (reg *Reg) blobPutUploadFull(ctx context.Context, r ref.Ref, d digest.Diges
 				Repository: r.Repository,
 				DirectURL:  putURL,
 				BodyFunc:   bodyFunc,
-				BodyLen:    cl,
+				BodyLen:    d.Size,
 				Headers:    header,
 			},
 		},
@@ -314,17 +314,17 @@ func (reg *Reg) blobPutUploadFull(ctx context.Context, r ref.Ref, d digest.Diges
 	}
 	resp, err := reg.reghttp.Do(ctx, req)
 	if err != nil {
-		return fmt.Errorf("failed to send blob (put), digest %s, ref %s: %w", d, r.CommonName(), err)
+		return fmt.Errorf("failed to send blob (put), digest %s, ref %s: %w", d.Digest.String(), r.CommonName(), err)
 	}
 	defer resp.Close()
 	// 201 follows distribution-spec, 204 is listed as possible in the Docker registry spec
 	if resp.HTTPResponse().StatusCode != 201 && resp.HTTPResponse().StatusCode != 204 {
-		return fmt.Errorf("failed to send blob (put), digest %s, ref %s: %w", d, r.CommonName(), reghttp.HTTPError(resp.HTTPResponse().StatusCode))
+		return fmt.Errorf("failed to send blob (put), digest %s, ref %s: %w", d.Digest.String(), r.CommonName(), reghttp.HTTPError(resp.HTTPResponse().StatusCode))
 	}
 	return nil
 }
 
-func (reg *Reg) blobPutUploadChunked(ctx context.Context, r ref.Ref, putURL *url.URL, rdr io.Reader) (digest.Digest, int64, error) {
+func (reg *Reg) blobPutUploadChunked(ctx context.Context, r ref.Ref, putURL *url.URL, rdr io.Reader) (types.Descriptor, error) {
 	host := reg.hostGet(r.Registry)
 	bufSize := host.BlobChunk
 	if bufSize <= 0 {
@@ -361,7 +361,7 @@ func (reg *Reg) blobPutUploadChunked(ctx context.Context, r ref.Ref, putURL *url
 		if err == io.EOF || err == io.ErrUnexpectedEOF {
 			finalChunk = true
 		} else if err != nil {
-			return "", 0, fmt.Errorf("failed to send blob chunk, ref %s: %w", r.CommonName(), err)
+			return types.Descriptor{}, fmt.Errorf("failed to send blob chunk, ref %s: %w", r.CommonName(), err)
 		}
 		// update length on partial read
 		if chunkSize != len(bufBytes) {
@@ -396,7 +396,7 @@ func (reg *Reg) blobPutUploadChunked(ctx context.Context, r ref.Ref, putURL *url
 			}
 			resp, err := reg.reghttp.Do(ctx, req)
 			if err != nil {
-				return "", 0, fmt.Errorf("failed to send blob (chunk), ref %s: %w", r.CommonName(), err)
+				return types.Descriptor{}, fmt.Errorf("failed to send blob (chunk), ref %s: %w", r.CommonName(), err)
 			}
 			resp.Close()
 
@@ -408,7 +408,7 @@ func (reg *Reg) blobPutUploadChunked(ctx context.Context, r ref.Ref, putURL *url
 					"chunkSize":  chunkSize,
 				}).Debug("Early accept of chunk in PATCH before PUT request")
 			} else if resp.HTTPResponse().StatusCode != 202 {
-				return "", 0, fmt.Errorf("failed to send blob (chunk), ref %s: %w", r.CommonName(), reghttp.HTTPError(resp.HTTPResponse().StatusCode))
+				return types.Descriptor{}, fmt.Errorf("failed to send blob (chunk), ref %s: %w", r.CommonName(), reghttp.HTTPError(resp.HTTPResponse().StatusCode))
 			}
 			chunkStart += int64(chunkSize)
 			location := resp.HTTPResponse().Header.Get("Location")
@@ -419,7 +419,7 @@ func (reg *Reg) blobPutUploadChunked(ctx context.Context, r ref.Ref, putURL *url
 				prevURL := resp.HTTPResponse().Request.URL
 				parseURL, err := prevURL.Parse(location)
 				if err != nil {
-					return "", 0, fmt.Errorf("failed to send blob (parse next chunk location), ref %s: %w", r.CommonName(), err)
+					return types.Descriptor{}, fmt.Errorf("failed to send blob (parse next chunk location), ref %s: %w", r.CommonName(), err)
 				}
 				chunkURL = *parseURL
 			}
@@ -456,15 +456,15 @@ func (reg *Reg) blobPutUploadChunked(ctx context.Context, r ref.Ref, putURL *url
 	}
 	resp, err := reg.reghttp.Do(ctx, req)
 	if err != nil {
-		return "", 0, fmt.Errorf("failed to send blob (chunk digest), digest %s, ref %s: %w", d, r.CommonName(), err)
+		return types.Descriptor{}, fmt.Errorf("failed to send blob (chunk digest), digest %s, ref %s: %w", d, r.CommonName(), err)
 	}
 	defer resp.Close()
 	// 201 follows distribution-spec, 204 is listed as possible in the Docker registry spec
 	if resp.HTTPResponse().StatusCode != 201 && resp.HTTPResponse().StatusCode != 204 {
-		return "", 0, fmt.Errorf("failed to send blob (chunk digest), digest %s, ref %s: %w", d, r.CommonName(), reghttp.HTTPError(resp.HTTPResponse().StatusCode))
+		return types.Descriptor{}, fmt.Errorf("failed to send blob (chunk digest), digest %s, ref %s: %w", d, r.CommonName(), reghttp.HTTPError(resp.HTTPResponse().StatusCode))
 	}
 
-	return d, chunkStart, nil
+	return types.Descriptor{Digest: d, Size: chunkStart}, nil
 }
 
 // TODO: just take a putURL rather than the uuid and call a delete on that url

--- a/scheme/reg/blob_test.go
+++ b/scheme/reg/blob_test.go
@@ -183,7 +183,7 @@ func TestBlobGet(t *testing.T) {
 		if err != nil {
 			t.Errorf("Failed creating ref: %v", err)
 		}
-		br, err := reg.BlobGet(ctx, r, d1)
+		br, err := reg.BlobGet(ctx, r, types.Descriptor{Digest: d1})
 		if err != nil {
 			t.Errorf("Failed running BlobGet: %v", err)
 			return
@@ -204,7 +204,7 @@ func TestBlobGet(t *testing.T) {
 		if err != nil {
 			t.Errorf("Failed creating ref: %v", err)
 		}
-		br, err := reg.BlobHead(ctx, r, d1)
+		br, err := reg.BlobHead(ctx, r, types.Descriptor{Digest: d1})
 		if err != nil {
 			t.Errorf("Failed running BlobHead: %v", err)
 			return
@@ -220,7 +220,7 @@ func TestBlobGet(t *testing.T) {
 		if err != nil {
 			t.Errorf("Failed creating ref: %v", err)
 		}
-		br, err := reg.BlobGet(ctx, r, dMissing)
+		br, err := reg.BlobGet(ctx, r, types.Descriptor{Digest: dMissing})
 		if err == nil {
 			defer br.Close()
 			t.Errorf("Unexpected success running BlobGet")
@@ -236,7 +236,7 @@ func TestBlobGet(t *testing.T) {
 		if err != nil {
 			t.Errorf("Failed creating ref: %v", err)
 		}
-		br, err := reg.BlobGet(ctx, r, d2)
+		br, err := reg.BlobGet(ctx, r, types.Descriptor{Digest: d2})
 		if err != nil {
 			t.Errorf("Failed running BlobGet: %v", err)
 			return
@@ -257,7 +257,7 @@ func TestBlobGet(t *testing.T) {
 		if err != nil {
 			t.Errorf("Failed creating ref: %v", err)
 		}
-		br, err := reg.BlobGet(ctx, r, d1)
+		br, err := reg.BlobGet(ctx, r, types.Descriptor{Digest: d1})
 		if err == nil {
 			defer br.Close()
 			t.Errorf("Unexpected success running BlobGet")
@@ -716,16 +716,16 @@ func TestBlobPut(t *testing.T) {
 			t.Errorf("Failed creating ref: %v", err)
 		}
 		br := bytes.NewReader(blob1)
-		dp, clp, err := reg.BlobPut(ctx, r, d1, br, int64(len(blob1)))
+		dp, err := reg.BlobPut(ctx, r, types.Descriptor{Digest: d1, Size: int64(len(blob1))}, br)
 		if err != nil {
 			t.Errorf("Failed running BlobPut: %v", err)
 			return
 		}
-		if dp.String() != d1.String() {
-			t.Errorf("Digest mismatch, expected %s, received %s", d1.String(), dp.String())
+		if dp.Digest.String() != d1.String() {
+			t.Errorf("Digest mismatch, expected %s, received %s", d1.String(), dp.Digest.String())
 		}
-		if clp != int64(len(blob1)) {
-			t.Errorf("Content length mismatch, expected %d, received %d", len(blob1), clp)
+		if dp.Size != int64(len(blob1)) {
+			t.Errorf("Content length mismatch, expected %d, received %d", len(blob1), dp.Size)
 		}
 
 	})
@@ -736,16 +736,16 @@ func TestBlobPut(t *testing.T) {
 			t.Errorf("Failed creating ref: %v", err)
 		}
 		br := bytes.NewReader(blob2)
-		dp, clp, err := reg.BlobPut(ctx, r, d2, br, int64(len(blob2)))
+		dp, err := reg.BlobPut(ctx, r, types.Descriptor{Digest: d2, Size: int64(len(blob2))}, br)
 		if err != nil {
 			t.Errorf("Failed running BlobPut: %v", err)
 			return
 		}
-		if dp.String() != d2.String() {
-			t.Errorf("Digest mismatch, expected %s, received %s", d2.String(), dp.String())
+		if dp.Digest.String() != d2.String() {
+			t.Errorf("Digest mismatch, expected %s, received %s", d2.String(), dp.Digest.String())
 		}
-		if clp != int64(len(blob2)) {
-			t.Errorf("Content length mismatch, expected %d, received %d", len(blob2), clp)
+		if dp.Size != int64(len(blob2)) {
+			t.Errorf("Content length mismatch, expected %d, received %d", len(blob2), dp.Size)
 		}
 
 	})
@@ -756,16 +756,16 @@ func TestBlobPut(t *testing.T) {
 			t.Errorf("Failed creating ref: %v", err)
 		}
 		br := bytes.NewReader(blob3)
-		dp, clp, err := reg.BlobPut(ctx, r, d3, br, int64(len(blob3)))
+		dp, err := reg.BlobPut(ctx, r, types.Descriptor{Digest: d3, Size: int64(len(blob3))}, br)
 		if err != nil {
 			t.Errorf("Failed running BlobPut: %v", err)
 			return
 		}
-		if dp.String() != d3.String() {
-			t.Errorf("Digest mismatch, expected %s, received %s", d3.String(), dp.String())
+		if dp.Digest.String() != d3.String() {
+			t.Errorf("Digest mismatch, expected %s, received %s", d3.String(), dp.Digest.String())
 		}
-		if clp != int64(len(blob3)) {
-			t.Errorf("Content length mismatch, expected %d, received %d", len(blob3), clp)
+		if dp.Size != int64(len(blob3)) {
+			t.Errorf("Content length mismatch, expected %d, received %d", len(blob3), dp.Size)
 		}
 
 	})

--- a/scheme/reg/tag.go
+++ b/scheme/reg/tag.go
@@ -135,7 +135,7 @@ func (reg *Reg) TagDelete(ctx context.Context, r ref.Ref) error {
 	}).Debug("Sending dummy manifest to replace tag")
 
 	// push config
-	_, _, err = reg.BlobPut(ctx, r, confDigest, bytes.NewReader(confB), int64(len(confB)))
+	_, err = reg.BlobPut(ctx, r, types.Descriptor{Digest: confDigest, Size: int64(len(confB))}, bytes.NewReader(confB))
 	if err != nil {
 		return fmt.Errorf("failed sending dummy config to delete %s: %w", r.CommonName(), err)
 	}

--- a/scheme/scheme.go
+++ b/scheme/scheme.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/opencontainers/go-digest"
+	"github.com/regclient/regclient/types"
 	"github.com/regclient/regclient/types/blob"
 	"github.com/regclient/regclient/types/manifest"
 	"github.com/regclient/regclient/types/ref"
@@ -18,15 +18,15 @@ type API interface {
 	Info() Info
 
 	// BlobDelete removes a blob from the repository
-	BlobDelete(ctx context.Context, r ref.Ref, d digest.Digest) error
+	BlobDelete(ctx context.Context, r ref.Ref, d types.Descriptor) error
 	// BlobGet retrieves a blob, returning a reader
-	BlobGet(ctx context.Context, r ref.Ref, d digest.Digest) (blob.Reader, error)
+	BlobGet(ctx context.Context, r ref.Ref, d types.Descriptor) (blob.Reader, error)
 	// BlobHead verifies the existence of a blob, the reader contains the headers but no body to read
-	BlobHead(ctx context.Context, r ref.Ref, d digest.Digest) (blob.Reader, error)
+	BlobHead(ctx context.Context, r ref.Ref, d types.Descriptor) (blob.Reader, error)
 	// BlobMount attempts to perform a server side copy of the blob
-	BlobMount(ctx context.Context, refSrc ref.Ref, refTgt ref.Ref, d digest.Digest) error
+	BlobMount(ctx context.Context, refSrc ref.Ref, refTgt ref.Ref, d types.Descriptor) error
 	// BlobPut sends a blob to the repository, returns the digest and size when successful
-	BlobPut(ctx context.Context, r ref.Ref, d digest.Digest, rdr io.Reader, cl int64) (digest.Digest, int64, error)
+	BlobPut(ctx context.Context, r ref.Ref, d types.Descriptor, rdr io.Reader) (types.Descriptor, error)
 
 	// ManifestDelete removes a manifest, including all tags that point to that manifest
 	ManifestDelete(ctx context.Context, r ref.Ref) error


### PR DESCRIPTION
Descriptors will be useful when Data field is added.

Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Change the blob methods to use a descriptor instead of only the digest and size. This changes the following methods:

```
	// BlobDelete removes a blob from the repository
-	BlobDelete(ctx context.Context, r ref.Ref, d digest.Digest) error
+	BlobDelete(ctx context.Context, r ref.Ref, d types.Descriptor) error
	// BlobGet retrieves a blob, returning a reader
-	BlobGet(ctx context.Context, r ref.Ref, d digest.Digest) (blob.Reader, error)
+	BlobGet(ctx context.Context, r ref.Ref, d types.Descriptor) (blob.Reader, error)
	// BlobHead verifies the existence of a blob, the reader contains the headers but no body to read
-	BlobHead(ctx context.Context, r ref.Ref, d digest.Digest) (blob.Reader, error)
+	BlobHead(ctx context.Context, r ref.Ref, d types.Descriptor) (blob.Reader, error)
	// BlobMount attempts to perform a server side copy of the blob
-	BlobMount(ctx context.Context, refSrc ref.Ref, refTgt ref.Ref, d digest.Digest) error
+	BlobMount(ctx context.Context, refSrc ref.Ref, refTgt ref.Ref, d types.Descriptor) error
	// BlobPut sends a blob to the repository, returns the digest and size when successful
-	BlobPut(ctx context.Context, r ref.Ref, d digest.Digest, rdr io.Reader, cl int64) (digest.Digest, int64, error)
+	BlobPut(ctx context.Context, r ref.Ref, d types.Descriptor, rdr io.Reader) (types.Descriptor, error)
```

This breaking change is needed to support the data field in the descriptor.

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

<!-- Include steps that can be taken to verify the change -->

### Changelog text

Breaking: Blob methods have been updated to use a descriptor instead of the digest and size
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
