### PR TITLE
Fixing args to regctl mod

### DIFF
--- a/cmd/regctl/image.go
+++ b/cmd/regctl/image.go
@@ -265,7 +265,7 @@ func init() {
 	imageModCmd.Flags().VarP(&modFlagFunc{
 		t: "stringArray",
 		f: func(val string) error {
-			imageOpts.modOpts = append(imageOpts.modOpts, mod.WithExposeAdd(val))
+			imageOpts.modOpts = append(imageOpts.modOpts, mod.WithExposeRm(val))
 			return nil
 		},
 	}, "expose-rm", "", `delete an exposed port`)
@@ -373,7 +373,7 @@ func init() {
 	imageModCmd.Flags().VarP(&modFlagFunc{
 		t: "stringArray",
 		f: func(val string) error {
-			imageOpts.modOpts = append(imageOpts.modOpts, mod.WithVolumeAdd(val))
+			imageOpts.modOpts = append(imageOpts.modOpts, mod.WithVolumeRm(val))
 			return nil
 		},
 	}, "volume-rm", "", `delete a volume definition`)
@@ -530,6 +530,7 @@ func runImageMod(cmd *cobra.Command, args []string) error {
 			}
 		} else {
 			rNew = r
+			rNew.Digest = ""
 			rNew.Tag = imageOpts.create
 		}
 	} else if imageOpts.replace {

--- a/mod/mod.go
+++ b/mod/mod.go
@@ -210,8 +210,10 @@ func Apply(ctx context.Context, rc *regclient.RegClient, r ref.Ref, opts ...Opts
 	if err != nil {
 		return rMod, err
 	}
-	rMod.Digest = string(dm.newDesc.Digest)
-	rMod.Tag = ""
+	if dm.mod == replaced {
+		rMod.Digest = string(dm.newDesc.Digest)
+		rMod.Tag = ""
+	}
 	return rMod, nil
 }
 


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

`regctl image mod` called the wrong functions for `volume-rm` and `expose-rm`.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This calls the right functions on the rm commands.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

`regctl image mod --expose-rm ...` or `regctl image mod --volume-rm ...`
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Fix: regctl image mod args for expose and volume rm actually rm
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
