### PR TITLE
Handle multiple tags to same digest in ocidir

### DIFF
--- a/scheme/ocidir/ocidir.go
+++ b/scheme/ocidir/ocidir.go
@@ -223,11 +223,10 @@ func indexSet(index *v1.Index, r ref.Ref, d types.Descriptor) error {
 	// search for existing
 	for i := range index.Manifests {
 		var name string
-		var ok bool
-		if r.Tag != "" && index.Manifests[i].Annotations != nil {
-			name, ok = index.Manifests[i].Annotations[aRefName]
+		if index.Manifests[i].Annotations != nil {
+			name = index.Manifests[i].Annotations[aRefName]
 		}
-		if (index.Manifests[i].Digest == d.Digest && !ok) || (ok && name == r.Tag) {
+		if (name == "" && index.Manifests[i].Digest == d.Digest) || (r.Tag != "" && name == r.Tag) {
 			index.Manifests[i] = d
 			pos = i
 			break
@@ -237,11 +236,12 @@ func indexSet(index *v1.Index, r ref.Ref, d types.Descriptor) error {
 		// existing entry was replaced, remove any dup entries
 		for i := len(index.Manifests) - 1; i > pos; i-- {
 			var name string
-			var ok bool
-			if r.Tag != "" && index.Manifests[i].Annotations != nil {
-				name, ok = index.Manifests[i].Annotations[aRefName]
+			if index.Manifests[i].Annotations != nil {
+				name = index.Manifests[i].Annotations[aRefName]
 			}
-			if (index.Manifests[i].Digest == d.Digest && !ok) || (ok && name == r.Tag) {
+			// prune entries without any tag and a matching digest
+			// or entries with a matching tag
+			if (name == "" && index.Manifests[i].Digest == d.Digest) || (r.Tag != "" && name == r.Tag) {
 				index.Manifests = append(index.Manifests[:i], index.Manifests[i+1:]...)
 			}
 		}


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Pushing a second tag to the same digest in ocidir would result in deleting the first tag.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Handling new entries to index.json has been fixed for entries with another tag.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
regctl image copy regclient/regctl ocidir://repo:regctl1
regctl image copy regclient/regctl ocidir://repo:regctl2
regctl tag ls ocidir://repo
```

<!-- Include steps that can be taken to verify the change -->

### Changelog text

Fix handling of ocidir when multiple tags point to the same digest
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
