### PR TITLE
Refers field needs to be a pointer for "omitempty"

### DIFF
--- a/cmd/regctl/artifact.go
+++ b/cmd/regctl/artifact.go
@@ -387,13 +387,14 @@ func runArtifactPut(cmd *cobra.Command, args []string) error {
 	rc := newRegClient()
 	defer rc.Close(ctx, r)
 
-	refDesc := types.Descriptor{}
+	var refDesc *types.Descriptor
 	if artifactOpts.refers {
 		rmh, err := rc.ManifestHead(ctx, r)
 		if err != nil {
 			return fmt.Errorf("unable to find referenced manifest: %w", err)
 		}
-		refDesc = rmh.GetDescriptor()
+		d := rmh.GetDescriptor()
+		refDesc = &d
 	}
 
 	// read config, or initialize to an empty json config

--- a/scheme/ocidir/referrer_test.go
+++ b/scheme/ocidir/referrer_test.go
@@ -55,6 +55,7 @@ func TestReferrer(t *testing.T) {
 		annotType:  aType,
 		extraAnnot: extraValue,
 	}
+	mDesc := m.GetDescriptor()
 	artifact := v1.Manifest{
 		Versioned: v1.ManifestSchemaVersion,
 		MediaType: types.MediaTypeOCI1Manifest,
@@ -71,7 +72,7 @@ func TestReferrer(t *testing.T) {
 			},
 		},
 		Annotations: artifactAnnot,
-		Refers:      m.GetDescriptor(),
+		Refers:      &mDesc,
 	}
 	artifactM, err := manifest.New(manifest.WithOrig(artifact))
 	if err != nil {

--- a/scheme/reg/referrer.go
+++ b/scheme/reg/referrer.go
@@ -206,16 +206,9 @@ func (reg *Reg) ReferrerPut(ctx context.Context, r ref.Ref, m manifest.Manifest)
 		return err
 	}
 	// validate/set referrer descriptor
