### PR TITLE
Add template vars to regsync source and target

### DIFF
--- a/cmd/regsync/config.go
+++ b/cmd/regsync/config.go
@@ -185,6 +185,9 @@ func ConfigLoadFile(filename string) (*Config, error) {
 
 // expand templates in various parts of the config
 func configExpandTemplates(c *Config) error {
+	dataSync := struct {
+		Sync ConfigSync
+	}{}
 	for i := range c.Creds {
 		val, err := template.String(c.Creds[i].Registry, nil)
 		if err != nil {
@@ -208,12 +211,14 @@ func configExpandTemplates(c *Config) error {
 		c.Creds[i].RegCert = val
 	}
 	for i := range c.Sync {
-		val, err := template.String(c.Sync[i].Source, nil)
+		dataSync.Sync = c.Sync[i]
+		val, err := template.String(c.Sync[i].Source, dataSync)
 		if err != nil {
 			return err
 		}
 		c.Sync[i].Source = val
-		val, err = template.String(c.Sync[i].Target, nil)
+		dataSync.Sync.Source = val
+		val, err = template.String(c.Sync[i].Target, dataSync)
 		if err != nil {
 			return err
 		}

--- a/cmd/regsync/regsync_test.go
+++ b/cmd/regsync/regsync_test.go
@@ -329,5 +329,57 @@ func TestRegsync(t *testing.T) {
 			}
 		})
 	}
+}
 
+func TestConfigRead(t *testing.T) {
+	cRead := bytes.NewReader([]byte(`
+    version: 1
+    creds:
+      - registry: registry:5000
+        tls: disabled
+      - registry: docker.io
+    defaults:
+      ratelimit:
+        min: 100
+        retry: 15m
+      parallel: 2
+      interval: 60m
+      backup: "bkup-{{.Ref.Tag}}"
+    x-sync-hub: &sync-hub
+      target: registry:5000/hub/{{ .Sync.Source }}
+    x-sync-gcr: &sync-gcr
+      target: registry:5000/gcr/{{ index (split .Sync.Source "gcr.io/") 1 }}
+    sync:
+      - source: busybox:latest
+        target: registry:5000/library/busybox:latest
+        type: image
+      - <<: *sync-hub
+        source: alpine
+        type: repository
+        tags:
+          allow:
+          - 3
+          - 3.9
+          - latest
+      - <<: *sync-gcr
+        source: gcr.io/example/repo
+        type: repository
+        tags:
+          allow:
+          - 3
+          - 3.9
+          - latest
+  `))
+	c, err := ConfigLoadReader(cRead)
+	if err != nil {
+		t.Errorf("Filed to load reader: %v", err)
+		return
+	}
+	if c.Sync[1].Target != "registry:5000/hub/alpine" {
+		t.Errorf("template sync-hub mismatch, expected: %s, received: %s", "registry:5000/hub/alpine", c.Sync[1].Target)
+	}
+	if c.Sync[2].Target != "registry:5000/gcr/example/repo" {
+		t.Errorf("template sync-gcr mismatch, expected: %s, received: %s", "registry:5000/gcr/example/repo", c.Sync[2].Target)
+	}
+	// TODO: test remainder of templates and parsing
 }

--- a/cmd/regsync/root.go
+++ b/cmd/regsync/root.go
@@ -705,7 +705,8 @@ func (s ConfigSync) processRef(ctx context.Context, src, tgt ref.Ref, action str
 		data := struct {
 			Ref  ref.Ref
 			Step ConfigSync
-		}{Ref: tgt, Step: s}
+			Sync ConfigSync
+		}{Ref: tgt, Step: s, Sync: s}
 		backupStr, err := template.String(s.Backup, data)
 		if err != nil {
 			log.WithFields(logrus.Fields{

--- a/docs/regsync.md
+++ b/docs/regsync.md
@@ -203,7 +203,22 @@ sync:
   Any field beginning with `x-` is considered a user extension and will not be parsed in current or future versions of the project.
   These are useful for integrating your own tooling, or setting values for yaml anchors and aliases.
 
+## Templates
+
 [Go templates](https://golang.org/pkg/text/template/) are used to expand values in `registry`, `user`, `pass`, `regcert`, `source`, `target`, and `backup`.
+
+The `source` and `target` templates support the following objects:
+
+- `.Sync`: Values from the current sync step
+  - `.Sync.Source`: Source
+  - `.Sync.Target`: Target
+  - `.Sync.Type`: Type
+  - `.Sync.Backup`: Backup
+  - `.Sync.Interval`: Interval
+  - `.Sync.Schedule`: Schedule
+
+Note that `source` is expanded before `target`, and both are expanded before `backup`.
+
 The `backup` template supports the following objects:
 
 - `.Ref`: Reference object about to be overwritten
@@ -211,12 +226,12 @@ The `backup` template supports the following objects:
   - `.Ref.Registry`: Registry name
   - `.Ref.Repository`: Repository
   - `.Ref.Tag`: Tag
-- `.Step`: Values from the current step
-  - `.Step.Source`: Source
-  - `.Step.Target`: Target
-  - `.Step.Type`: Type
-  - `.Step.Backup`: Backup
-  - `.Step.Interval`: Interval
-  - `.Step.Schedule`: Schedule
+- `.Sync`: Values from the current sync step
+  - `.Sync.Source`: Source
+  - `.Sync.Target`: Target
+  - `.Sync.Type`: Type
+  - `.Sync.Backup`: Backup
+  - `.Sync.Interval`: Interval
+  - `.Sync.Schedule`: Schedule
 
 See [Template Functions](README.md#Template-Functions) for more details on the custom functions available in templates.


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

This is an alternative for #204 
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

The source and target fields of regsync now support a `.Sync` template variable that can be used to query other settings within the sync entry.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Using a regsync.yml file similar to the following allows the target to be based on the source in a reusable way:

```yml
version: 1
creds:
  - registry: registry:5000
    tls: disabled
x-sync-hub: &sync-hub
  target: registry:5000/hub/{{ .Sync.Source }}
  type: repository
x-sync-gcr: &sync-gcr
  target: registry:5000/gcr/{{ index (split .Sync.Source "gcr.io/") 1 }}
  type: repository
sync:
  - <<: *sync-hub
    source: alpine
    tags:
      allow:
      - 3
      - 3.9
      - latest
  - <<: *sync-hub
    source: busybox
    tags:
      allow:
      - latest
  - <<: *sync-gcr
    source: gcr.io/example/repo
    tags:
      allow:
      - 1
      - 1.5
      - latest
```

<!-- Include steps that can be taken to verify the change -->

### Changelog text

regsync now supports the `.Sync` template variable on source and target
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
