### PR TITLE
Rename config to avoid import conflicts

### DIFF
--- a/scheme/ocidir/ocidir.go
+++ b/scheme/ocidir/ocidir.go
@@ -31,18 +31,18 @@ type OCIDir struct {
 	mu      sync.Mutex
 }
 
-type config struct {
+type ociConf struct {
 	fs  rwfs.RWFS
 	gc  bool
 	log *logrus.Logger
 }
 
 // Opts are used for passing options to ocidir
-type Opts func(*config)
+type Opts func(*ociConf)
 
 // New creates a new OCIDir with options
 func New(opts ...Opts) *OCIDir {
-	conf := config{
+	conf := ociConf{
 		log: &logrus.Logger{Out: ioutil.Discard},
 		gc:  true,
 	}
@@ -61,7 +61,7 @@ func New(opts ...Opts) *OCIDir {
 // The default is to use the OS, this can be used to sandbox within a folder
 // This can also be used to pass an in-memory filesystem for testing or special use cases
 func WithFS(fs rwfs.RWFS) Opts {
-	return func(c *config) {
+	return func(c *ociConf) {
 		c.fs = fs
 	}
 }
@@ -69,7 +69,7 @@ func WithFS(fs rwfs.RWFS) Opts {
 // WithGC configures the garbage collection setting
 // This defaults to enabled
 func WithGC(gc bool) Opts {
-	return func(c *config) {
+	return func(c *ociConf) {
 		c.gc = gc
 	}
 }
@@ -77,7 +77,7 @@ func WithGC(gc bool) Opts {
 // WithLog provides a logrus logger
 // By default logging is disabled
 func WithLog(log *logrus.Logger) Opts {
-	return func(c *config) {
+	return func(c *ociConf) {
 		c.log = log
 	}
 }


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

The `config` value conflicts with a possible regclient import, so it was renamed.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Nothing breaks.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
