### PR TITLE
Updating Go from 1.16 to 1.17

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.16
+    - name: Set up Go 1.17
       uses: actions/setup-go@v2
       with:
-        go-version: 1.16.x
+        go-version: 1.17.x
       id: go
 
     - name: Check out code

--- a/build/Dockerfile.regbot
+++ b/build/Dockerfile.regbot
@@ -1,6 +1,6 @@
 ARG REGISTRY=docker.io
 ARG ALPINE_VER=3
-ARG GO_VER=1.16-alpine
+ARG GO_VER=1.17-alpine
 
 FROM ${REGISTRY}/library/golang:${GO_VER} as golang
 RUN apk add --no-cache \

--- a/build/Dockerfile.regbot.buildkit
+++ b/build/Dockerfile.regbot.buildkit
@@ -2,7 +2,7 @@
 
 ARG REGISTRY=docker.io
 ARG ALPINE_VER=3
-ARG GO_VER=1.16-alpine
+ARG GO_VER=1.17-alpine
 
 FROM --platform=$BUILDPLATFORM ${REGISTRY}/library/golang:${GO_VER} as golang
 RUN apk add --no-cache \

--- a/build/Dockerfile.regctl
+++ b/build/Dockerfile.regctl
@@ -1,6 +1,6 @@
 ARG REGISTRY=docker.io
 ARG ALPINE_VER=3
-ARG GO_VER=1.16-alpine
+ARG GO_VER=1.17-alpine
 
 FROM ${REGISTRY}/library/golang:${GO_VER} as golang
 RUN apk add --no-cache \

--- a/build/Dockerfile.regctl.buildkit
+++ b/build/Dockerfile.regctl.buildkit
@@ -2,7 +2,7 @@
 
 ARG REGISTRY=docker.io
 ARG ALPINE_VER=3
-ARG GO_VER=1.16-alpine
+ARG GO_VER=1.17-alpine
 
 FROM --platform=$BUILDPLATFORM ${REGISTRY}/library/golang:${GO_VER} as golang
 RUN apk add --no-cache \

--- a/build/Dockerfile.regsync
+++ b/build/Dockerfile.regsync
@@ -1,6 +1,6 @@
 ARG REGISTRY=docker.io
 ARG ALPINE_VER=3
-ARG GO_VER=1.16-alpine
+ARG GO_VER=1.17-alpine
 
 FROM ${REGISTRY}/library/golang:${GO_VER} as golang
 RUN apk add --no-cache \

--- a/build/Dockerfile.regsync.buildkit
+++ b/build/Dockerfile.regsync.buildkit
@@ -2,7 +2,7 @@
 
 ARG REGISTRY=docker.io
 ARG ALPINE_VER=3
-ARG GO_VER=1.16-alpine
+ARG GO_VER=1.17-alpine
 
 FROM --platform=$BUILDPLATFORM ${REGISTRY}/library/golang:${GO_VER} as golang
 RUN apk add --no-cache \

--- a/go.mod
+++ b/go.mod
@@ -1,16 +1,12 @@
 module github.com/regclient/regclient
 
-go 1.16
+go 1.17
 
 require (
 	github.com/docker/cli v20.10.12+incompatible
-	github.com/docker/docker v20.10.12+incompatible // indirect
-	github.com/docker/docker-credential-helpers v0.6.4 // indirect
 	github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7
 	github.com/google/uuid v1.2.0
-	github.com/kr/pretty v0.2.1 // indirect
 	github.com/opencontainers/go-digest v1.0.0
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.3.0
@@ -19,5 +15,14 @@ require (
 	golang.org/x/sys v0.0.0-20220227234510-4e6760a101f9
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
 	gopkg.in/yaml.v2 v2.4.0
+)
+
+require (
+	github.com/docker/docker v20.10.12+incompatible // indirect
+	github.com/docker/docker-credential-helpers v0.6.4 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/kr/pretty v0.2.1 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
 	gotest.tools/v3 v3.0.3 // indirect
 )

--- a/mod/config.go
+++ b/mod/config.go
@@ -20,8 +20,7 @@ func WithConfigTimestampFromLabel(label string) Opts {
 			if !ok {
 				return fmt.Errorf("label not found: %s", label)
 			}
-			t := time.Time{}
-			t, err = time.Parse(time.RFC3339, tl)
+			t, err := time.Parse(time.RFC3339, tl)
 			if err != nil {
 				// TODO: add fallbacks
 				return fmt.Errorf("could not parse time %s from %s: %w", tl, label, err)


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Go 1.16 is no longer supported. Upstream tools like staticcheck no longer work with 1.16.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

All instances of 1.16 were updated to 1.17. `go mod tidy` and `go mod vendor`.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

CI should succeed.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Upgrade to Go 1.17
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
