### PR TITLE
Fix manifest head with digest on ocidir

### DIFF
--- a/scheme/ocidir/manifest_test.go
+++ b/scheme/ocidir/manifest_test.go
@@ -32,6 +32,22 @@ func TestManifest(t *testing.T) {
 		t.Errorf("manifest head: %v", err)
 		return
 	}
+	// manifest head on a child digest
+	rh, err := ref.New("ocidir://testdata/regctl@sha256:41770c110431b0ffc5f577aa44968bfbfd79e92eb0929e37f006179fd4aeddcc")
+	if err != nil {
+		t.Errorf("failed to parse ref %s: %v", rs, err)
+	}
+	_, err = o.ManifestHead(ctx, rh)
+	if err != nil {
+		t.Errorf("manifest head failed on child digest: %v", err)
+		return
+	}
+	rh.Digest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	_, err = o.ManifestHead(ctx, rh)
+	if err == nil {
+		t.Errorf("manifest head succeeded on missing digest: %s", rh.CommonName())
+		return
+	}
 	// manifest list
 	ml, err := o.ManifestGet(ctx, r)
 	if err != nil {

--- a/scheme/ocidir/tag_test.go
+++ b/scheme/ocidir/tag_test.go
@@ -33,7 +33,7 @@ func TestTag(t *testing.T) {
 	rCp := r
 
 	t.Run("TagList", func(t *testing.T) {
-		exTags := []string{"latest", "v0.3", "v0.3.10"}
+		exTags := []string{"broken", "latest", "v0.3", "v0.3.10"}
 		tl, err := oMem.TagList(ctx, r)
 		if err != nil {
 			t.Errorf("failed to retrieve tag list: %v", err)
@@ -49,7 +49,7 @@ func TestTag(t *testing.T) {
 	})
 
 	t.Run("TagDelete", func(t *testing.T) {
-		exTags := []string{"v0.3"}
+		exTags := []string{"broken", "v0.3"}
 		rCp.Tag = "missing"
 		err := oMem.TagDelete(ctx, rCp)
 		if err == nil || !errors.Is(err, types.ErrNotFound) {

--- a/scheme/ocidir/testdata/regctl/index.json
+++ b/scheme/ocidir/testdata/regctl/index.json
@@ -25,6 +25,14 @@
       "annotations": {
         "org.opencontainers.image.ref.name": "latest"
       }
+    },
+    {
+      "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
+      "digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "size": 2342,
+      "annotations": {
+        "org.opencontainers.image.ref.name": "broken"
+      }
     }
   ]
 }


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Manifest head on an ocidir with a digest was giving a false positive.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Updates manifest head to follow the same logic as manifest get, and also parses the file for the media type and size.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Image export to an ocidir of an index should not be missing manifests.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Fix: manifest head on an ocidir with a digest won't succeed if manifest is missing
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
