### PR TITLE
Fix handling of relative OS paths

### DIFF
--- a/internal/rwfs/os.go
+++ b/internal/rwfs/os.go
@@ -116,13 +116,6 @@ func (o *OSFS) join(op, name string) (string, error) {
 		}
 		return ".", nil
 	}
-	if (name[:1] == "/" && !fs.ValidPath(name[1:])) || (name[:1] != "/" && !fs.ValidPath(name)) {
-		return "", &fs.PathError{
-			Op:   op,
-			Path: name,
-			Err:  fs.ErrInvalid,
-		}
-	}
 	// relative paths allowed when o.dir is not set
 	if o.dir == "" {
 		return path.Clean(name), nil
@@ -132,7 +125,16 @@ func (o *OSFS) join(op, name string) (string, error) {
 		name = path.Clean(name)
 	} else {
 		name = path.Clean("/" + name)
-		name = name[1:]
+		if len(name) > 1 {
+			name = name[1:]
+		}
+	}
+	if !fs.ValidPath(name) {
+		return "", &fs.PathError{
+			Op:   op,
+			Path: name,
+			Err:  fs.ErrInvalid,
+		}
 	}
 	return path.Join(o.dir, name), nil
 }

--- a/internal/rwfs/os_test.go
+++ b/internal/rwfs/os_test.go
@@ -14,5 +14,25 @@ func TestOS(t *testing.T) {
 	}
 	testRWFS(t, fs)
 
-	// TODO: attempt to escape tempdir
+	fsOS := OSNew("")
+	f, err := fsOS.Open("..")
+	if err != nil {
+		t.Errorf("failed opening relative dir: %v", err)
+	} else {
+		defer f.Close()
+		fi, err := f.Stat()
+		if err != nil {
+			t.Errorf("failed stat on relative dir: %v", err)
+		}
+		if !fi.IsDir() {
+			t.Errorf("relative dir is not a directory")
+		}
+	}
+	// attempt to escape tempdir
+	fsCur := OSNew(".")
+	f, err = fsCur.Open("..")
+	if err == nil {
+		t.Errorf("opened relative dir")
+		defer f.Close()
+	}
 }


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Relative paths with the rwfs library would fail on a `..`. This corrects the handling when the root is not fixed.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Use `ocidir://../path:latest` in a regctl command.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Fix handling of relative paths in `ocidir`.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
