### PR TITLE
Add support for parsing docker config directly

### DIFF
--- a/config/credhelper.go
+++ b/config/credhelper.go
@@ -1,0 +1,64 @@
+package config
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// cred helper wraps a command
+type credHelper struct {
+	prog string
+	env  map[string]string
+}
+
+func newCredHelper(prog string, env map[string]string) *credHelper {
+	return &credHelper{prog: prog, env: env}
+}
+
+func (ch *credHelper) run(arg string, input io.Reader) ([]byte, error) {
+	cmd := exec.Command(ch.prog, arg)
+	cmd.Env = os.Environ()
+	if ch.env != nil {
+		for k, v := range ch.env {
+			cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", k, v))
+		}
+	}
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = input
+	return cmd.Output()
+}
+
+type credStore struct {
+	ServerURL string `json:"ServerURL"`
+	Username  string `json:"Username"`
+	Secret    string `json:"Secret"`
+}
+
+func (ch *credHelper) get(host *Host) error {
+	hostIn := strings.NewReader(host.Hostname)
+	credOut := credStore{
+		Username: host.User,
+		Secret:   host.Pass,
+	}
+	outB, err := ch.run("get", hostIn)
+	if err != nil {
+		outS := strings.TrimSpace(string(outB))
+		return fmt.Errorf("error getting credentials: %s: %v", outS, err)
+	}
+	err = json.NewDecoder(bytes.NewReader(outB)).Decode(&credOut)
+	if err != nil {
+		return fmt.Errorf("error reading credentials: %w", err)
+	}
+	host.User = credOut.Username
+	host.Pass = credOut.Secret
+	host.credRefresh = time.Now().Add(time.Duration(host.CredExpire))
+	return nil
+}
+
+// store and list methods not implemented

--- a/config/credhelper_test.go
+++ b/config/credhelper_test.go
@@ -1,0 +1,27 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+func TestCredHelper(t *testing.T) {
+	testHost := "testhost.example.com"
+	expectUser, expectPass := "hello", "world"
+	curPath := os.Getenv("PATH")
+	os.Setenv("PATH", "testdata"+string(os.PathListSeparator)+curPath)
+	defer os.Setenv("PATH", curPath)
+	ch := newCredHelper("docker-credential-test", map[string]string{})
+	h := HostNewName(testHost)
+	h.CredHelper = "docker-credential-test"
+	err := ch.get(h)
+	if err != nil {
+		t.Errorf("error running get: %v", err)
+	}
+	if expectUser != h.User {
+		t.Errorf("user mismatch: expected %s, received %s", expectUser, h.User)
+	}
+	if expectPass != h.Pass {
+		t.Errorf("password mismatch: expected %s, received %s", expectPass, h.Pass)
+	}
+}

