### PR TITLE
Support referrers with image copy

### DIFF
--- a/cmd/regctl/artifact.go
+++ b/cmd/regctl/artifact.go
@@ -325,7 +325,7 @@ func runArtifactList(cmd *cobra.Command, args []string) error {
 		referrerOpts = append(referrerOpts, scheme.WithReferrerForceGet())
 	}
 
-	rl, err := rc.RefererrList(ctx, r, referrerOpts...)
+	rl, err := rc.ReferrerList(ctx, r, referrerOpts...)
 	if err != nil {
 		return err
 	}

--- a/cmd/regctl/image.go
+++ b/cmd/regctl/image.go
@@ -123,6 +123,7 @@ var imageOpts struct {
 	modOpts         []mod.Opts
 	platform        string
 	platforms       []string
+	referrers       bool
 	replace         bool
 	requireList     bool
 }
@@ -134,6 +135,7 @@ func init() {
 	imageCopyCmd.Flags().BoolVarP(&imageOpts.includeExternal, "include-external", "", false, "Include external layers")
 	imageCopyCmd.Flags().StringArrayVarP(&imageOpts.platforms, "platforms", "", []string{}, "Copy only specific platforms, registry validation must be disabled")
 	imageCopyCmd.Flags().BoolVarP(&imageOpts.digestTags, "digest-tags", "", false, "Include digest tags (\"sha256-<digest>.*\") when copying manifests")
+	imageCopyCmd.Flags().BoolVarP(&imageOpts.referrers, "referrers", "", false, "Experimental: Include referrers")
 	// platforms should be treated as experimental since it will break many registries
 	imageCopyCmd.Flags().MarkHidden("platforms")
 
@@ -441,6 +443,9 @@ func runImageCopy(cmd *cobra.Command, args []string) error {
 	}
 	if imageOpts.digestTags {
 		opts = append(opts, regclient.ImageWithDigestTags())
+	}
+	if imageOpts.referrers {
+		opts = append(opts, regclient.ImageWithReferrers())
 	}
 	if len(imageOpts.platforms) > 0 {
 		opts = append(opts, regclient.ImageWithPlatforms(imageOpts.platforms))

--- a/referrer.go
+++ b/referrer.go
@@ -9,8 +9,8 @@ import (
 	"github.com/regclient/regclient/types/referrer"
 )
 
-// RefererrList retrieves a manifest
-func (rc *RegClient) RefererrList(ctx context.Context, r ref.Ref, opts ...scheme.ReferrerOpts) (referrer.ReferrerList, error) {
+// ReferrerList retrieves a manifest
+func (rc *RegClient) ReferrerList(ctx context.Context, r ref.Ref, opts ...scheme.ReferrerOpts) (referrer.ReferrerList, error) {
 	schemeAPI, err := rc.schemeGet(r.Scheme)
 	if err != nil {
 		return referrer.ReferrerList{}, err


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Allow referrers to be queried for a recursive image copy.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

`regctl image copy --referrers src:tag dst:tag`
<!-- Include steps that can be taken to verify the change -->

### Changelog text

<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

Still no e2e tests that would be useful here, and docs not provided for experimental features.
<!-- Mark the following with an [X] to verify they are included -->

- [ ] Tests have been added or not applicable
- [ ] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
