### PR TITLE
Setting trimpath on go build

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -176,7 +176,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2020 The regctl Authors.
+   Copyright 2020 The regclient Authors.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ ifneq ($(shell git status --porcelain 2>/dev/null),)
 endif
 VCS_TAG:=$(shell git describe --tags --abbrev=0 2>/dev/null || true)
 LD_FLAGS=-s -w -extldflags -static
-GO_BUILD_FLAGS=-ldflags "$(LD_FLAGS)" -tags nolegacy
+GO_BUILD_FLAGS=-trimpath -ldflags "$(LD_FLAGS)" -tags nolegacy
 DOCKERFILE_EXT:=$(shell if docker build --help 2>/dev/null | grep -q -- '--progress'; then echo ".buildkit"; fi)
 DOCKER_ARGS=--build-arg "VCS_REF=$(VCS_REF)"
 GOPATH:=$(shell go env GOPATH)


### PR DESCRIPTION
This also fixes a minor license detail.

Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Using `-trimpath` on go build, removing host specific details from output binary.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Searching the binary should not show any host specific paths.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Go build now runs with `-trimpath`
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