--- a/config/docker.go
+++ b/config/docker.go
@@ -1,0 +1,160 @@
+package config
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/regclient/regclient/internal/conffile"
+)
+
+const (
+	dockerEnv       = "DOCKER_CONFIG"
+	dockerDir       = ".docker"
+	dockerConfFile  = "config.json"
+	dockerHelperPre = "docker-credential-"
+)
+
+// methods to parse user's docker config.json file
+
+// dockerConfig is used to parse the ~/.docker/config.json
+type dockerConfig struct {
+	AuthConfigs       map[string]dockerAuthConfig  `json:"auths"`
+	HTTPHeaders       map[string]string            `json:"HttpHeaders,omitempty"`
+	DetachKeys        string                       `json:"detachKeys,omitempty"`
+	CredentialsStore  string                       `json:"credsStore,omitempty"`
+	CredentialHelpers map[string]string            `json:"credHelpers,omitempty"`
+	Proxies           map[string]dockerProxyConfig `json:"proxies,omitempty"`
+}
+
+// dockerProxyConfig contains proxy configuration settings
+type dockerProxyConfig struct {
+	HTTPProxy  string `json:"httpProxy,omitempty"`
+	HTTPSProxy string `json:"httpsProxy,omitempty"`
+	NoProxy    string `json:"noProxy,omitempty"`
+	FTPProxy   string `json:"ftpProxy,omitempty"`
+	AllProxy   string `json:"allProxy,omitempty"`
+}
+
+// dockerAuthConfig contains the auths
+type dockerAuthConfig struct {
+	Username string `json:"username,omitempty"`
+	Password string `json:"password,omitempty"`
+	Auth     string `json:"auth,omitempty"`
+
+	ServerAddress string `json:"serveraddress,omitempty"`
+
+	// IdentityToken is used to authenticate the user and get
+	// an access token for the registry.
+	IdentityToken string `json:"identitytoken,omitempty"`
+
+	// RegistryToken is a bearer token to be sent to a registry
+	RegistryToken string `json:"registrytoken,omitempty"`
+}
+
+func DockerLoad() ([]Host, error) {
+	cf := conffile.New(conffile.WithDirName(dockerDir, dockerConfFile), conffile.WithEnv(dockerEnv))
+	return dockerParse(cf)
+}
+
+// parse from io.Reader to []Host
+func dockerParse(cf *conffile.File) ([]Host, error) {
+	rdr, err := cf.Open()
+	if err != nil {
+		return nil, err
+	}
+	defer rdr.Close()
+	dc := dockerConfig{}
+	if err := json.NewDecoder(rdr).Decode(&dc); err != nil && !errors.Is(err, io.EOF) {
+		return nil, err
+	}
+	hosts := []Host{}
+	for name, auth := range dc.AuthConfigs {
+		h, err := dockerAuthToHost(name, dc, auth)
+		if err != nil {
+			continue
+		}
+		hosts = append(hosts, h)
+	}
+	// also include default entries for credential helpers
+	for name, helper := range dc.CredentialHelpers {
+		if _, ok := dc.AuthConfigs[name]; ok {
+			continue // skip fields with auth config
+		}
+		hosts = append(hosts, Host{
+			Name:       name,
+			Hostname:   name,
+			CredHelper: dockerHelperPre + helper,
+		})
+	}
+	return hosts, nil
+}
+
+func dockerAuthToHost(name string, conf dockerConfig, auth dockerAuthConfig) (Host, error) {
+	helper := ""
+	if conf.CredentialHelpers != nil && conf.CredentialHelpers[name] != "" {
+		helper = dockerHelperPre + conf.CredentialHelpers[name]
+	} else if conf.CredentialsStore != "" {
+		helper = dockerHelperPre + conf.CredentialsStore
+	}
+	// parse base64 auth into user/pass
+	if auth.Auth != "" {
+		var err error
+		auth.Username, auth.Password, err = decodeAuth(auth.Auth)
+		if err != nil {
+			return Host{}, err
+		}
+	}
+	if (auth.Username == "" || auth.Password == "") && auth.IdentityToken == "" && helper == "" {
+		return Host{}, fmt.Errorf("no credentials found for %s", name)
+	}
+
+	// Docker Hub is a special case
+	if name == DockerRegistryAuth {
+		name = DockerRegistry
+		auth.ServerAddress = DockerRegistryDNS
+	}
+	// handle names with a scheme included (https://registry.example.com)
+	tls := TLSEnabled
+	i := strings.Index(name, "://")
+	if i > 0 {
+		scheme := name[:i]
+		if name == auth.ServerAddress {
+			auth.ServerAddress = name[i+3:]
+		}
+		name = name[i+3:]
+		if scheme == "http" {
+			tls = TLSDisabled
+		}
+	}
+	if auth.ServerAddress == "" {
+		auth.ServerAddress = name
+	}
+	return Host{
+		Name:       name,
+		Hostname:   auth.ServerAddress,
+		TLS:        tls,
+		User:       auth.Username,
+		Pass:       auth.Password,
+		Token:      auth.IdentityToken, // TODO: verify token can be used
+		CredHelper: helper,
+	}, nil
+}
+
+func decodeAuth(authStr string) (string, string, error) {
+	if authStr == "" {
+		return "", "", nil
+	}
+	decoded, err := base64.StdEncoding.DecodeString(authStr)
+	if err != nil {
+		return "", "", err
+	}
+	userPass := strings.SplitN(string(decoded), ":", 2)
+	if len(userPass) != 2 {
+		return "", "", fmt.Errorf("invalid auth configuration file")
+	}
+	return userPass[0], strings.Trim(userPass[1], "\x00"), nil
+}

--- a/config/docker_test.go
+++ b/config/docker_test.go
@@ -1,0 +1,63 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+func TestDocker(t *testing.T) {
+	curPath := os.Getenv("PATH")
+	os.Setenv("PATH", "testdata"+string(os.PathListSeparator)+curPath)
+	defer os.Setenv("PATH", curPath)
+	curDockerConf := os.Getenv(dockerEnv)
+	os.Setenv(dockerEnv, "testdata/docker-config.json")
+	if curDockerConf != "" {
+		defer os.Setenv(dockerEnv, curDockerConf)
+	} else {
+		defer os.Unsetenv(dockerEnv)
+	}
+	hosts, err := DockerLoad()
+	if err != nil {
+		t.Errorf("error loading docker credentials: %v", err)
+	}
+	hostMap := map[string]*Host{}
+	for _, h := range hosts {
+		h := h // shadow h for unique var/pointer
+		hostMap[h.Name] = &h
+	}
+	tests := []struct {
+		name       string
+		hostname   string
+		expectUser string
+		expectPass string
+	}{
+		{
+			name:       "testhost",
+			hostname:   "testhost.example.com",
+			expectUser: "hello",
+			expectPass: "world",
+		},
+		{
+			name:       "localhost:5001",
+			hostname:   "localhost:5001",
+			expectUser: "hello",
+			expectPass: "docker",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h, ok := hostMap[tt.hostname]
+			if !ok {
+				t.Errorf("host not found: %s", tt.hostname)
+				return
+			}
+			cred := h.GetCred()
+			if tt.expectUser != cred.User {
+				t.Errorf("user mismatch, expect %s, received %s", tt.expectUser, cred.User)
+			}
+			if tt.expectPass != cred.Password {
+				t.Errorf("user mismatch, expect %s, received %s", tt.expectPass, cred.Password)
+			}
+		})
+	}
+}

