### PR TITLE
Support annotations on docker2 media types

### DIFF
--- a/mod/mod_test.go
+++ b/mod/mod_test.go
@@ -82,6 +82,13 @@ func TestMod(t *testing.T) {
 			ref: "ocidir://testrepo:v1",
 		},
 		{
+			name: "Delete Annotation",
+			opts: []Opts{
+				WithAnnotation("org.example.version", ""),
+			},
+			ref: "ocidir://testrepo:v1",
+		},
+		{
 			name: "Add Base Annotations",
 			opts: []Opts{
 				WithAnnotationOCIBase(bRef, bDig),

--- a/types/docker/schema2/manifest.go
+++ b/types/docker/schema2/manifest.go
@@ -21,4 +21,8 @@ type Manifest struct {
 	// Layers lists descriptors for the layers referenced by the
 	// configuration.
 	Layers []types.Descriptor `json:"layers"`
+
+	// Annotations contains arbitrary metadata for the image index.
+	// Note, this is not a defined docker schema2 field.
+	Annotations map[string]string `json:"annotations,omitempty"`
 }

--- a/types/docker/schema2/manifestlist.go
+++ b/types/docker/schema2/manifestlist.go
@@ -17,4 +17,8 @@ type ManifestList struct {
 
 	// Config references the image configuration as a blob.
 	Manifests []types.Descriptor `json:"manifests"`
+
+	// Annotations contains arbitrary metadata for the image index.
+	// Note, this is not a defined docker schema2 field.
+	Annotations map[string]string `json:"annotations,omitempty"`
 }

--- a/types/manifest/docker2.go
+++ b/types/manifest/docker2.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"text/tabwriter"
 
 	// crypto libraries included for go-digest
@@ -120,6 +121,18 @@ func (m *docker2Manifest) MarshalPretty() ([]byte, error) {
 	}
 	fmt.Fprintf(tw, "MediaType:\t%s\n", m.desc.MediaType)
 	fmt.Fprintf(tw, "Digest:\t%s\n", m.desc.Digest.String())
+	if m.Annotations != nil && len(m.Annotations) > 0 {
+		fmt.Fprintf(tw, "Annotations:\t\n")
+		keys := make([]string, 0, len(m.Annotations))
+		for k := range m.Annotations {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, name := range keys {
+			val := m.Annotations[name]
+			fmt.Fprintf(tw, "  %s:\t%s\n", name, val)
+		}
+	}
 	var total int64
 	for _, d := range m.Layers {
 		total += d.Size
@@ -154,6 +167,18 @@ func (m *docker2ManifestList) MarshalPretty() ([]byte, error) {
 	}
 	fmt.Fprintf(tw, "MediaType:\t%s\n", m.desc.MediaType)
 	fmt.Fprintf(tw, "Digest:\t%s\n", m.desc.Digest.String())
+	if m.Annotations != nil && len(m.Annotations) > 0 {
+		fmt.Fprintf(tw, "Annotations:\t\n")
+		keys := make([]string, 0, len(m.Annotations))
+		for k := range m.Annotations {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, name := range keys {
+			val := m.Annotations[name]
+			fmt.Fprintf(tw, "  %s:\t%s\n", name, val)
+		}
+	}
 	fmt.Fprintf(tw, "\t\n")
 	fmt.Fprintf(tw, "Manifests:\t\n")
 	for _, d := range m.Manifests {

--- a/types/manifest/manifest.go
+++ b/types/manifest/manifest.go
@@ -222,6 +222,7 @@ func OCIIndexFromAny(orig interface{}) (v1.Index, error) {
 	switch orig := orig.(type) {
 	case schema2.ManifestList:
 		ociI.Manifests = orig.Manifests
+		ociI.Annotations = orig.Annotations
 	case v1.Index:
 		ociI = orig
 	default:
@@ -247,6 +248,7 @@ func OCIIndexToAny(ociI v1.Index, origP interface{}) error {
 	case schema2.ManifestList:
 		orig.Versioned = schema2.ManifestListSchemaVersion
 		orig.Manifests = ociI.Manifests
+		orig.Annotations = ociI.Annotations
 		rv.Set(reflect.ValueOf(orig))
 	case v1.Index:
 		rv.Set(reflect.ValueOf(ociI))
@@ -265,6 +267,7 @@ func OCIManifestFromAny(orig interface{}) (v1.Manifest, error) {
 	case schema2.Manifest:
 		ociM.Config = orig.Config
 		ociM.Layers = orig.Layers
+		ociM.Annotations = orig.Annotations
 	case v1.Manifest:
 		ociM = orig
 	default:
@@ -292,6 +295,7 @@ func OCIManifestToAny(ociM v1.Manifest, origP interface{}) error {
 		orig.Versioned = schema2.ManifestSchemaVersion
 		orig.Config = ociM.Config
 		orig.Layers = ociM.Layers
+		orig.Annotations = ociM.Annotations
 		rv.Set(reflect.ValueOf(orig))
 	case v1.Manifest:
 		rv.Set(reflect.ValueOf(ociM))

--- a/types/manifest/manifest_test.go
+++ b/types/manifest/manifest_test.go
@@ -46,7 +46,10 @@ var (
 						"digest": "sha256:9767ed5c27ebed39ff76afe979043e52dc7714c78d1dda8a8581965e06be2535",
 						"size": 3535944
 				}
-			]
+			],
+			"annotations": {
+				"org.example.test": "hello world"
+			}
 		}
 	`)
 	rawDockerSchema2List = []byte(`
@@ -119,8 +122,11 @@ var (
 					"os": "linux"
 				}
 			}
-		]
-	}
+			],
+			"annotations": {
+				"org.example.test": "hello world"
+			}
+		}
 	`)
 	rawAmbiguousOCI = []byte(`
 		{
@@ -157,7 +163,10 @@ var (
 						"os": "linux"
 					}
 				}
-			]
+			],
+			"annotations": {
+				"org.example.test": "hello world"
+			}
 		}
 	`)
 	rawOCIImage = []byte(`
