### PR TITLE
Fix handling of docker certificates

### DIFF
--- a/regclient.go
+++ b/regclient.go
@@ -51,9 +51,8 @@ func init() {
 
 // RegClient is used to access OCI distribution-spec registries
 type RegClient struct {
-	certPaths []string
-	hosts     map[string]*config.Host
-	log       *logrus.Logger
+	hosts map[string]*config.Host
+	log   *logrus.Logger
 	// mu        sync.Mutex
 	regOpts   []reg.Opts
 	schemes   map[string]scheme.API
@@ -67,7 +66,6 @@ type Opt func(*RegClient)
 // New returns a registry client
 func New(opts ...Opt) *RegClient {
 	var rc = RegClient{
-		certPaths: []string{},
 		hosts:     map[string]*config.Host{},
 		userAgent: DefaultUserAgent,
 		// logging is disabled by default
@@ -94,9 +92,6 @@ func New(opts ...Opt) *RegClient {
 	}
 
 	// configure regOpts
-	if len(rc.certPaths) > 0 {
-		rc.regOpts = append(rc.regOpts, reg.WithCertFiles(rc.certPaths))
-	}
 	hostList := []*config.Host{}
 	for _, h := range rc.hosts {
 		hostList = append(hostList, h)
@@ -128,9 +123,7 @@ func WithCertDir(path ...string) Opt {
 
 // WithDockerCerts adds certificates trusted by docker in /etc/docker/certs.d
 func WithDockerCerts() Opt {
-	return func(rc *RegClient) {
-		rc.certPaths = append(rc.certPaths, DockerCertDir)
-	}
+	return WithCertDir(DockerCertDir)
 }
 
 // WithDockerCreds adds configuration from users docker config with registry logins


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Fixes #178 
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

The handling for `/etc/docker/certs.d` incorrectly treated this as file instead of a directory of host certs.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Access a registry with a private certificate and copy the certificate or ca to `/etc/docker/certs.d/ca.crt`.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Fix handling of `/etc/docker/certs.d`
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [ ] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

My local e2e tests have been updated, but these are not pushed to the repo yet.