### PR TITLE
Do not error when docker config.json is missing

### DIFF
--- a/cmd/regctl/config.go
+++ b/cmd/regctl/config.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
+	"io/fs"
 
 	"github.com/regclient/regclient/config"
 	"github.com/regclient/regclient/internal/conffile"
@@ -103,7 +103,7 @@ func ConfigLoadDefault() (*Config, error) {
 		return nil, fmt.Errorf("failed to define config file")
 	}
 	c, err := ConfigLoadConfFile(cf)
-	if err != nil && os.IsNotExist(err) {
+	if err != nil && errors.Is(err, fs.ErrNotExist) {
 		// do not error on file not found
 		c := ConfigNew()
 		c.Filename = cf.Name()

--- a/config/docker.go
+++ b/config/docker.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"strings"
 
 	"github.com/regclient/regclient/internal/conffile"
@@ -63,7 +64,9 @@ func DockerLoad() ([]Host, error) {
 // parse from io.Reader to []Host
 func dockerParse(cf *conffile.File) ([]Host, error) {
 	rdr, err := cf.Open()
-	if err != nil {
+	if err != nil && errors.Is(err, fs.ErrNotExist) {
+		return []Host{}, nil
+	} else if err != nil {
 		return nil, err
 	}
 	defer rdr.Close()

--- a/config/docker_test.go
+++ b/config/docker_test.go
@@ -3,6 +3,8 @@ package config
 import (
 	"os"
 	"testing"
+
+	"github.com/regclient/regclient/internal/conffile"
 )
 
 func TestDocker(t *testing.T) {
@@ -59,5 +61,16 @@ func TestDocker(t *testing.T) {
 				t.Errorf("user mismatch, expect %s, received %s", tt.expectPass, cred.Password)
 			}
 		})
+	}
+}
+
+func TestLoadMissing(t *testing.T) {
+	cf := conffile.New(conffile.WithFullname("testdata/missing.json"))
+	h, err := dockerParse(cf)
+	if err != nil {
+		t.Errorf("error encountered when parsing missing file: %v", err)
+	}
+	if len(h) > 0 {
+		t.Errorf("hosts returned from missing file")
 	}
 }


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

A warning is output if the `~/.docker/config.json` is missing.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Ignore `fs.ErrNotFound` when loading config, return an empty host list.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

The following no longer outputs a warning:
```
docker run -it --rm regclient/regctl tag ls regclient/regctl
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