@@ -196,7 +205,10 @@ var (
 						"os": "linux"
 					}
 				}
-			]
+			],
+			"annotations": {
+				"org.example.test": "hello world"
+			}
 		}
 	`)
 	rawOCIIndex = []byte(`
@@ -235,7 +247,10 @@ var (
 						"os": "linux"
 					}
 				}
-			]
+			],
+			"annotations": {
+				"org.example.test": "hello world"
+			}
 		}
 	`)
 	// signed schemas are white space sensitive, contents here must be indented with 3 spaces, no tabs
@@ -702,6 +717,19 @@ func TestModify(t *testing.T) {
 		t.Errorf("failed to unmarshal OCI index json: %v", err)
 		return
 	}
+	if manifestDockerSchema2.Annotations == nil || manifestDockerSchema2.Annotations["org.example.test"] != "hello world" {
+		t.Errorf("annotation missing from docker manifest")
+	}
+	if manifestDockerSchema2List.Annotations == nil || manifestDockerSchema2List.Annotations["org.example.test"] != "hello world" {
+		t.Errorf("annotation missing from docker manifest list")
+	}
+	if manifestOCIImage.Annotations == nil || manifestOCIImage.Annotations["org.example.test"] != "hello world" {
+		t.Errorf("annotation missing from oci image")
+	}
+	if manifestOCIIndex.Annotations == nil || manifestOCIIndex.Annotations["org.example.test"] != "hello world" {
+		t.Errorf("annotation missing from oci index")
+	}
+
 	t.Run("BadIndex", func(t *testing.T) {
 		_, err = OCIIndexFromAny(manifestDockerSchema2)
 		if err == nil {

--- a/types/manifest/oci1.go
+++ b/types/manifest/oci1.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"text/tabwriter"
 
 	// crypto libraries included for go-digest
@@ -124,6 +125,18 @@ func (m *oci1Manifest) MarshalPretty() ([]byte, error) {
 	}
 	fmt.Fprintf(tw, "MediaType:\t%s\n", m.desc.MediaType)
 	fmt.Fprintf(tw, "Digest:\t%s\n", m.desc.Digest.String())
+	if m.Annotations != nil && len(m.Annotations) > 0 {
+		fmt.Fprintf(tw, "Annotations:\t\n")
+		keys := make([]string, 0, len(m.Annotations))
+		for k := range m.Annotations {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, name := range keys {
+			val := m.Annotations[name]
+			fmt.Fprintf(tw, "  %s:\t%s\n", name, val)
+		}
+	}
 	var total int64
 	for _, d := range m.Layers {
 		total += d.Size
@@ -160,7 +173,13 @@ func (m *oci1Index) MarshalPretty() ([]byte, error) {
 	fmt.Fprintf(tw, "Digest:\t%s\n", m.desc.Digest.String())
 	if m.Annotations != nil && len(m.Annotations) > 0 {
 		fmt.Fprintf(tw, "Annotations:\t\n")
-		for name, val := range m.Annotations {
+		keys := make([]string, 0, len(m.Annotations))
+		for k := range m.Annotations {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, name := range keys {
+			val := m.Annotations[name]
 			fmt.Fprintf(tw, "  %s:\t%s\n", name, val)
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This adds support for annotations on docker2 manifest types. This may not be supported on registries that reject unknown fields.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```
regctl image mod --annotation key=value registry.example.org/repo/image:tag --create new-tag
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Add support for annotations on docker2 schemas
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
