### PR TITLE
Detect errors with localhost ref without a repo

### DIFF
--- a/types/ref/ref.go
+++ b/types/ref/ref.go
@@ -100,6 +100,9 @@ func New(parse string) (Ref, error) {
 		if ret.Tag == "" && ret.Digest == "" {
 			ret.Tag = "latest"
 		}
+		if ret.Repository == "" {
+			return Ref{}, fmt.Errorf("invalid reference \"%s\"", path)
+		}
 
 	case "ocidir", "ocifile":
 		matchPath := pathRE.FindStringSubmatch(path)

--- a/types/ref/ref_test.go
+++ b/types/ref/ref_test.go
@@ -172,6 +172,17 @@ func TestRef(t *testing.T) {
 			wantE:      nil,
 		},
 		{
+			name:       "Localhost registry with port",
+			ref:        "localhost:5000/group/image:v42",
+			scheme:     "reg",
+			registry:   "localhost:5000",
+			repository: "group/image",
+			tag:        "v42",
+			digest:     "",
+			path:       "",
+			wantE:      nil,
+		},
+		{
 			name:       "ip address registry",
 			ref:        "127.0.0.1:5000/image:v42",
 			scheme:     "reg",
@@ -328,6 +339,11 @@ func TestRef(t *testing.T) {
 			name:  "invalid ocidir digest",
 			ref:   "ocidir://filename@sha256:abcd",
 			wantE: fmt.Errorf(`invalid path for scheme "ocidir": filename@sha256:abcd`),
+		},
+		{
+			name:  "localhost missing repo",
+			ref:   "localhost:5000",
+			wantE: fmt.Errorf(`invalid reference "localhost:5000"`),
 		},
 	}
 


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

A `regctl tag ls localhost:5000` tries to connect to localhost with an empty repository, parsing the 5000 as a tag.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

When localhost is pulled up as a registry, a missing repository value is now considered an error.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

`regctl tag ls localhost:5000`
<!-- Include steps that can be taken to verify the change -->

### Changelog text

<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
