### PR TITLE
Fix ocidir index.json dangling entries

### DIFF
--- a/scheme/ocidir/manifest.go
+++ b/scheme/ocidir/manifest.go
@@ -29,20 +29,24 @@ func (o *OCIDir) ManifestDelete(ctx context.Context, r ref.Ref) error {
 	}
 
 	// get index
+	changed := false
 	index, err := o.readIndex(r)
 	if err != nil {
 		return fmt.Errorf("failed to read index: %w", err)
 	}
-	for i, desc := range index.Manifests {
+	for i := len(index.Manifests) - 1; i >= 0; i-- {
 		// remove matching entry from index
-		if r.Digest != "" && desc.Digest.String() == r.Digest {
+		if r.Digest != "" && index.Manifests[i].Digest.String() == r.Digest {
+			changed = true
 			index.Manifests = append(index.Manifests[:i], index.Manifests[i+1:]...)
 		}
 	}
 	// push manifest back out
-	err = o.writeIndex(r, index)
-	if err != nil {
-		return fmt.Errorf("failed to write index: %w", err)
+	if changed {
+		err = o.writeIndex(r, index)
+		if err != nil {
+			return fmt.Errorf("failed to write index: %w", err)
+		}
 	}
 
 	// delete from filesystem like a registry would do
@@ -65,15 +69,13 @@ func (o *OCIDir) ManifestGet(ctx context.Context, r ref.Ref) (manifest.Manifest,
 	if r.Digest == "" && r.Tag == "" {
 		r.Tag = "latest"
 	}
-	desc := types.Descriptor{}
-	if r.Digest != "" {
-		desc.Digest = digest.Digest(r.Digest)
-	} else {
-		i, err := indexRefLookup(index, r)
-		if err != nil {
+	desc, err := indexGet(index, r)
+	if err != nil {
+		if r.Digest != "" {
+			desc.Digest = digest.Digest(r.Digest)
+		} else {
 			return nil, err
 		}
-		desc = index.Manifests[i]
 	}
 	if desc.Digest == "" {
 		return nil, types.ErrNotFound
@@ -176,11 +178,9 @@ func (o *OCIDir) ManifestPut(ctx context.Context, r ref.Ref, m manifest.Manifest
 	}
 	// replace existing tag or create a new entry
 	if !config.Child {
-		i, err := indexRefLookup(index, r)
-		if err == nil {
-			index.Manifests[i] = desc
-		} else {
-			index.Manifests = append(index.Manifests, desc)
+		err := indexSet(&index, r, desc)
+		if err != nil {
+			return fmt.Errorf("failed to update index: %w", err)
 		}
 		err = o.writeIndex(r, index)
 		if err != nil {


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This fixes cases when both a tag and digest match two separate descriptors on a manifest push to an ocidir, where the tag is being replaced by a descriptor that was first pushed by digest. The first entry is replaced and now later entries are deleted.

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

This will show up with the future `regctl image mod` command.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Fix an issue with dangling references in the ocidir index.json.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
