### PR TITLE
Fix size extracted from manifest head request

### DIFF
--- a/types/manifest/manifest.go
+++ b/types/manifest/manifest.go
@@ -75,9 +75,9 @@ func New(opts ...Opts) (Manifest, error) {
 		if c.desc.MediaType == "" {
 			c.desc.MediaType = mc.header.Get("Content-Type")
 		}
-		if mc.desc.Size == 0 {
+		if c.desc.Size == 0 {
 			cl, _ := strconv.Atoi(mc.header.Get("Content-Length"))
-			mc.desc.Size = int64(cl)
+			c.desc.Size = int64(cl)
 		}
 		if c.desc.Digest == "" {
 			c.desc.Digest, _ = digest.Parse(mc.header.Get("Docker-Content-Digest"))

--- a/types/manifest/manifest_test.go
+++ b/types/manifest/manifest_test.go
@@ -380,6 +380,23 @@ func TestNew(t *testing.T) {
 			wantE: nil,
 		},
 		{
+			name: "Header Request",
+			opts: []Opts{
+				WithRef(r),
+				WithHeader(http.Header{
+					"Content-Type":          []string{types.MediaTypeDocker2Manifest},
+					"Content-Length":        []string{fmt.Sprintf("%d", len(rawDockerSchema2))},
+					"Docker-Content-Digest": []string{digestDockerSchema2.String()},
+				}),
+			},
+			wantDesc: types.Descriptor{
+				MediaType: types.MediaTypeDocker2Manifest,
+				Size:      int64(len(rawDockerSchema2)),
+				Digest:    digestDockerSchema2,
+			},
+			wantE: nil,
+		},
+		{
 			name: "Docker Schema 1 Signed",
 			opts: []Opts{
 				WithRef(r),


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

The content-length header was not properly imported from manifest head requests.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This sets the correct variable for the manifest size.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Verify the descriptor from a manifest head request.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Fix: manifest head request now set the descriptor size correctly.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