--- a/config/host.go
+++ b/config/host.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 
+	"github.com/regclient/regclient/internal/timejson"
 	"github.com/sirupsen/logrus"
 )
 
@@ -31,6 +33,11 @@ const (
 	DockerRegistryAuth = "https://index.docker.io/v1/"
 	// DockerRegistryDNS is the host to connect to for Hub
 	DockerRegistryDNS = "registry-1.docker.io"
+)
+
+var (
+	defaultExpire          = time.Minute * 5
+	defaultCredHelperRetry = time.Second * 5
 )
 
 // MarshalJSON converts to a json string using MarshalText
@@ -86,25 +93,32 @@ func (t *TLSConf) UnmarshalText(b []byte) error {
 
 // Host struct contains host specific settings
 type Host struct {
-	Name       string            `json:"-"`
-	Scheme     string            `json:"scheme,omitempty"` // TODO: deprecate, delete
-	TLS        TLSConf           `json:"tls,omitempty"`
-	RegCert    string            `json:"regcert,omitempty"`
-	ClientCert string            `json:"clientcert,omitempty"`
-	ClientKey  string            `json:"clientkey,omitempty"`
-	DNS        []string          `json:"dns,omitempty"`      // TODO: remove slice, single string, or remove entirely?
-	Hostname   string            `json:"hostname,omitempty"` // replaces DNS array with single string
-	User       string            `json:"user,omitempty"`
-	Pass       string            `json:"pass,omitempty"`
-	Token      string            `json:"token,omitempty"`
-	PathPrefix string            `json:"pathPrefix,omitempty"` // used for mirrors defined within a repository namespace
-	Mirrors    []string          `json:"mirrors,omitempty"`    // list of other Host Names to use as mirrors
-	Priority   uint              `json:"priority,omitempty"`   // priority when sorting mirrors, higher priority attempted first
-	RepoAuth   bool              `json:"repoAuth,omitempty"`   // tracks a separate auth per repo
-	API        string            `json:"api,omitempty"`        // experimental: registry API to use
-	APIOpts    map[string]string `json:"apiOpts,omitempty"`    // options for APIs
-	BlobChunk  int64             `json:"blobChunk,omitempty"`  // size of each blob chunk
-	BlobMax    int64             `json:"blobMax,omitempty"`    // threshold to switch to chunked upload, -1 to disable, 0 for regclient.blobMaxPut
+	Name        string            `json:"-" yaml:"-"`                             // internal use, name of the host
+	Scheme      string            `json:"scheme,omitempty" yaml:"scheme"`         // TODO: deprecate, delete
+	TLS         TLSConf           `json:"tls,omitempty" yaml:"tls"`               // enabled, disabled, insecure
+	RegCert     string            `json:"regcert,omitempty" yaml:"regcert"`       // public pem cert of registry
+	ClientCert  string            `json:"clientcert,omitempty" yaml:"clientcert"` // public pem cert for client (mTLS)
+	ClientKey   string            `json:"clientkey,omitempty" yaml:"clientkey"`   // private pem cert for client (mTLS)
+	DNS         []string          `json:"dns,omitempty" yaml:"dns"`               // TODO: remove slice, single string, or remove entirely?
+	Hostname    string            `json:"hostname,omitempty" yaml:"hostname"`     // replaces DNS array with single string
+	User        string            `json:"user,omitempty" yaml:"user"`             // username, not used with credHelper
+	Pass        string            `json:"pass,omitempty" yaml:"pass"`             // password, not used with credHelper
+	Token       string            `json:"token,omitempty" yaml:"token"`           // token, experimental for specific APIs
+	CredHelper  string            `json:"credHelper,omitempty" yaml:"credHelper"` // credential helper command for requesting logins
+	CredExpire  timejson.Duration `json:"credExpire,omitempty" yaml:"credExpire"` // time until credential expires
+	credRefresh time.Time         `json:"-" yaml:"-"`                             // internal use, when to refresh credentials
+	PathPrefix  string            `json:"pathPrefix,omitempty" yaml:"pathPrefix"` // used for mirrors defined within a repository namespace
+	Mirrors     []string          `json:"mirrors,omitempty" yaml:"mirrors"`       // list of other Host Names to use as mirrors
+	Priority    uint              `json:"priority,omitempty" yaml:"priority"`     // priority when sorting mirrors, higher priority attempted first
+	RepoAuth    bool              `json:"repoAuth,omitempty" yaml:"repoAuth"`     // tracks a separate auth per repo
+	API         string            `json:"api,omitempty" yaml:"api"`               // experimental: registry API to use
+	APIOpts     map[string]string `json:"apiOpts,omitempty" yaml:"apiOpts"`       // options for APIs
+	BlobChunk   int64             `json:"blobChunk,omitempty" yaml:"blobChunk"`   // size of each blob chunk
+	BlobMax     int64             `json:"blobMax,omitempty" yaml:"blobMax"`       // threshold to switch to chunked upload, -1 to disable, 0 for regclient.blobMaxPut
+}
+
+type Cred struct {
+	User, Password, Token string
 }
 
 // HostNew creates a default Host entry
@@ -129,6 +143,29 @@ func HostNewName(host string) *Host {
 		h.Hostname = DockerRegistryDNS
 	}
 	return &h
+}
+
+func (host *Host) GetCred() Cred {
+	// refresh from credHelper if needed
+	if host.CredHelper != "" && (host.credRefresh.IsZero() || time.Now().After(host.credRefresh)) {
+		host.refreshHelper()
+	}
+	return Cred{User: host.User, Password: host.Pass, Token: host.Token}
+}
+
+func (host *Host) refreshHelper() {
+	if host.CredHelper == "" {
+		return
+	}
+	if host.CredExpire <= 0 {
+		host.CredExpire = timejson.Duration(defaultExpire)
+	}
+	// run a cred helper, calling get method
+	ch := newCredHelper(host.CredHelper, map[string]string{})
+	err := ch.get(host)
+	if err != nil {
+		host.credRefresh = time.Now().Add(defaultCredHelperRetry)
+	}
 }
 
 // Merge adds fields from a new config host entry
