### PR TITLE
Remove tty from example container commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,10 +99,10 @@ Merges into the main branch also have binaries available as artifacts within [Gi
 
 You can run `regctl`, `regsync`, and `regbot` in a container.
 
-For `regctl`:
+For `regctl` (include a `-t` for any commands that require a tty, e.g. `registry login`):
 
 ```shell
-docker container run -it --rm --net host \
+docker container run -i --rm --net host \
   -v regctl-conf:/home/appuser/.regctl/ \
   regclient/regctl:latest --help
 ```
@@ -110,7 +110,7 @@ docker container run -it --rm --net host \
 For `regsync`:
 
 ```shell
-docker container run -it --rm --net host \
+docker container run -i --rm --net host \
   -v "$(pwd)/regsync.yml:/home/appuser/regsync.yml" \
   regclient/regsync:latest -c /home/appuser/regsync.yml check
 ```
@@ -118,7 +118,7 @@ docker container run -it --rm --net host \
 For `regbot`:
 
 ```shell
-docker container run -it --rm --net host \
+docker container run -i --rm --net host \
   -v "$(pwd)/regbot.yml:/home/appuser/regbot.yml" \
   regclient/regbot:latest -c /home/appuser/regbot.yml once --dry-run
 ```
@@ -127,7 +127,7 @@ Or on Linux and Mac environments, you can run `regctl` as your own user and save
 configuration settings, use docker credentials, and use any docker certs:
 
 ```shell
-docker container run -it --rm --net host \
+docker container run -i --rm --net host \
   -u "$(id -u):$(id -g)" -e HOME -v $HOME:$HOME \
   -v /etc/docker/certs.d:/etc/docker/certs.d:ro \
   regclient/regctl:latest --help
@@ -138,8 +138,11 @@ And `regctl` can be packaged as a shell script with:
 ```shell
 cat >regctl <<EOF
 #!/bin/sh
-
-docker container run -it --rm --net host \\
+opts=""
+case "\$*" in
+  "registry login"*) opts="-t";;
+esac
+docker container run \$opts -i --rm --net host \\
   -u "\$(id -u):\$(id -g)" -e HOME -v \$HOME:\$HOME \\
   -v /etc/docker/certs.d:/etc/docker/certs.d:ro \\
   regclient/regctl:latest "\$@"
@@ -147,6 +150,9 @@ EOF
 chmod 755 regctl
 ./regctl --help
 ```
+
+Images are also included with an alpine base, which are useful for CI pipelines that expect the container to include a `/bin/sh`.
+These alpine based images also include the `ecr-login` and `gcr` credential helpers.
 
 ## Installing as a Docker CLI Plugin
 


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Fixes #201 
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Most commands do not need a tty, and including it outputs carriage-returns that break a few things. This changes updates the readme with better directions.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

This should output `0`:
```
regctl image digest alpine | grep -c $'\r'
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
