### PR TITLE
Experimental support for artifact manifest type

### DIFF
--- a/scheme/ocidir/referrer.go
+++ b/scheme/ocidir/referrer.go
@@ -63,9 +63,13 @@ func (o *OCIDir) ReferrerList(ctx context.Context, r ref.Ref, opts ...scheme.Ref
 			if err != nil {
 				return rl, fmt.Errorf("failed to lookup tag in referrers: %s: %w", rt.CommonName(), err)
 			}
+			mCurAnnot, ok := mCur.(manifest.Annotator)
+			if !ok {
+				return rl, fmt.Errorf("manifest does not support annotations: %w", types.ErrUnsupportedMediaType)
+			}
 			d := mCur.GetDescriptor()
 			// pull up annotations
-			d.Annotations, err = mCur.GetAnnotations()
+			d.Annotations, err = mCurAnnot.GetAnnotations()
 			if err != nil {
 				return rl, fmt.Errorf("failed to pull up annotations: %w", err)
 			}

--- a/types/manifest/docker1.go
+++ b/types/manifest/docker1.go
@@ -32,17 +32,11 @@ type docker1SignedManifest struct {
 	schema1.SignedManifest
 }
 
-func (m *docker1Manifest) GetAnnotations() (map[string]string, error) {
-	return nil, wraperr.New(fmt.Errorf("annotations not available for media type %s", m.desc.MediaType), types.ErrUnsupportedMediaType)
-}
 func (m *docker1Manifest) GetConfig() (types.Descriptor, error) {
 	return types.Descriptor{}, wraperr.New(fmt.Errorf("config digest not available for media type %s", m.desc.MediaType), types.ErrUnsupportedMediaType)
 }
 func (m *docker1Manifest) GetConfigDigest() (digest.Digest, error) {
 	return "", wraperr.New(fmt.Errorf("config digest not available for media type %s", m.desc.MediaType), types.ErrUnsupportedMediaType)
-}
-func (m *docker1SignedManifest) GetAnnotations() (map[string]string, error) {
-	return nil, wraperr.New(fmt.Errorf("annotations not available for media type %s", m.desc.MediaType), types.ErrUnsupportedMediaType)
 }
 func (m *docker1SignedManifest) GetConfig() (types.Descriptor, error) {
 	return types.Descriptor{}, wraperr.New(fmt.Errorf("config digest not available for media type %s", m.desc.MediaType), types.ErrUnsupportedMediaType)
@@ -129,13 +123,6 @@ func (m *docker1SignedManifest) MarshalPretty() ([]byte, error) {
 	enc.SetIndent("", "  ")
 	enc.Encode(m.SignedManifest)
 	return buf.Bytes(), nil
-}
-
-func (m *docker1Manifest) SetAnnotation(key, val string) error {
-	return wraperr.New(fmt.Errorf("annotations not available for media type %s", m.desc.MediaType), types.ErrUnsupportedMediaType)
-}
-func (m *docker1SignedManifest) SetAnnotation(key, val string) error {
-	return wraperr.New(fmt.Errorf("annotations not available for media type %s", m.desc.MediaType), types.ErrUnsupportedMediaType)
 }
 
 func (m *docker1Manifest) SetOrig(origIn interface{}) error {

--- a/types/manifest/docker2.go
+++ b/types/manifest/docker2.go
@@ -99,6 +99,13 @@ func (m *docker2ManifestList) GetPlatformList() ([]*platform.Platform, error) {
 	return getPlatformList(dl)
 }
 
+func (m *docker2Manifest) GetRefers() (types.Descriptor, error) {
+	if !m.manifSet {
+		return types.Descriptor{}, wraperr.New(fmt.Errorf("Manifest unavailable, perform a ManifestGet first"), types.ErrUnavailable)
+	}
+	return m.Manifest.Refers, nil
+}
+
 func (m *docker2Manifest) MarshalJSON() ([]byte, error) {
 	if !m.manifSet {
 		return []byte{}, wraperr.New(fmt.Errorf("manifest unavailable, perform a ManifestGet first"), types.ErrUnavailable)
@@ -255,6 +262,14 @@ func (m *docker2ManifestList) SetOrig(origIn interface{}) error {
 	}
 	m.manifSet = true
 	m.ManifestList = orig
+	return m.updateDesc()
+}
+
+func (m *docker2Manifest) SetRefers(d types.Descriptor) error {
+	if !m.manifSet {
+		return wraperr.New(fmt.Errorf("Manifest unavailable, perform a ManifestGet first"), types.ErrUnavailable)
+	}
+	m.Manifest.Refers = d
 	return m.updateDesc()
 }
 

--- a/types/manifest/oci1.go
+++ b/types/manifest/oci1.go
@@ -34,6 +34,10 @@ type oci1Index struct {
 	common
 	v1.Index
 }
+type oci1Artifact struct {
+	common
+	v1.ArtifactManifest
+}
 
 func (m *oci1Manifest) GetAnnotations() (map[string]string, error) {
 	if !m.manifSet {
@@ -59,12 +63,27 @@ func (m *oci1Index) GetConfig() (types.Descriptor, error) {
 func (m *oci1Index) GetConfigDigest() (digest.Digest, error) {
 	return "", wraperr.New(fmt.Errorf("config digest not available for media type %s", m.desc.MediaType), types.ErrUnsupportedMediaType)
 }
+func (m *oci1Artifact) GetAnnotations() (map[string]string, error) {
+	if !m.manifSet {
+		return nil, fmt.Errorf("manifest is not set")
+	}
+	return m.Annotations, nil
+}
+func (m *oci1Artifact) GetConfig() (types.Descriptor, error) {
+	return types.Descriptor{}, wraperr.New(fmt.Errorf("config digest not available for media type %s", m.desc.MediaType), types.ErrUnsupportedMediaType)
+}
+func (m *oci1Artifact) GetConfigDigest() (digest.Digest, error) {
+	return "", wraperr.New(fmt.Errorf("config digest not available for media type %s", m.desc.MediaType), types.ErrUnsupportedMediaType)
+}
 
 func (m *oci1Manifest) GetManifestList() ([]types.Descriptor, error) {
 	return []types.Descriptor{}, wraperr.New(fmt.Errorf("platform descriptor list not available for media type %s", m.desc.MediaType), types.ErrUnsupportedMediaType)
 }
 func (m *oci1Index) GetManifestList() ([]types.Descriptor, error) {
 	return m.Manifests, nil
+}
+func (m *oci1Artifact) GetManifestList() ([]types.Descriptor, error) {
+	return []types.Descriptor{}, wraperr.New(fmt.Errorf("platform descriptor list not available for media type %s", m.desc.MediaType), types.ErrUnsupportedMediaType)
 }
 
 func (m *oci1Manifest) GetLayers() ([]types.Descriptor, error) {
@@ -73,12 +92,18 @@ func (m *oci1Manifest) GetLayers() ([]types.Descriptor, error) {
 func (m *oci1Index) GetLayers() ([]types.Descriptor, error) {
 	return []types.Descriptor{}, wraperr.New(fmt.Errorf("layers are not available for media type %s", m.desc.MediaType), types.ErrUnsupportedMediaType)
 }
+func (m *oci1Artifact) GetLayers() ([]types.Descriptor, error) {
+	return m.Blobs, nil
+}
 
 func (m *oci1Manifest) GetOrig() interface{} {
 	return m.Manifest
 }
 func (m *oci1Index) GetOrig() interface{} {
 	return m.Index
+}
+func (m *oci1Artifact) GetOrig() interface{} {
+	return m.ArtifactManifest
 }
 
 func (m *oci1Manifest) GetPlatformDesc(p *platform.Platform) (*types.Descriptor, error) {
@@ -91,6 +116,9 @@ func (m *oci1Index) GetPlatformDesc(p *platform.Platform) (*types.Descriptor, er
 	}
 	return getPlatformDesc(p, dl)
 }
+func (m *oci1Artifact) GetPlatformDesc(p *platform.Platform) (*types.Descriptor, error) {
+	return nil, wraperr.New(fmt.Errorf("platform lookup not available for media type %s", m.desc.MediaType), types.ErrUnsupportedMediaType)
+}
 
 func (m *oci1Manifest) GetPlatformList() ([]*platform.Platform, error) {
 	return nil, wraperr.New(fmt.Errorf("platform list not available for media type %s", m.desc.MediaType), types.ErrUnsupportedMediaType)
@@ -101,6 +129,9 @@ func (m *oci1Index) GetPlatformList() ([]*platform.Platform, error) {
 		return nil, err
 	}
 	return getPlatformList(dl)
+}
+func (m *oci1Artifact) GetPlatformList() ([]*platform.Platform, error) {
+	return nil, wraperr.New(fmt.Errorf("platform list not available for media type %s", m.desc.MediaType), types.ErrUnsupportedMediaType)
 }
 
 func (m *oci1Manifest) MarshalJSON() ([]byte, error) {
@@ -114,6 +145,19 @@ func (m *oci1Manifest) MarshalJSON() ([]byte, error) {
 
 	return json.Marshal((m.Manifest))
 }
+func (m *oci1Manifest) GetRefers() (types.Descriptor, error) {
+	if !m.manifSet {
+		return types.Descriptor{}, wraperr.New(fmt.Errorf("Manifest unavailable, perform a ManifestGet first"), types.ErrUnavailable)
+	}
+	return m.Manifest.Refers, nil
+}
+func (m *oci1Artifact) GetRefers() (types.Descriptor, error) {
+	if !m.manifSet {
+		return types.Descriptor{}, wraperr.New(fmt.Errorf("Manifest unavailable, perform a ManifestGet first"), types.ErrUnavailable)
+	}
+	return m.ArtifactManifest.Refers, nil
+}
+
 func (m *oci1Index) MarshalJSON() ([]byte, error) {
 	if !m.manifSet {
 		return []byte{}, wraperr.New(fmt.Errorf("Manifest unavailable, perform a ManifestGet first"), types.ErrUnavailable)
@@ -124,6 +168,17 @@ func (m *oci1Index) MarshalJSON() ([]byte, error) {
 	}
 
 	return json.Marshal((m.Index))
+}
+func (m *oci1Artifact) MarshalJSON() ([]byte, error) {
+	if !m.manifSet {
+		return []byte{}, wraperr.New(fmt.Errorf("Manifest unavailable, perform a ManifestGet first"), types.ErrUnavailable)
+	}
+
+	if len(m.rawBody) > 0 {
+		return m.rawBody, nil
+	}
+
+	return json.Marshal((m.ArtifactManifest))
 }
 
 func (m *oci1Manifest) MarshalPretty() ([]byte, error) {
@@ -212,6 +267,46 @@ func (m *oci1Index) MarshalPretty() ([]byte, error) {
 	tw.Flush()
 	return buf.Bytes(), nil
 }
+func (m *oci1Artifact) MarshalPretty() ([]byte, error) {
+	if m == nil {
+		return []byte{}, nil
+	}
+	buf := &bytes.Buffer{}
+	tw := tabwriter.NewWriter(buf, 0, 0, 1, ' ', 0)
+	if m.r.Reference != "" {
+		fmt.Fprintf(tw, "Name:\t%s\n", m.r.Reference)
+	}
+	fmt.Fprintf(tw, "MediaType:\t%s\n", m.desc.MediaType)
+	fmt.Fprintf(tw, "Digest:\t%s\n", m.desc.Digest.String())
+	if m.Annotations != nil && len(m.Annotations) > 0 {
+		fmt.Fprintf(tw, "Annotations:\t\n")
+		keys := make([]string, 0, len(m.Annotations))
+		for k := range m.Annotations {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, name := range keys {
+			val := m.Annotations[name]
+			fmt.Fprintf(tw, "  %s:\t%s\n", name, val)
+		}
+	}
+	var total int64
+	for _, d := range m.Blobs {
+		total += d.Size
+	}
+	fmt.Fprintf(tw, "Total Size:\t%s\n", units.HumanSize(float64(total)))
+	fmt.Fprintf(tw, "\t\n")
+	fmt.Fprintf(tw, "Blobs:\t\n")
+	for _, d := range m.Blobs {
+		fmt.Fprintf(tw, "\t\n")
+		err := d.MarshalPrettyTW(tw, "  ")
+		if err != nil {
+			return []byte{}, err
+		}
+	}
+	tw.Flush()
+	return buf.Bytes(), nil
+}
 
 func (m *oci1Manifest) SetAnnotation(key, val string) error {
 	if !m.manifSet {
@@ -224,6 +319,16 @@ func (m *oci1Manifest) SetAnnotation(key, val string) error {
 	return m.updateDesc()
 }
 func (m *oci1Index) SetAnnotation(key, val string) error {
+	if !m.manifSet {
+		return fmt.Errorf("manifest is not set")
+	}
+	if m.Annotations == nil {
+		m.Annotations = map[string]string{}
+	}
+	m.Annotations[key] = val
+	return m.updateDesc()
+}
+func (m *oci1Artifact) SetAnnotation(key, val string) error {
 	if !m.manifSet {
 		return fmt.Errorf("manifest is not set")
 	}
@@ -264,6 +369,36 @@ func (m *oci1Index) SetOrig(origIn interface{}) error {
 	return m.updateDesc()
 }
 
+func (m *oci1Artifact) SetRefers(d types.Descriptor) error {
+	if !m.manifSet {
+		return wraperr.New(fmt.Errorf("Manifest unavailable, perform a ManifestGet first"), types.ErrUnavailable)
+	}
+	m.ArtifactManifest.Refers = d
+	return m.updateDesc()
+}
+func (m *oci1Manifest) SetRefers(d types.Descriptor) error {
+	if !m.manifSet {
+		return wraperr.New(fmt.Errorf("Manifest unavailable, perform a ManifestGet first"), types.ErrUnavailable)
+	}
+	m.Manifest.Refers = d
+	return m.updateDesc()
+}
+
+func (m *oci1Artifact) SetOrig(origIn interface{}) error {
+	orig, ok := origIn.(v1.ArtifactManifest)
+	if !ok {
+		return types.ErrUnsupportedMediaType
+	}
+	if orig.MediaType != types.MediaTypeOCI1Artifact {
+		// TODO: error?
+		orig.MediaType = types.MediaTypeOCI1Artifact
+	}
+	m.manifSet = true
+	m.ArtifactManifest = orig
+
+	return m.updateDesc()
+}
+
 func (m *oci1Manifest) updateDesc() error {
 	mj, err := json.Marshal(m.Manifest)
 	if err != nil {
@@ -289,5 +424,17 @@ func (m *oci1Index) updateDesc() error {
 		Size:      int64(len(mj)),
 	}
 	return nil
-
+}
+func (m *oci1Artifact) updateDesc() error {
+	mj, err := json.Marshal(m.ArtifactManifest)
+	if err != nil {
+		return err
+	}
+	m.rawBody = mj
+	m.desc = types.Descriptor{
+		MediaType: types.MediaTypeOCI1Artifact,
+		Digest:    digest.FromBytes(mj),
+		Size:      int64(len(mj)),
+	}
+	return nil
 }

--- a/types/mediatype.go
+++ b/types/mediatype.go
@@ -11,6 +11,8 @@ const (
 	MediaTypeDocker2ManifestList = "application/vnd.docker.distribution.manifest.list.v2+json"
 	// MediaTypeDocker2ImageConfig is for the configuration json object media type
 	MediaTypeDocker2ImageConfig = "application/vnd.docker.container.image.v1+json"
+	// MediaTypeOCI1Artifact OCI v1 artifact media type (EXPERIMENTAL)
+	MediaTypeOCI1Artifact = "application/vnd.oci.artifact.manifest.v1+json"
 	// MediaTypeOCI1Manifest OCI v1 manifest media type
 	MediaTypeOCI1Manifest = "application/vnd.oci.image.manifest.v1+json"
 	// MediaTypeOCI1ManifestList OCI v1 manifest list media type

--- a/types/oci/v1/artifact.go
+++ b/types/oci/v1/artifact.go
@@ -1,0 +1,29 @@
+package v1
+
+import (
+	"github.com/regclient/regclient/types"
+	"github.com/regclient/regclient/types/oci"
+)
+
+// ArtifactSchemaVersion is a pre-configured versioned field for manifests
+var ArtifactSchemaVersion = oci.Versioned{
+	SchemaVersion: 2,
+}
+
+// ArtifactManifest defines an OCI Artifact
+// This is EXPERIMENTAL
+type ArtifactManifest struct {
+	oci.Versioned
+
+	// MediaType is the media type of the object this schema refers to.
+	MediaType string `json:"mediaType"`
+
+	// Blobs is a collection of blobs referenced by this manifest.
+	Blobs []types.Descriptor `json:"blobs"`
+
+	// Refers indicates this manifest references another manifest
+	Refers types.Descriptor `json:"refers,omitempty"`
+
+	// Annotations contains arbitrary metadata for the artifact manifest.
+	Annotations map[string]string `json:"annotations,omitempty"`
+}


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This adds experimental support for a new OCI artifact manifest type. This is not considered stable until approved by the OCI.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

This requires a registry with the new media type support, see [oci-playground/distribution](https://github.com/oci-playground/distribution) for an example.

```
echo hello oci | regctl artifact put --refers \
  --annotation org.opencontainers.artifact.type=misc \
  --annotation org.example.test=hello \
  --annotation org.example.location=oci \
  --manifest-media-type application/vnd.oci.artifact.manifest.v1+json \
  $registry/$repo:$tag
regctl artifact list $registry/$repo:$tag
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Experimental: adding support for OCI artifact media type
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

Documentation is not included for experimental features.
<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
