### PR TITLE
Remove deprecated title template function

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -59,8 +59,6 @@ The following functions have been added in addition to the defaults available in
     Returns current time object, e.g. `{{ $t := time.Now }}{{printf "%d%d%d" $t.Year $t.Month $t.Day}}`.
   - `time.Parse`:
     Parses string using layout into time object, e.g. `{{ $t := time.Parse "2006-01-02" "2020-06-07"}}`.
-- `title`:
-  Makes the first letter of each word uppercase.
 - `upper`:
   Converts a string to uppercase.
 

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -49,7 +49,6 @@ var tmplFuncs = gotemplate.FuncMap{
 	"lower":       strings.ToLower,
 	"split":       strings.Split,
 	"time":        func() *TimeFuncs { return &TimeFuncs{} },
-	"title":       strings.Title,
 	"upper":       strings.ToUpper,
 }
 


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Fixes #192 
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Go 1.18 has deprecated `strings.Title`: https://github.com/golang/go/issues/48367
This removes the template that calls this function.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Format strings that use `title` will no longer work.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Breaking: format templates no longer support `title`
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
