### PR TITLE
Switching to fixed uid/gid in docker builds

### DIFF
--- a/build/Dockerfile.regbot.buildkit
+++ b/build/Dockerfile.regbot.buildkit
@@ -9,7 +9,8 @@ RUN apk add --no-cache \
       ca-certificates \
       git \
       make
-RUN adduser -D appuser \
+RUN addgroup -g 1000 appuser \
+ && adduser -u 1000 -G appuser -D appuser \
  && mkdir -p /home/appuser/.docker \
  && chown -R appuser /home/appuser
 WORKDIR /src
@@ -66,7 +67,7 @@ COPY --link cmd/regbot/lua/ /lua/
 FROM ${REGISTRY}/library/alpine:${ALPINE_VER} as release-alpine
 COPY --link --from=build /etc/passwd /etc/group /etc/
 COPY --link --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=build --chown=appuser /home/appuser /home/appuser
+COPY --link --from=build --chown=1000:1000 /home/appuser /home/appuser
 COPY --link --from=docker-cred-ecr-login /usr/local/bin/docker-credential-* /usr/local/bin/
 COPY --link --from=docker-cred-gcr /usr/local/bin/docker-credential-* /usr/local/bin/
 COPY --link --from=build /src/bin/regbot /usr/local/bin/regbot
@@ -93,7 +94,7 @@ LABEL maintainer="" \
 FROM scratch as release-scratch
 COPY --link --from=build /etc/passwd /etc/group /etc/
 COPY --link --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=build --chown=appuser /home/appuser/ /home/appuser/
+COPY --link --from=build --chown=1000:1000 /home/appuser/ /home/appuser/
 COPY --link --from=build /src/bin/regbot /regbot
 COPY --link --from=lua-mods /lua/ /lua-mods/
 ENV LUA_PATH="?;?.lua;/lua-user/?;/lua-user/?.lua;/lua-mods/?;/lua-mods/?.lua"

--- a/build/Dockerfile.regctl.buildkit
+++ b/build/Dockerfile.regctl.buildkit
@@ -9,7 +9,8 @@ RUN apk add --no-cache \
       ca-certificates \
       git \
       make
-RUN adduser -D appuser \
+RUN addgroup -g 1000 appuser \
+ && adduser -u 1000 -G appuser -D appuser \
  && mkdir -p /home/appuser/.regctl \
  && chown -R appuser /home/appuser/.regctl
 WORKDIR /src
@@ -55,7 +56,7 @@ RUN --mount=type=cache,id=gomod,target=/go/pkg/mod/cache \
 FROM ${REGISTRY}/library/alpine:${ALPINE_VER} as release-alpine
 COPY --link --from=build /etc/passwd /etc/group /etc/
 COPY --link --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=build --chown=appuser /home/appuser/ /home/appuser/
+COPY --link --from=build --chown=1000:1000 /home/appuser/ /home/appuser/
 COPY --link --from=docker-cred-ecr-login /usr/local/bin/docker-credential-* /usr/local/bin/
 COPY --link --from=docker-cred-gcr /usr/local/bin/docker-credential-* /usr/local/bin/
 COPY --link --from=build /src/bin/regctl /usr/local/bin/regctl
@@ -80,7 +81,7 @@ LABEL maintainer="" \
 FROM scratch as release-scratch
 COPY --link --from=build /etc/passwd /etc/group /etc/
 COPY --link --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=build --chown=appuser /home/appuser/ /home/appuser/
+COPY --link --from=build --chown=1000:1000 /home/appuser/ /home/appuser/
 COPY --link --from=build /src/bin/regctl /regctl
 USER appuser
 ENTRYPOINT [ "/regctl" ]

--- a/build/Dockerfile.regsync.buildkit
+++ b/build/Dockerfile.regsync.buildkit
@@ -9,7 +9,8 @@ RUN apk add --no-cache \
       ca-certificates \
       git \
       make
-RUN adduser -D appuser \
+RUN addgroup -g 1000 appuser \
+ && adduser -u 1000 -G appuser -D appuser \
  && mkdir -p /home/appuser/.docker \
  && chown -R appuser /home/appuser
 WORKDIR /src
@@ -55,7 +56,7 @@ RUN --mount=type=cache,id=gomod,target=/go/pkg/mod/cache \
 FROM ${REGISTRY}/library/alpine:${ALPINE_VER} as release-alpine
 COPY --link --from=build /etc/passwd /etc/group /etc/
 COPY --link --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=build --chown=appuser /home/appuser/ /home/appuser/
+COPY --link --from=build --chown=1000:1000 /home/appuser/ /home/appuser/
 COPY --link --from=docker-cred-ecr-login /usr/local/bin/docker-credential-* /usr/local/bin/
 COPY --link --from=docker-cred-gcr /usr/local/bin/docker-credential-* /usr/local/bin/
 COPY --link --from=build /src/bin/regsync /usr/local/bin/regsync
@@ -80,7 +81,7 @@ LABEL maintainer="" \
 FROM scratch as release-scratch
 COPY --link --from=build /etc/passwd /etc/group /etc/
 COPY --link --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=build --chown=appuser /home/appuser/ /home/appuser/
+COPY --link --from=build --chown=1000:1000 /home/appuser/ /home/appuser/
 COPY --link --from=build /src/bin/regsync /regsync
 USER appuser
 ENTRYPOINT [ "/regsync" ]


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

GHA builds with `COPY --link --chown=appuser` were failing, likely because of an older version of docker in GHA. This moves over to fixed uid/gid which is needed for `--link` to work anyway.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

GHA docker builds won't fail.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
