### PR TITLE
Fix authentication token renewal handling

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -539,6 +539,10 @@ func (b *BearerHandler) addScope(scope string) error {
 	replaced := false
 	for i, cur := range b.scopes {
 		// extend an existing scope with more actions
+		if cur == scope {
+			// nothing has changed, return early
+			return nil
+		}
 		if strings.HasPrefix(scope, cur+",") {
 			b.scopes[i] = scope
 			replaced = true
@@ -725,9 +729,7 @@ func (b *BearerHandler) validateResponse(resp *http.Response) error {
 		b.token.ExpiresIn = minTokenLife
 	}
 
-	if b.token.IssuedAt.IsZero() {
-		b.token.IssuedAt = time.Now().UTC()
-	}
+	b.token.IssuedAt = time.Now().UTC()
 
 	// AccessToken and Token should be the same and we use Token elsewhere
 	if b.token.AccessToken != "" {


### PR DESCRIPTION
Signed-off-by: Argannor <thetwo@gmx.net>

### Fixes issue

Closes #189 

### Describe the change

- IssuedAt date is set everytime a new token is aquired, not just the first time
- If the Scope is already present (with == comparison), then the scope is not added another time

### How to verify it

See the steps outlined in #189 
Dependent on infrastructure, verified it with my GitLab instance.

### Changelog text

Fix authentication token renewal handling

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [ n/a ] Tests have been added or not applicable
- [ n/a ] Documentation has been added, updated, or not applicable
- [ x ] Changes have been rebased to main
- [ x ] Multiple commits to the same code have been squashed
