### PR TITLE
Parse the descriptor data field when available

### DIFF
--- a/blob.go
+++ b/blob.go
@@ -1,6 +1,7 @@
 package regclient
 
 import (
+	"bytes"
 	"context"
 	"io"
 
@@ -83,6 +84,10 @@ func (rc *RegClient) BlobDelete(ctx context.Context, r ref.Ref, d types.Descript
 
 // BlobGet retrieves a blob, returning a reader
 func (rc *RegClient) BlobGet(ctx context.Context, r ref.Ref, d types.Descriptor) (blob.Reader, error) {
+	data, err := d.GetData()
+	if err == nil {
+		return blob.NewReader(blob.WithDesc(d), blob.WithRef(r), blob.WithReader(bytes.NewReader(data))), nil
+	}
 	schemeAPI, err := rc.schemeGet(r.Scheme)
 	if err != nil {
 		return nil, err

--- a/cmd/regctl/manifest.go
+++ b/cmd/regctl/manifest.go
@@ -122,8 +122,7 @@ func getManifest(ctx context.Context, rc *regclient.RegClient, r ref.Ref) (manif
 		if err != nil {
 			return m, fmt.Errorf("failed to lookup platform specific digest: %w", err)
 		}
-		r.Digest = desc.Digest.String()
-		m, err = rc.ManifestGet(ctx, r)
+		m, err = rc.ManifestGet(ctx, r, regclient.ManifestWithDesc(*desc))
 		if err != nil {
 			return m, fmt.Errorf("failed to pull platform specific digest: %w", err)
 		}

--- a/types/descriptor_test.go
+++ b/types/descriptor_test.go
@@ -1,0 +1,86 @@
+package types
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/opencontainers/go-digest"
+)
+
+func TestDescriptorData(t *testing.T) {
+	tests := []struct {
+		name     string
+		d        Descriptor
+		wantData []byte
+		wantErr  error
+	}{
+		{
+			name: "No Data",
+			d: Descriptor{
+				MediaType: MediaTypeDocker2Layer,
+				Size:      941,
+				Digest:    digest.Digest("sha256:f6e2d7fa40092cf3d9817bf6ff54183d68d108a47fdf5a5e476c612626c80e14"),
+			},
+			wantErr: ErrParsingFailed,
+		},
+		{
+			name: "Bad Data",
+			d: Descriptor{
+				MediaType: MediaTypeOCI1LayerGzip,
+				Size:      1234,
+				Digest:    digest.Digest("sha256:f6e2d7fa40092cf3d9817bf6ff54183d68d108a47fdf5a5e476c612626c80e14"),
+				Data:      []byte("Invalid data string"),
+			},
+			wantErr: ErrParsingFailed,
+		},
+		{
+			name: "Bad Digest",
+			d: Descriptor{
+				MediaType: MediaTypeOCI1LayerGzip,
+				Size:      1234,
+				Digest:    digest.Digest("sha256:f6e2d7fa40092cf3d9817bf6ff54183d68d108a47fdf5a5e476c612626c80e14"),
+				Data:      []byte("QmFkIGRpZ2VzdCBkYXRhCg=="),
+			},
+			wantErr: ErrParsingFailed,
+		},
+		{
+			name: "Bad Size",
+			d: Descriptor{
+				MediaType: MediaTypeOCI1LayerGzip,
+				Size:      1000,
+				Digest:    digest.Digest("sha256:e4a380728755139f156563e8b795581d5915dcc947fe937c524c6d52fd604b88"),
+				Data:      []byte("R29vZCBkYXRhCg=="),
+			},
+			wantErr: ErrParsingFailed,
+		},
+		{
+			name: "Good data",
+			d: Descriptor{
+				MediaType: MediaTypeOCI1LayerGzip,
+				Size:      10,
+				Digest:    digest.Digest("sha256:e4a380728755139f156563e8b795581d5915dcc947fe937c524c6d52fd604b88"),
+				Data:      []byte("R29vZCBkYXRhCg=="),
+			},
+			wantData: []byte("Good data\n"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := tt.d.GetData()
+			if tt.wantErr != nil {
+				if err == nil || (!errors.Is(err, tt.wantErr) && err.Error() != tt.wantErr.Error()) {
+					t.Errorf("expected error %v, received %v", tt.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("received error %v", err)
+				return
+			}
+			if !bytes.Equal(out, tt.wantData) {
+				t.Errorf("data mismatch, expected %s, received %s", string(tt.wantData), string(out))
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

When the data field is defined in the descriptor, attempt to parse and use it instead of fetching from the registry.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Define an image with the Data field in the manifest, when fetching the image to copy, a query should not be made for those manifests or blobs.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Support the Data field in the descriptor on manifest and blob gets
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