-	if refers.MediaType != mRef.GetMediaType() || refers.Digest != mRef.GetDigest() || refers.Size != mRef.GetDescriptor().Size {
-		reg.log.WithFields(logrus.Fields{
-			"old MT":   refers.MediaType,
-			"new MT":   mRef.GetDescriptor().MediaType,
-			"old Dig":  refers.Digest.String(),
-			"new Dig":  mRef.GetDescriptor().Digest.String(),
-			"old Size": refers.Size,
-			"new Size": mRef.GetDescriptor().Size,
-		}).Debug("refers field updated")
-		err = mRefer.SetRefers(mRef.GetDescriptor())
+	mRefDesc := mRef.GetDescriptor()
+	if refers == nil || refers.MediaType != mRefDesc.MediaType || refers.Digest != mRefDesc.Digest || refers.Size != mRefDesc.Size {
+		err = mRefer.SetRefers(&mRefDesc)
 		if err != nil {
 			return err
 		}

--- a/scheme/reg/referrer_test.go
+++ b/scheme/reg/referrer_test.go
@@ -77,7 +77,7 @@ func TestReferrer(t *testing.T) {
 			},
 		},
 		Annotations: artifactAnnot,
-		Refers: types.Descriptor{
+		Refers: &types.Descriptor{
 			MediaType: types.MediaTypeDocker2Manifest,
 			Size:      int64(mLen),
 			Digest:    mDigest,

--- a/types/docker/schema2/manifest.go
+++ b/types/docker/schema2/manifest.go
@@ -27,5 +27,5 @@ type Manifest struct {
 	Annotations map[string]string `json:"annotations,omitempty"`
 
 	// Refers indicates this manifest references another manifest
-	Refers types.Descriptor `json:"refers,omitempty"`
+	Refers *types.Descriptor `json:"refers,omitempty"`
 }

--- a/types/manifest/docker2.go
+++ b/types/manifest/docker2.go
@@ -99,9 +99,9 @@ func (m *docker2ManifestList) GetPlatformList() ([]*platform.Platform, error) {
 	return getPlatformList(dl)
 }
 
-func (m *docker2Manifest) GetRefers() (types.Descriptor, error) {
+func (m *docker2Manifest) GetRefers() (*types.Descriptor, error) {
 	if !m.manifSet {
-		return types.Descriptor{}, wraperr.New(fmt.Errorf("Manifest unavailable, perform a ManifestGet first"), types.ErrUnavailable)
+		return nil, wraperr.New(fmt.Errorf("Manifest unavailable, perform a ManifestGet first"), types.ErrUnavailable)
 	}
 	return m.Manifest.Refers, nil
 }
@@ -265,7 +265,7 @@ func (m *docker2ManifestList) SetOrig(origIn interface{}) error {
 	return m.updateDesc()
 }
 
-func (m *docker2Manifest) SetRefers(d types.Descriptor) error {
+func (m *docker2Manifest) SetRefers(d *types.Descriptor) error {
 	if !m.manifSet {
 		return wraperr.New(fmt.Errorf("Manifest unavailable, perform a ManifestGet first"), types.ErrUnavailable)
 	}

--- a/types/manifest/manifest.go
+++ b/types/manifest/manifest.go
@@ -55,8 +55,8 @@ type Annotator interface {
 }
 
 type Referrer interface {
-	GetRefers() (types.Descriptor, error)
-	SetRefers(types.Descriptor) error
+	GetRefers() (*types.Descriptor, error)
+	SetRefers(*types.Descriptor) error
 }
 
 type manifestConfig struct {

--- a/types/manifest/manifest_test.go
+++ b/types/manifest/manifest_test.go
@@ -658,7 +658,7 @@ func TestNew(t *testing.T) {
 					if err != nil {
 						t.Errorf("failed getting annotations: %v", err)
 					}
-					if getAnnot["testkey"] != "testval" {
+					if getAnnot == nil || getAnnot["testkey"] != "testval" {
 						t.Errorf("annotation testkey missing, expected testval, received map %v", getAnnot)
 					}
 				} else if ok {
@@ -671,7 +671,7 @@ func TestNew(t *testing.T) {
 					if !ok {
 						t.Errorf("manifest does not support referrer")
 					}
-					err = mr.SetRefers(rDesc)
+					err = mr.SetRefers(&rDesc)
 					if err != nil {
 						t.Errorf("failed setting referrer: %v", err)
 					}
@@ -679,7 +679,7 @@ func TestNew(t *testing.T) {
 					if err != nil {
 						t.Errorf("failed getting referrer: %v", err)
 					}
-					if getDesc.MediaType != rDesc.MediaType || getDesc.Digest != rDesc.Digest {
+					if getDesc == nil || getDesc.MediaType != rDesc.MediaType || getDesc.Digest != rDesc.Digest {
 						t.Errorf("referrer did not match, expected %v, received %v", rDesc, getDesc)
 					}
 				} else if ok {

--- a/types/manifest/oci1.go
+++ b/types/manifest/oci1.go
@@ -145,15 +145,15 @@ func (m *oci1Manifest) MarshalJSON() ([]byte, error) {
 
 	return json.Marshal((m.Manifest))
 }
-func (m *oci1Manifest) GetRefers() (types.Descriptor, error) {
+func (m *oci1Manifest) GetRefers() (*types.Descriptor, error) {
 	if !m.manifSet {
-		return types.Descriptor{}, wraperr.New(fmt.Errorf("Manifest unavailable, perform a ManifestGet first"), types.ErrUnavailable)
+		return nil, wraperr.New(fmt.Errorf("Manifest unavailable, perform a ManifestGet first"), types.ErrUnavailable)
 	}
 	return m.Manifest.Refers, nil
 }
-func (m *oci1Artifact) GetRefers() (types.Descriptor, error) {
+func (m *oci1Artifact) GetRefers() (*types.Descriptor, error) {
 	if !m.manifSet {
-		return types.Descriptor{}, wraperr.New(fmt.Errorf("Manifest unavailable, perform a ManifestGet first"), types.ErrUnavailable)
+		return nil, wraperr.New(fmt.Errorf("Manifest unavailable, perform a ManifestGet first"), types.ErrUnavailable)
 	}
 	return m.ArtifactManifest.Refers, nil
 }
@@ -369,14 +369,14 @@ func (m *oci1Index) SetOrig(origIn interface{}) error {
 	return m.updateDesc()
 }
 
-func (m *oci1Artifact) SetRefers(d types.Descriptor) error {
+func (m *oci1Artifact) SetRefers(d *types.Descriptor) error {
 	if !m.manifSet {
 		return wraperr.New(fmt.Errorf("Manifest unavailable, perform a ManifestGet first"), types.ErrUnavailable)
 	}
 	m.ArtifactManifest.Refers = d
 	return m.updateDesc()
 }
-func (m *oci1Manifest) SetRefers(d types.Descriptor) error {
+func (m *oci1Manifest) SetRefers(d *types.Descriptor) error {
 	if !m.manifSet {
 		return wraperr.New(fmt.Errorf("Manifest unavailable, perform a ManifestGet first"), types.ErrUnavailable)
 	}

--- a/types/oci/v1/artifact.go
+++ b/types/oci/v1/artifact.go
@@ -22,7 +22,7 @@ type ArtifactManifest struct {
 	Blobs []types.Descriptor `json:"blobs"`
 
 	// Refers indicates this manifest references another manifest
-	Refers types.Descriptor `json:"refers,omitempty"`
+	Refers *types.Descriptor `json:"refers,omitempty"`
 
 	// Annotations contains arbitrary metadata for the artifact manifest.
 	Annotations map[string]string `json:"annotations,omitempty"`

--- a/types/oci/v1/manifest.go
+++ b/types/oci/v1/manifest.go
@@ -28,5 +28,5 @@ type Manifest struct {
 	Annotations map[string]string `json:"annotations,omitempty"`
 
 	// Refers indicates this manifest references another manifest
-	Refers types.Descriptor `json:"refers,omitempty"`
+	Refers *types.Descriptor `json:"refers,omitempty"`
 }


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

The experimental refers field should be omitted when not used. This switches the field to a pointer so the json marshaling can detect the nil value.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

`regctl image mod` on a supported manifest type (docker image, OCI image, OCI artifact) does not result in an empty `refers: {}` field.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [ ] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
