### PR TITLE
Fix handling of boolean args to image mod

### DIFF
--- a/cmd/regctl/image.go
+++ b/cmd/regctl/image.go
@@ -158,6 +158,7 @@ func init() {
 
 	imageModCmd.Flags().StringVarP(&imageOpts.create, "create", "", "", "Create tag")
 	imageModCmd.Flags().BoolVarP(&imageOpts.replace, "replace", "", false, "Replace tag (ignored when \"create\" is used)")
+	// most image mod flags are order dependent, so they are added using VarP/VarPF to append to modOpts
 	imageModCmd.Flags().VarP(&modFlagFunc{
 		t: "stringArray",
 		f: func(val string) error {
@@ -283,7 +284,7 @@ func init() {
 			return nil
 		},
 	}, "label", "", `set an label (name=value)`)
-	imageModCmd.Flags().VarP(&modFlagFunc{
+	flagLabelAnnot := imageModCmd.Flags().VarPF(&modFlagFunc{
 		t: "bool",
 		f: func(val string) error {
 			b, err := strconv.ParseBool(val)
@@ -296,6 +297,7 @@ func init() {
 			return nil
 		},
 	}, "label-to-annotation", "", `set annotations from labels`)
+	flagLabelAnnot.NoOptDefVal = "true"
 	imageModCmd.Flags().VarP(&modFlagFunc{
 		t: "string",
 		f: func(val string) error {
@@ -350,7 +352,7 @@ func init() {
 			return nil
 		},
 	}, "time-max", "", `max timestamp for both the config and layers`)
-	imageModCmd.Flags().VarP(&modFlagFunc{
+	flagOCI := imageModCmd.Flags().VarPF(&modFlagFunc{
 		t: "bool",
 		f: func(val string) error {
 			b, err := strconv.ParseBool(val)
@@ -363,6 +365,7 @@ func init() {
 			return nil
 		},
 	}, "to-oci", "", `convert to OCI media types`)
+	flagOCI.NoOptDefVal = "true"
 	imageModCmd.Flags().VarP(&modFlagFunc{
 		t: "stringArray",
 		f: func(val string) error {
@@ -590,6 +593,10 @@ func runImageRateLimit(cmd *cobra.Command, args []string) error {
 type modFlagFunc struct {
 	f func(string) error
 	t string
+}
+
+func (m *modFlagFunc) IsBoolFlag() bool {
+	return m.t == "bool"
 }
 
 func (m *modFlagFunc) String() string {


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Fixes handling of boolean args to `regctl image mod` without the `=true` default.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This configures the arg as a bool with a `NoOptDefVal` setting.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

`regctl image mod --to-oci --create $target $source`
<!-- Include steps that can be taken to verify the change -->

### Changelog text

<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [ ] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
