### PR TITLE
Fixing bearer auth renewing expired tokens

### DIFF
--- a/internal/reqresp/reqresp.go
+++ b/internal/reqresp/reqresp.go
@@ -112,7 +112,7 @@ func (r *rrHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		}
 		return
 	}
-	r.t.Errorf("Unhandled request: %v", req)
+	r.t.Errorf("Unhandled request: %v, body: %s", req, reqBody)
 	rw.WriteHeader(http.StatusInternalServerError)
 	rw.Write([]byte("Unsupported request"))
 }


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Fixes #189 
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Bug fix: Bearer auth was not properly renewing tokens, keeping values from the previous token, and duplicating scopes once the current token expired.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

A long running regsync job should continue to work without errors after the original token expires.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Fix bearer token renewals
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
