### PR TITLE
Use default transport instead of empty transport

### DIFF
--- a/internal/reghttp/http.go
+++ b/internal/reghttp/http.go
@@ -405,7 +405,7 @@ func (resp *clientResp) Next() error {
 				httpClient = *h.httpClient
 			} else if h.config.TLS == config.TLSInsecure || len(c.rootCAPool) > 0 || len(c.rootCADirs) > 0 || h.config.RegCert != "" {
 				if httpClient.Transport == nil {
-					httpClient.Transport = &http.Transport{}
+					httpClient.Transport = http.DefaultTransport.(*http.Transport).Clone()
 				}
 				t, ok := httpClient.Transport.(*http.Transport)
 				if ok {


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Running through a proxy did not work.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

The default transport needed to be used instead of an empty transport when setting up a new client.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Running with `https_transport` defined uses that proxy.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Fix handling of http_proxy and https_proxy
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [ ] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
