### PR TITLE
Improve handling of external URLs

### DIFF
--- a/blob.go
+++ b/blob.go
@@ -15,6 +15,8 @@ import (
 // If the blob already exists in the target, the copy is skipped
 // A server side cross repository blob mount is attempted
 func (rc *RegClient) BlobCopy(ctx context.Context, refSrc ref.Ref, refTgt ref.Ref, d types.Descriptor) error {
+	tDesc := d
+	tDesc.URLs = []string{} // ignore URLs when pushing to target
 	// for the same repository, there's nothing to copy
 	if ref.EqualRepository(refSrc, refTgt) {
 		rc.log.WithFields(logrus.Fields{
@@ -25,7 +27,7 @@ func (rc *RegClient) BlobCopy(ctx context.Context, refSrc ref.Ref, refTgt ref.Re
 		return nil
 	}
 	// check if layer already exists
-	if _, err := rc.BlobHead(ctx, refTgt, d); err == nil {
+	if _, err := rc.BlobHead(ctx, refTgt, tDesc); err == nil {
 		rc.log.WithFields(logrus.Fields{
 			"tgt":    refTgt.Reference,
 			"digest": d,

--- a/blob_test.go
+++ b/blob_test.go
@@ -737,4 +737,5 @@ func TestBlobPut(t *testing.T) {
 
 	})
 
+	// TODO: Test BlobCopy, with and without external URLs
 }

--- a/cmd/regbot/sandbox/image.go
+++ b/cmd/regbot/sandbox/image.go
@@ -171,9 +171,10 @@ func (s *Sandbox) imageCopy(ls *lua.LState) int {
 	tgt := s.checkReference(ls, 2)
 	opts := []regclient.ImageOpts{}
 	lOpts := struct {
-		DigestTags     bool     `json:"digestTags"`
-		ForceRecursive bool     `json:"forceRecursive"`
-		Platforms      []string `json:"platforms"`
+		DigestTags      bool     `json:"digestTags"`
+		ForceRecursive  bool     `json:"forceRecursive"`
+		IncludeExternal bool     `json:"includeExternal"`
+		Platforms       []string `json:"platforms"`
 	}{}
 	if ls.GetTop() == 3 {
 		err := go2lua.Import(ls, ls.Get(3), &lOpts, lOpts)
@@ -186,6 +187,9 @@ func (s *Sandbox) imageCopy(ls *lua.LState) int {
 		if lOpts.ForceRecursive {
 			opts = append(opts, regclient.ImageWithForceRecursive())
 		}
+		if lOpts.IncludeExternal {
+			opts = append(opts, regclient.ImageWithIncludeExternal())
+		}
 		if len(lOpts.Platforms) > 0 {
 			opts = append(opts, regclient.ImageWithPlatforms(lOpts.Platforms))
 		}
@@ -195,12 +199,13 @@ func (s *Sandbox) imageCopy(ls *lua.LState) int {
 		defer s.sem.Release(1)
 	}
 	s.log.WithFields(logrus.Fields{
-		"script":         s.name,
-		"source":         src.r.CommonName(),
-		"target":         tgt.r.CommonName(),
-		"digestTags":     lOpts.DigestTags,
-		"forceRecursive": lOpts.ForceRecursive,
-		"dry-run":        s.dryRun,
+		"script":          s.name,
+		"source":          src.r.CommonName(),
+		"target":          tgt.r.CommonName(),
+		"digestTags":      lOpts.DigestTags,
+		"forceRecursive":  lOpts.ForceRecursive,
+		"includeExternal": lOpts.IncludeExternal,
+		"dry-run":         s.dryRun,
 	}).Info("Copy image")
 	if s.dryRun {
 		return 0

--- a/cmd/regsync/config.go
+++ b/cmd/regsync/config.go
@@ -75,17 +75,18 @@ func credsToRCHost(c ConfigCreds) config.Host {
 
 // ConfigDefaults is uses for general options and defaults for ConfigSync entries
 type ConfigDefaults struct {
-	Backup         string          `yaml:"backup" json:"backup"`
-	Interval       time.Duration   `yaml:"interval" json:"interval"`
-	Schedule       string          `yaml:"schedule" json:"schedule"`
-	RateLimit      ConfigRateLimit `yaml:"ratelimit" json:"ratelimit"`
-	Parallel       int             `yaml:"parallel" json:"parallel"`
-	DigestTags     *bool           `yaml:"digestTags" json:"digestTags"`
-	ForceRecursive *bool           `yaml:"forceRecursive" json:"forceRecursive"`
-	MediaTypes     []string        `yaml:"mediaTypes" json:"mediaTypes"`
-	SkipDockerConf bool            `yaml:"skipDockerConfig" json:"skipDockerConfig"`
-	Hooks          ConfigHooks     `yaml:"hooks" json:"hooks"`
-	UserAgent      string          `yaml:"userAgent" json:"userAgent"`
+	Backup          string          `yaml:"backup" json:"backup"`
+	Interval        time.Duration   `yaml:"interval" json:"interval"`
+	Schedule        string          `yaml:"schedule" json:"schedule"`
+	RateLimit       ConfigRateLimit `yaml:"ratelimit" json:"ratelimit"`
+	Parallel        int             `yaml:"parallel" json:"parallel"`
+	DigestTags      *bool           `yaml:"digestTags" json:"digestTags"`
+	ForceRecursive  *bool           `yaml:"forceRecursive" json:"forceRecursive"`
+	IncludeExternal *bool           `yaml:"includeExternal" json:"includeExternal"`
+	MediaTypes      []string        `yaml:"mediaTypes" json:"mediaTypes"`
+	SkipDockerConf  bool            `yaml:"skipDockerConfig" json:"skipDockerConfig"`
+	Hooks           ConfigHooks     `yaml:"hooks" json:"hooks"`
+	UserAgent       string          `yaml:"userAgent" json:"userAgent"`
 }
 
 // ConfigRateLimit is for rate limit settings
@@ -96,20 +97,21 @@ type ConfigRateLimit struct {
 
 // ConfigSync defines a source/target repository to sync
 type ConfigSync struct {
-	Source         string          `yaml:"source" json:"source"`
-	Target         string          `yaml:"target" json:"target"`
-	Type           string          `yaml:"type" json:"type"`
-	Tags           ConfigTags      `yaml:"tags" json:"tags"`
-	DigestTags     *bool           `yaml:"digestTags" json:"digestTags"`
-	Platform       string          `yaml:"platform" json:"platform"`
-	Platforms      []string        `yaml:"platforms" json:"platforms"`
-	ForceRecursive *bool           `yaml:"forceRecursive" json:"forceRecursive"`
-	Backup         string          `yaml:"backup" json:"backup"`
-	Interval       time.Duration   `yaml:"interval" json:"interval"`
-	Schedule       string          `yaml:"schedule" json:"schedule"`
-	RateLimit      ConfigRateLimit `yaml:"ratelimit" json:"ratelimit"`
-	MediaTypes     []string        `yaml:"mediaTypes" json:"mediaTypes"`
-	Hooks          ConfigHooks     `yaml:"hooks" json:"hooks"`
+	Source          string          `yaml:"source" json:"source"`
+	Target          string          `yaml:"target" json:"target"`
+	Type            string          `yaml:"type" json:"type"`
+	Tags            ConfigTags      `yaml:"tags" json:"tags"`
+	DigestTags      *bool           `yaml:"digestTags" json:"digestTags"`
+	Platform        string          `yaml:"platform" json:"platform"`
+	Platforms       []string        `yaml:"platforms" json:"platforms"`
+	ForceRecursive  *bool           `yaml:"forceRecursive" json:"forceRecursive"`
+	IncludeExternal *bool           `yaml:"includeExternal" json:"includeExternal"`
+	Backup          string          `yaml:"backup" json:"backup"`
+	Interval        time.Duration   `yaml:"interval" json:"interval"`
+	Schedule        string          `yaml:"schedule" json:"schedule"`
+	RateLimit       ConfigRateLimit `yaml:"ratelimit" json:"ratelimit"`
+	MediaTypes      []string        `yaml:"mediaTypes" json:"mediaTypes"`
+	Hooks           ConfigHooks     `yaml:"hooks" json:"hooks"`
 }
 
 // ConfigTags is an allow and deny list of tag regex strings
@@ -260,6 +262,10 @@ func syncSetDefaults(s *ConfigSync, d ConfigDefaults) {
 	if s.ForceRecursive == nil {
 		b := (d.ForceRecursive != nil && *d.ForceRecursive)
 		s.ForceRecursive = &b
+	}
+	if s.IncludeExternal == nil {
+		b := (d.IncludeExternal != nil && *d.IncludeExternal)
+		s.IncludeExternal = &b
 	}
 	if s.Hooks.Pre == nil && d.Hooks.Pre != nil {
 		s.Hooks.Pre = d.Hooks.Pre

--- a/cmd/regsync/root.go
+++ b/cmd/regsync/root.go
@@ -759,6 +759,9 @@ func (s ConfigSync) processRef(ctx context.Context, src, tgt ref.Ref, action str
 	if s.ForceRecursive != nil && *s.ForceRecursive {
 		opts = append(opts, regclient.ImageWithForceRecursive())
 	}
+	if s.IncludeExternal != nil && *s.IncludeExternal {
+		opts = append(opts, regclient.ImageWithIncludeExternal())
+	}
 	if len(s.Platforms) > 0 {
 		opts = append(opts, regclient.ImageWithPlatforms(s.Platforms))
 	}

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -40,7 +40,7 @@ func TestManifest(t *testing.T) {
 		},
 		Layers: []types.Descriptor{
 			{
-				MediaType: types.MediaTypeDocker2Layer,
+				MediaType: types.MediaTypeDocker2LayerGzip,
 				Size:      8,
 				Digest:    digest2,
 			},

--- a/mod/mod.go
+++ b/mod/mod.go
@@ -83,7 +83,8 @@ func Apply(ctx context.Context, rc *regclient.RegClient, r ref.Ref, opts ...Opts
 	}
 	if len(dc.stepsLayer) > 0 || len(dc.stepsLayerFile) > 0 {
 		err = dagWalkLayers(dm, func(dl *dagLayer) (*dagLayer, error) {
-			if dl.mod == deleted {
+			if dl.mod == deleted || len(dl.desc.URLs) > 0 {
+				// skip deleted or external layers
 				return dl, nil
 			}
 			br, err := rc.BlobGet(ctx, r, dl.desc)
@@ -118,7 +119,7 @@ func Apply(ctx context.Context, rc *regclient.RegClient, r ref.Ref, opts ...Opts
 				var gw *gzip.Writer
 				digRaw := digest.Canonical.Digester() // raw/compressed digest
 				digUC := digest.Canonical.Digester()  // uncompressed digest
-				if dl.desc.MediaType == types.MediaTypeDocker2Layer || dl.desc.MediaType == types.MediaTypeOCI1LayerGzip {
+				if dl.desc.MediaType == types.MediaTypeDocker2LayerGzip || dl.desc.MediaType == types.MediaTypeOCI1LayerGzip {
 					cw := io.MultiWriter(fh, digRaw.Hash())
 					gw = gzip.NewWriter(cw)
 					defer gw.Close()
@@ -246,7 +247,7 @@ func WithManifestToOCI() Opts {
 					return err
 				}
 				for i, l := range ociM.Layers {
-					if l.MediaType == types.MediaTypeDocker2Layer {
+					if l.MediaType == types.MediaTypeDocker2LayerGzip {
 						ociM.Layers[i].MediaType = types.MediaTypeOCI1LayerGzip
 					}
 				}

--- a/mod/mod_test.go
+++ b/mod/mod_test.go
@@ -148,6 +148,14 @@ func TestMod(t *testing.T) {
 			wantSame: true,
 		},
 		{
+			name: "External layer remove unchanged",
+			opts: []Opts{
+				WithExternalURLsRm(),
+			},
+			ref:      "ocidir://testrepo:v1",
+			wantSame: true,
+		},
+		{
 			name: "Layer Timestamp Missing Label",
 			opts: []Opts{
 				WithLayerTimestampFromLabel("missing"),

--- a/regclient/manifest/manifest.go
+++ b/regclient/manifest/manifest.go
@@ -21,7 +21,7 @@ const (
 	MediaTypeOCI1Manifest          = topTypes.MediaTypeOCI1Manifest
 	MediaTypeOCI1ManifestList      = topTypes.MediaTypeOCI1ManifestList
 	MediaTypeOCI1ImageConfig       = topTypes.MediaTypeOCI1ImageConfig
-	MediaTypeDocker2Layer          = topTypes.MediaTypeDocker2Layer
+	MediaTypeDocker2Layer          = topTypes.MediaTypeDocker2LayerGzip
 	MediaTypeOCI1Layer             = topTypes.MediaTypeOCI1Layer
 	MediaTypeOCI1LayerGzip         = topTypes.MediaTypeOCI1LayerGzip
 	MediaTypeBuildkitCacheConfig   = topTypes.MediaTypeBuildkitCacheConfig

--- a/regclient/mediatype.go
+++ b/regclient/mediatype.go
@@ -16,7 +16,7 @@ var (
 	MediaTypeOCI1Manifest          = types.MediaTypeOCI1Manifest
 	MediaTypeOCI1ManifestList      = types.MediaTypeOCI1ManifestList
 	MediaTypeOCI1ImageConfig       = types.MediaTypeOCI1ImageConfig
-	MediaTypeDocker2Layer          = types.MediaTypeDocker2Layer
+	MediaTypeDocker2Layer          = types.MediaTypeDocker2LayerGzip
 	MediaTypeOCI1Layer             = types.MediaTypeOCI1Layer
 	MediaTypeOCI1LayerGzip         = types.MediaTypeOCI1LayerGzip
 	MediaTypeBuildkitCacheConfig   = types.MediaTypeBuildkitCacheConfig

--- a/regclient/types/mediatype.go
+++ b/regclient/types/mediatype.go
@@ -18,7 +18,7 @@ const (
 	MediaTypeOCI1Manifest          = topTypes.MediaTypeOCI1Manifest
 	MediaTypeOCI1ManifestList      = topTypes.MediaTypeOCI1ManifestList
 	MediaTypeOCI1ImageConfig       = topTypes.MediaTypeOCI1ImageConfig
-	MediaTypeDocker2Layer          = topTypes.MediaTypeDocker2Layer
+	MediaTypeDocker2Layer          = topTypes.MediaTypeDocker2LayerGzip
 	MediaTypeOCI1Layer             = topTypes.MediaTypeOCI1Layer
 	MediaTypeOCI1LayerGzip         = topTypes.MediaTypeOCI1LayerGzip
 	MediaTypeBuildkitCacheConfig   = topTypes.MediaTypeBuildkitCacheConfig

--- a/scheme/reg/manifest_test.go
+++ b/scheme/reg/manifest_test.go
@@ -38,7 +38,7 @@ func TestManifest(t *testing.T) {
 		},
 		Layers: []types.Descriptor{
 			{
-				MediaType: types.MediaTypeDocker2Layer,
+				MediaType: types.MediaTypeDocker2LayerGzip,
 				Size:      8,
 				Digest:    digest2,
 			},

--- a/types/descriptor_test.go
+++ b/types/descriptor_test.go
@@ -18,7 +18,7 @@ func TestDescriptorData(t *testing.T) {
 		{
 			name: "No Data",
 			d: Descriptor{
-				MediaType: MediaTypeDocker2Layer,
+				MediaType: MediaTypeDocker2LayerGzip,
 				Size:      941,
 				Digest:    digest.Digest("sha256:f6e2d7fa40092cf3d9817bf6ff54183d68d108a47fdf5a5e476c612626c80e14"),
 			},

--- a/types/mediatype.go
+++ b/types/mediatype.go
@@ -17,12 +17,22 @@ const (
 	MediaTypeOCI1ManifestList = "application/vnd.oci.image.index.v1+json"
 	// MediaTypeOCI1ImageConfig OCI v1 configuration json object media type
 	MediaTypeOCI1ImageConfig = "application/vnd.oci.image.config.v1+json"
-	// MediaTypeDocker2Layer is the default compressed layer for docker schema2
-	MediaTypeDocker2Layer = "application/vnd.docker.image.rootfs.diff.tar.gzip"
+	// MediaTypeDocker2LayerGzip is the default compressed layer for docker schema2
+	MediaTypeDocker2LayerGzip = "application/vnd.docker.image.rootfs.diff.tar.gzip"
+	// MediaTypeDocker2ForeignLayer is the default compressed layer for foreign layers in docker schema2
+	MediaTypeDocker2ForeignLayer = "application/vnd.docker.image.rootfs.foreign.diff.tar.gzip"
 	// MediaTypeOCI1Layer is the uncompressed layer for OCIv1
 	MediaTypeOCI1Layer = "application/vnd.oci.image.layer.v1.tar"
 	// MediaTypeOCI1LayerGzip is the gzip compressed layer for OCI v1
 	MediaTypeOCI1LayerGzip = "application/vnd.oci.image.layer.v1.tar+gzip"
+	// MediaTypeOCI1LayerZstd is the zstd compressed layer for OCI v1
+	MediaTypeOCI1LayerZstd = "application/vnd.oci.image.layer.v1.tar+zstd"
+	// MediaTypeOCI1ForeignLayer is the foreign layer for OCI v1
+	MediaTypeOCI1ForeignLayer = "application/vnd.oci.image.layer.nondistributable.v1.tar"
+	// MediaTypeOCI1ForeignLayerGzip is the gzip compressed foreign layer for OCI v1
+	MediaTypeOCI1ForeignLayerGzip = "application/vnd.oci.image.layer.nondistributable.v1.tar+gzip"
+	// MediaTypeOCI1ForeignLayerZstd is the zstd compressed foreign layer for OCI v1
+	MediaTypeOCI1ForeignLayerZstd = "application/vnd.oci.image.layer.nondistributable.v1.tar+zstd"
 	// MediaTypeBuildkitCacheConfig is used by buildkit cache images
 	MediaTypeBuildkitCacheConfig = "application/vnd.buildkit.cacheconfig.v0"
 )


### PR DESCRIPTION
- Attempt to pull external blob from registry
- Handle blob pull to external URL
- Copy option to copy external blobs
- Mod option to remove external URLs from descriptors

Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Mod of an image with external layers no longer fails.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

- Blob pull of external URL first attempts to pull directly from the registry, then loops through external URLs.
- Image copy now has an option to copy external blobs
- Image mod now has an option to remove external URLs from descriptors
- `types.MediaTypeDocker2Layer` renamed to `types.MediaTypeDocker2LayerGzip`
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

`regctl image mod ...` with actions on layers no longer fails for images with external layers.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Feature: Improve handling of external URLs
Breaking: Media type variable for docker image layers has been renamed
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
