### PR TITLE
Allow pushing a manifest by digest

### DIFF
--- a/docs/regctl.md
+++ b/docs/regctl.md
@@ -178,6 +178,7 @@ This is also useful for analyzing multi-platform manifest lists to see what plat
 
 The `put` command uploads the manifest to the registry.
 This can be used to create or modify an image.
+The format option includes `.Manifest` which supports methods from [manifest.Manifest](https://pkg.go.dev/github.com/regclient/regclient/types/manifest#Manifest).
 
 ## Blob Commands
 
@@ -262,37 +263,39 @@ Each file should have a media type passed in the same order on the command line.
 A single file may be pushed using stdin.
 The config json may also be pushed, and have it's own media type.
 To set annotations on the manifest, use `--annotation name=value`, and repeat the flag for additional annotations.
+The format option includes `.Manifest` which supports methods from [manifest.Manifest](https://pkg.go.dev/github.com/regclient/regclient/types/manifest#Manifest).
 
 The following demonstrates uploading a simple artifact from stdin/stdout:
 
 ```shell
 $ regctl artifact put \
   --annotation demo=true --annotation format=oci \
+  --format '{{ .Manifest.GetDescriptor.Digest }}' \
   localhost:5000/artifact:demo <<EOF
 Test artifact from regctl.
 This follows the OCI artifact format
 EOF
+sha256:36484d44383fc9ffd34be11da4a617a96cb06b912c98114bfdb6ad2dddd443e2
 
 $ regctl manifest get localhost:5000/artifact:demo
-{
-  "schemaVersion": 2,
-  "config": {
-    "mediaType": "application/vnd.unknown.config.v1+json",
-    "digest": "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
-    "size": 2
-  },
-  "layers": [
-    {
-      "mediaType": "application/octet-stream",
-      "digest": "sha256:7f8028bb058b780630dcd31cde93cb3efe96d60108ffbfe2727e4e76fdf4c9dc",
-      "size": 64
-    }
-  ],
-  "annotations": {
-    "demo": "true",
-    "format": "oci"
-  }
-}
+Name:        localhost:5000/artifact:demo
+MediaType:   application/vnd.oci.image.manifest.v1+json
+Digest:      sha256:36484d44383fc9ffd34be11da4a617a96cb06b912c98114bfdb6ad2dddd443e2
+Annotations: 
+  demo:      true
+  format:    oci
+Total Size:  64B
+             
+Config:      
+  Digest:    sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
+  MediaType: application/vnd.unknown.config.v1+json
+  Size:      2B
+             
+Layers:      
+             
+  Digest:    sha256:7f8028bb058b780630dcd31cde93cb3efe96d60108ffbfe2727e4e76fdf4c9dc
+  MediaType: application/octet-stream
+  Size:      64B
 
 $ regctl artifact get localhost:5000/artifact:demo
 Test artifact from regctl.

--- a/types/manifest/manifest_test.go
+++ b/types/manifest/manifest_test.go
@@ -368,9 +368,6 @@ func TestNew(t *testing.T) {
 			name: "Docker Schema 2 Manifest",
 			opts: []Opts{
 				WithRef(r),
-				WithDesc(types.Descriptor{
-					MediaType: types.MediaTypeDocker2Manifest,
-				}),
 				WithRaw(rawDockerSchema2),
 			},
 			wantR: r,
@@ -459,9 +456,6 @@ func TestNew(t *testing.T) {
 			opts: []Opts{
 				WithRef(r),
 				WithRaw(rawDockerSchema1Signed),
-				WithDesc(types.Descriptor{
-					MediaType: types.MediaTypeDocker1ManifestSigned,
-				}),
 			},
 			wantE:     nil,
 			testAnnot: true,


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Related to #241 
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This adds `--by-digest` to artifact and manifest put commands to push using a digest instead of a tag.
The media-type is now optional on a `manifest put` since that is automatically detected from the manifest body.
The put commands also support a format option to extract content from the pushed manifest.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```
$ echo hello | regctl artifact put --by-digest localhost:5000/artifact
sha256:9cd73ae83674712678356e7e820add0b7f492014bfdfe9db454c963f6c4640ae

$ regctl artifact get localhost:5000/artifact@sha256:9cd73ae83674712678356e7e820add0b7f492014bfdfe9db454c963f6c4640ae
hello
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Allow pushing artifacts and manifest by digest.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