@@ -174,6 +211,28 @@ func (host *Host) Merge(newHost Host, log *logrus.Logger) error {
 			}).Warn("Changing login token for registry")
 		}
 		host.Token = newHost.Token
+	}
+
+	if newHost.CredHelper != "" {
+		if host.CredHelper != "" && host.CredHelper != newHost.CredHelper {
+			log.WithFields(logrus.Fields{
+				"host": name,
+				"orig": host.CredHelper,
+				"new":  newHost.CredHelper,
+			}).Warn("Changing credential helper for registry")
+		}
+		host.CredHelper = newHost.CredHelper
+	}
+
+	if newHost.CredExpire != 0 {
+		if host.CredExpire != 0 && host.CredExpire != newHost.CredExpire {
+			log.WithFields(logrus.Fields{
+				"host": name,
+				"orig": host.CredExpire,
+				"new":  newHost.CredExpire,
+			}).Warn("Changing credential expire for registry")
+		}
+		host.CredExpire = newHost.CredExpire
 	}
 
 	if newHost.TLS != TLSUndefined {

--- a/config/host_test.go
+++ b/config/host_test.go
@@ -2,10 +2,18 @@ package config
 
 import (
 	"encoding/json"
+	"os"
 	"testing"
+	"time"
+
+	"github.com/regclient/regclient/internal/timejson"
 )
 
 func TestConfig(t *testing.T) {
+	curPath := os.Getenv("PATH")
+	os.Setenv("PATH", "testdata"+string(os.PathListSeparator)+curPath)
+	defer os.Setenv("PATH", curPath)
+
 	// generate new/blank
 	blankHostP := HostNew()
 
@@ -34,14 +42,22 @@ func TestConfig(t *testing.T) {
 		"user": "user-ex3",
 		"pass": "secret3",
 		"pathPrefix": "hub3",
-		"mirrors": ["host3.example.com"],
+		"mirrors": ["testhost.example.com"],
 		"priority": 42,
 		"apiOpts": {"disableHead": "false", "unknownOpt": "3"},
 		"blobChunk": 333333,
 		"blobMax": 333333
 	}
 	`
-	var exHost, exHost2 Host
+	exJSONCredHelper := `
+	{
+	  "tls": "insecure",
+		"hostname": "testhost.example.com",
+		"credHelper": "docker-credential-test",
+		"credExpire": "1h0m0s"
+	}
+	`
+	var exHost, exHost2, exHostCredHelper Host
 	err := json.Unmarshal([]byte(exJSON), &exHost)
 	if err != nil {
 		t.Errorf("failed unmarshaling exJson: %v", err)
@@ -49,6 +65,10 @@ func TestConfig(t *testing.T) {
 	err = json.Unmarshal([]byte(exJSON2), &exHost2)
 	if err != nil {
 		t.Errorf("failed unmarshaling exJson2: %v", err)
+	}
+	err = json.Unmarshal([]byte(exJSONCredHelper), &exHostCredHelper)
+	if err != nil {
+		t.Errorf("failed unmarshaling exJsonCredHelper: %v", err)
 	}
 
 	// merge blank with json
@@ -62,12 +82,18 @@ func TestConfig(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed to merge ex host with exHost2: %v", err)
 	}
+	exMergeCredHelper := *blankHostP
+	err = (&exMergeCredHelper).Merge(exHostCredHelper, nil)
+	if err != nil {
+		t.Errorf("failed to merge blank host with exHostCredHelper: %v", err)
+	}
 
 	// verify fields in each
 	tests := []struct {
 		name       string
 		host       Host
 		hostExpect Host
+		credExpect Cred
 	}{
 		{
 			name: "blank",
@@ -76,6 +102,7 @@ func TestConfig(t *testing.T) {
 				TLS:     TLSEnabled,
 				APIOpts: map[string]string{},
 			},
+			credExpect: Cred{},
 		},
 		{
 			name: "empty",
@@ -85,6 +112,7 @@ func TestConfig(t *testing.T) {
 				Hostname: "host.example.org",
 				APIOpts:  map[string]string{},
 			},
+			credExpect: Cred{},
 		},
 		{
 			name: "exHost",
@@ -101,6 +129,10 @@ func TestConfig(t *testing.T) {
 				PathPrefix: "hub",
 				Mirrors:    []string{"host1.example.com", "host2.example.com"},
 			},
+			credExpect: Cred{
+				User:     "user-ex",
+				Password: "secret",
+			},
 		},
 		{
 			name: "exHost2",
@@ -111,11 +143,30 @@ func TestConfig(t *testing.T) {
 				User:       "user-ex3",
 				Pass:       "secret3",
 				PathPrefix: "hub3",
-				Mirrors:    []string{"host3.example.com"},
+				Mirrors:    []string{"testhost.example.com"},
 				Priority:   42,
 				APIOpts:    map[string]string{"disableHead": "false", "unknownOpt": "3"},
 				BlobChunk:  333333,
 				BlobMax:    333333,
+			},
+			credExpect: Cred{
+				User:     "user-ex3",
+				Password: "secret3",
+			},
+		},
+		{
+			name: "exHostCredHelper",
+			host: exHostCredHelper,
+			hostExpect: Host{
+				TLS:        TLSInsecure,
+				Hostname:   "testhost.example.com",
+				CredHelper: "docker-credential-test",
+				CredExpire: timejson.Duration(time.Hour),
+				APIOpts:    map[string]string{},
+			},
+			credExpect: Cred{
+				User:     "hello",
+				Password: "world",
 			},
 		},
 		{
@@ -133,6 +184,10 @@ func TestConfig(t *testing.T) {
 				PathPrefix: "hub",
 				Mirrors:    []string{"host1.example.com", "host2.example.com"},
 			},
+			credExpect: Cred{
+				User:     "user-ex",
+				Password: "secret",
+			},
 		},
 		{
 			name: "mergeHost2",
@@ -143,11 +198,30 @@ func TestConfig(t *testing.T) {
 				User:       "user-ex3",
 				Pass:       "secret3",
 				PathPrefix: "hub3",
-				Mirrors:    []string{"host3.example.com"},
+				Mirrors:    []string{"testhost.example.com"},
 				Priority:   42,
 				APIOpts:    map[string]string{"disableHead": "false", "unknownOpt": "3"},
 				BlobChunk:  333333,
 				BlobMax:    333333,
+			},
+			credExpect: Cred{
+				User:     "user-ex3",
+				Password: "secret3",
+			},
+		},
+		{
+			name: "mergeHostCredHelper",
+			host: exMergeCredHelper,
+			hostExpect: Host{
+				TLS:        TLSInsecure,
+				Hostname:   "testhost.example.com",
+				CredHelper: "docker-credential-test",
+				CredExpire: timejson.Duration(time.Hour),
+				APIOpts:    map[string]string{},
+			},
+			credExpect: Cred{
+				User:     "hello",
+				Password: "world",
 			},
 		},
 	}
@@ -174,6 +248,12 @@ func TestConfig(t *testing.T) {
 			}
 			if tt.host.Token != tt.hostExpect.Token {
 				t.Errorf("token field mismatch, expected %s, found %s", tt.hostExpect.Token, tt.host.Token)
+			}
+			if tt.host.CredHelper != tt.hostExpect.CredHelper {
+				t.Errorf("credHelper field mismatch, expected %s, found %s", tt.hostExpect.CredHelper, tt.host.CredHelper)
+			}
+			if tt.host.CredExpire != tt.hostExpect.CredExpire {
+				t.Errorf("credExCredExpire field mismatch, expected %s, found %s", time.Duration(tt.hostExpect.CredExpire).String(), time.Duration(tt.host.CredExpire).String())
 			}
 			if tt.host.PathPrefix != tt.hostExpect.PathPrefix {
 				t.Errorf("pathPrefix field mismatch, expected %s, found %s", tt.hostExpect.PathPrefix, tt.host.PathPrefix)
@@ -204,6 +284,16 @@ func TestConfig(t *testing.T) {
 						t.Errorf("apiOpts field %s mismatch, expected %s, found %s", i, tt.hostExpect.APIOpts[i], tt.host.APIOpts[i])
 					}
 				}
+			}
+			cred := tt.host.GetCred()
+			if tt.credExpect.User != cred.User {
+				t.Errorf("cred user field mismatch, expected %s, found %s", tt.credExpect.User, cred.User)
+			}
+			if tt.credExpect.Password != cred.Password {
+				t.Errorf("cred password field mismatch, expected %s, found %s", tt.credExpect.Password, cred.Password)
+			}
+			if tt.credExpect.Token != cred.Token {
+				t.Errorf("cred token field mismatch, expected %s, found %s", tt.credExpect.Token, cred.Token)
 			}
 		})
 	}

--- a/config/testdata/docker-config.json
+++ b/config/testdata/docker-config.json
@@ -1,0 +1,13 @@
+{
+  "auths": {
+    "localhost:5001": {
+      "auth": "aGVsbG86ZG9ja2Vy"
+    },
+    "hub-tool-token": {
+      "identitytoken": "MTIzNDUK"
+    }
+  },
+  "credHelpers": {
+    "testhost.example.com": "test"
+  }
+}

--- a/config/testdata/docker-credential-test
+++ b/config/testdata/docker-credential-test
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+registry_testhost='
+{ "ServerURL": "testhost.example.com",
+  "Username": "hello",
+  "Secret": "world"
+}
+'
+
+if [ "$1" = "get" ]; then
+  read hostname
+  case "$hostname" in
+    testhost.example.com)
+      echo "${registry_testhost}"
+      exit 0
+      ;;
+  esac
+fi
+# unhandled request
+exit 1

--- a/internal/conffile/conffile.go
+++ b/internal/conffile/conffile.go
@@ -1,0 +1,139 @@
+// Package conffile wraps the read and write of configuration files
+package conffile
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/regclient/regclient/internal/rwfs"
+)
+
+type File struct {
+	// dir, name string
+	perms    int
+	fullname string
+	fs       rwfs.RWFS
+}
+
+type Opt func(*File)
+
+// New returns a new File
+func New(opts ...Opt) *File {
+	f := File{perms: 0600, fs: rwfs.OSNew("")}
+	for _, fn := range opts {
+		fn(&f)
+	}
+	if f.fullname == "" {
+		return nil
+	}
+	return &f
+}
+
+// WithDirName determines the filename from a subdirectory in the user's HOME
+// e.g. dir=".app", name="config.json", sets the fullname to "$HOME/.app/config.json"
+func WithDirName(dir, name string) Opt {
+	return func(f *File) {
+		fullname := filepath.Join(homedir(), dir, name)
+		f.fullname = fullname
+	}
+}
+
+// WithEnv sets the fullname to the environment value if defined
+func WithEnv(envVar string) Opt {
+	return func(f *File) {
+		val := os.Getenv(envVar)
+		if val != "" {
+			f.fullname = val
+		}
+	}
+}
+
+// WithFullname specifies the filename
+func WithFullname(fullname string) Opt {
+	return func(f *File) {
+		f.fullname = fullname
+	}
+}
+
+// WithFS overrides the default OS filesystem
+func WithFS(fs rwfs.RWFS) Opt {
+	return func(f *File) {
+		f.fs = fs
+	}
+}
+
+// WithPerms specifies the permissions to create a file with (default 0600)
+func WithPerms(perms int) Opt {
+	return func(f *File) {
+		f.perms = perms
+	}
+}
+
+func (f *File) Name() string {
+	return f.fullname
+}
+
+func (f *File) Open() (io.ReadCloser, error) {
+	return f.fs.Open(f.fullname)
+}
+
+func (f *File) Write(rdr io.Reader) error {
+	// create temp file/open
+	dir := filepath.Dir(f.fullname)
+	if err := rwfs.MkdirAll(f.fs, dir, 0700); err != nil {
+		return err
+	}
+	tmp, err := rwfs.CreateTemp(f.fs, dir, filepath.Base(f.fullname))
+	if err != nil {
+		return err
+	}
+	tmpStat, err := tmp.Stat()
+	if err != nil {
+		return err
+	}
+	tmpName := tmpStat.Name()
+	tmpFullname := filepath.Join(dir, tmpName)
+	defer func() {
+		f.fs.Remove(tmpFullname)
+	}()
+
+	// copy from rdr to temp file
+	_, err = io.Copy(tmp, rdr)
+	tmp.Close()
+	if err != nil {
+		return fmt.Errorf("failed to write config: %w", err)
+	}
+
+	// adjust file ownership/permissions
+	mode := os.FileMode(0600)
+	uid := os.Getuid()
+	gid := os.Getgid()
+	// adjust defaults based on existing file if available
+	stat, err := rwfs.Stat(f.fs, f.fullname)
+	if err == nil {
+		// adjust mode to existing file
+		if stat.Mode().IsRegular() {
+			mode = stat.Mode()
+		}
+		uid, gid, _ = getFileOwner(stat)
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return err
+	}
+
+	// update mode and owner of temp file
+	fPerm, ok := f.fs.(rwfs.RWPerms)
+	if ok {
+		if err := fPerm.Chmod(tmpFullname, mode); err != nil {
+			return err
+		}
+		if uid > 0 && gid > 0 {
+			_ = fPerm.Chown(tmpFullname, uid, gid)
+		}
+	}
+	// move temp file to target filename
+	return f.fs.Rename(tmpFullname, f.fullname)
+}

--- a/internal/conffile/conffile_test.go
+++ b/internal/conffile/conffile_test.go
@@ -1,0 +1,114 @@
+package conffile
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/regclient/regclient/internal/rwfs"
+)
+
+// test New
+func TestNew(t *testing.T) {
+	testEnvVar, testEnvVal := "TEST_CONFFILE_NEW", "./test-filename.json"
+	os.Setenv(testEnvVar, testEnvVal)
+	testEnvUnset := "TEST_CONFFILE_NEW_UNSET"
+	os.Unsetenv(testEnvUnset)
+	hd := homedir()
+	tests := []struct {
+		name       string
+		opts       []Opt
+		expectNil  bool
+		expectName string
+	}{
+		{
+			name:      "empty",
+			expectNil: true,
+		},
+		{
+			name: "fullname override",
+			opts: []Opt{
+				WithDirName(".config", "file.json"),
+				WithEnv(testEnvVar),
+				WithFullname("/tmp/conf.json"),
+			},
+			expectName: "/tmp/conf.json",
+		},
+		{
+			name: "fullname only",
+			opts: []Opt{
+				WithFullname("/tmp/conf.json"),
+			},
+			expectName: "/tmp/conf.json",
+		},
+		{
+			name: "env override",
+			opts: []Opt{
+				WithDirName(".config", "file.json"),
+				WithEnv(testEnvVar),
+			},
+			expectName: testEnvVal,
+		},
+		{
+			name: "dir name",
+			opts: []Opt{
+				WithDirName(".config", "file.json"),
+			},
+			expectName: filepath.Join(hd, ".config", "file.json"),
+		},
+		{
+			name: "env unset",
+			opts: []Opt{
+				WithDirName(".config", "file.json"),
+				WithEnv(testEnvUnset),
+			},
+			expectName: filepath.Join(hd, ".config", "file.json"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cf := New(tt.opts...)
+			if tt.expectNil {
+				if cf != nil {
+					t.Errorf("result was not nil: %v", cf)
+				}
+				return
+			}
+			if cf == nil {
+				t.Errorf("result was nil")
+				return
+			}
+			if cf.Name() != tt.expectName {
+				t.Errorf("fullname mismatch, expected %s, received %s", tt.expectName, cf.Name())
+			}
+		})
+	}
+}
+
+// TestWriteOpen test Write and Open using MemFS
+func TestWriteOpen(t *testing.T) {
+	memfs := rwfs.MemNew()
+	confContent := []byte("hello test")
+	cf := New(WithFS(memfs), WithFullname("test.json"))
+	err := cf.Write(bytes.NewReader(confContent))
+	if err != nil {
+		t.Errorf("failed to write config file: %v", err)
+		return
+	}
+	rc, err := cf.Open()
+	if err != nil {
+		t.Errorf("failed to open config file: %v", err)
+		return
+	}
+	defer rc.Close()
+	readBytes, err := io.ReadAll(rc)
+	if err != nil {
+		t.Errorf("failed to read content: %v", err)
+		return
+	}
+	if !bytes.Equal(readBytes, confContent) {
+		t.Errorf("content mismatch, write: %s, read: %s", string(confContent), string(readBytes))
+	}
+}

--- a/internal/conffile/conffile_unix.go
+++ b/internal/conffile/conffile_unix.go
@@ -1,0 +1,20 @@
+//go:build !windows
+// +build !windows
+
+package conffile
+
+import (
+	"io/fs"
+	"syscall"
+)
+
+const homeEnv = "HOME"
+
+func getFileOwner(stat fs.FileInfo) (int, int, error) {
+	var uid, gid int
+	if sysstat, ok := stat.Sys().(*syscall.Stat_t); ok {
+		uid = int(sysstat.Uid)
+		gid = int(sysstat.Gid)
+	}
+	return uid, gid, nil
+}

--- a/internal/conffile/conffile_windows.go
+++ b/internal/conffile/conffile_windows.go
@@ -1,0 +1,14 @@
+//go:build windows
+// +build windows
+
+package conffile
+
+import (
+	"io/fs"
+)
+
+const homeEnv = "USERPROFILE"
+
+func getFileOwner(stat fs.FileInfo) (int, int, error) {
+	return 0, 0, nil
+}

--- a/internal/conffile/homedir.go
+++ b/internal/conffile/homedir.go
@@ -1,0 +1,17 @@
+package conffile
+
+import (
+	"os"
+	"os/user"
+)
+
+func homedir() string {
+	home := os.Getenv(homeEnv)
+	if home == "" {
+		u, err := user.Current()
+		if err == nil {
+			home = u.HomeDir
+		}
+	}
+	return home
+}

--- a/internal/timejson/timejson.go
+++ b/internal/timejson/timejson.go
@@ -1,0 +1,41 @@
+// Package timejson extends time methods with marshal/unmarshal for json
+package timejson
+
+import (
+	"encoding/json"
+	"errors"
+	"time"
+)
+
+var errInvalid = errors.New("invalid duration")
+
+// Duration is an alias to time.Duration
+// Implementation taken from https://stackoverflow.com/questions/48050945/how-to-unmarshal-json-into-durations
+type Duration time.Duration
+
+// MarshalJSON converts a duration to json
+func (d Duration) MarshalJSON() ([]byte, error) {
+	return json.Marshal(time.Duration(d).String())
+}
+
+// UnmarshalJSON converts json to a duration
+func (d *Duration) UnmarshalJSON(b []byte) error {
+	var v interface{}
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+	switch value := v.(type) {
+	case float64:
+		*d = Duration(time.Duration(value))
+		return nil
+	case string:
+		timeDur, err := time.ParseDuration(value)
+		if err != nil {
+			return err
+		}
+		*d = Duration(timeDur)
+		return nil
+	default:
+		return errInvalid
+	}
+}

--- a/internal/timejson/timejson_test.go
+++ b/internal/timejson/timejson_test.go
@@ -1,0 +1,106 @@
+package timejson
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestMarshal(t *testing.T) {
+	tests := []struct {
+		name   string
+		d      Duration
+		expect string
+	}{
+		{
+			name:   "second",
+			d:      Duration(time.Second),
+			expect: `"1s"`,
+		},
+		{
+			name:   "hour",
+			d:      Duration(time.Hour),
+			expect: `"1h0m0s"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b, err := tt.d.MarshalJSON()
+			if err != nil {
+				t.Errorf("failed marshaling: %v", err)
+				return
+			}
+			if !bytes.Equal(b, []byte(tt.expect)) {
+				t.Errorf("mismatch, expected %s, received %s", tt.expect, string(b))
+			}
+		})
+	}
+}
+
+func TestUnmarshal(t *testing.T) {
+	tests := []struct {
+		name   string
+		str    string
+		expect Duration
+		expErr error
+	}{
+		{
+			name:   "unquoted string",
+			str:    `1s`,
+			expErr: errors.New("invalid character 's' after top-level value"),
+		},
+		{
+			name:   "bool",
+			str:    `true`,
+			expErr: errInvalid,
+		},
+		{
+			name:   "invalid duration",
+			str:    `"42 years"`,
+			expErr: errors.New(`time: unknown unit " years" in duration "42 years"`),
+		},
+		{
+			name:   "second",
+			str:    `"1s"`,
+			expect: Duration(time.Second),
+			expErr: nil,
+		},
+		{
+			name:   "hour",
+			str:    `"1h"`,
+			expect: Duration(time.Hour),
+			expErr: nil,
+		},
+		{
+			name:   "second float",
+			str:    fmt.Sprintf("%d", time.Second),
+			expect: Duration(time.Second),
+			expErr: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var d Duration
+			err := (&d).UnmarshalJSON([]byte(tt.str))
+			if tt.expErr != nil {
+				if err == nil {
+					t.Errorf("error not encountered")
+				} else if err != tt.expErr && err.Error() != tt.expErr.Error() {
+					t.Errorf("error mismatch, expected %v, received %v", tt.expErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("failed unmarshaling: %v", err)
+				return
+			}
+			if d != tt.expect {
+				t.Errorf("duration mismatch, expected %s, received %s", time.Duration(tt.expect).String(), time.Duration(d).String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This adds support for parsing the docker config.json directly. This will remove an external dependency and also allow for calling credential helpers only when they are needed.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

This isn't externally visible yet.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
