### PR TITLE
Adding manifest get/set annotation methods

### DIFF
--- a/types/manifest/docker1.go
+++ b/types/manifest/docker1.go
@@ -32,11 +32,17 @@ type docker1SignedManifest struct {
 	schema1.SignedManifest
 }
 
+func (m *docker1Manifest) GetAnnotations() (map[string]string, error) {
+	return nil, wraperr.New(fmt.Errorf("annotations not available for media type %s", m.desc.MediaType), types.ErrUnsupportedMediaType)
+}
 func (m *docker1Manifest) GetConfig() (types.Descriptor, error) {
 	return types.Descriptor{}, wraperr.New(fmt.Errorf("config digest not available for media type %s", m.desc.MediaType), types.ErrUnsupportedMediaType)
 }
 func (m *docker1Manifest) GetConfigDigest() (digest.Digest, error) {
 	return "", wraperr.New(fmt.Errorf("config digest not available for media type %s", m.desc.MediaType), types.ErrUnsupportedMediaType)
+}
+func (m *docker1SignedManifest) GetAnnotations() (map[string]string, error) {
+	return nil, wraperr.New(fmt.Errorf("annotations not available for media type %s", m.desc.MediaType), types.ErrUnsupportedMediaType)
 }
 func (m *docker1SignedManifest) GetConfig() (types.Descriptor, error) {
 	return types.Descriptor{}, wraperr.New(fmt.Errorf("config digest not available for media type %s", m.desc.MediaType), types.ErrUnsupportedMediaType)
@@ -123,6 +129,13 @@ func (m *docker1SignedManifest) MarshalPretty() ([]byte, error) {
 	enc.SetIndent("", "  ")
 	enc.Encode(m.SignedManifest)
 	return buf.Bytes(), nil
+}
+
+func (m *docker1Manifest) SetAnnotation(key, val string) error {
+	return wraperr.New(fmt.Errorf("annotations not available for media type %s", m.desc.MediaType), types.ErrUnsupportedMediaType)
+}
+func (m *docker1SignedManifest) SetAnnotation(key, val string) error {
+	return wraperr.New(fmt.Errorf("annotations not available for media type %s", m.desc.MediaType), types.ErrUnsupportedMediaType)
 }
 
 func (m *docker1Manifest) SetOrig(origIn interface{}) error {

--- a/types/manifest/manifest.go
+++ b/types/manifest/manifest.go
@@ -27,6 +27,7 @@ import (
 // Manifest interface is implemented by all supported manifests but
 // many calls are only supported by certain underlying media types.
 type Manifest interface {
+	GetAnnotations() (map[string]string, error)
 	GetConfig() (types.Descriptor, error)
 	GetDescriptor() types.Descriptor
 	GetLayers() ([]types.Descriptor, error)
@@ -38,6 +39,7 @@ type Manifest interface {
 	MarshalJSON() ([]byte, error)
 	RawBody() ([]byte, error)
 	RawHeaders() (http.Header, error)
+	SetAnnotation(key, val string) error
 	SetOrig(interface{}) error
 
 	GetConfigDigest() (digest.Digest, error)                         // TODO: deprecate


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

With annotations defined on many manifest media types (even if not defined in upstream specs), a get/set method is added to improve usability.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Run a get/set on an annotation on a manifest.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [ ] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
