### PR TITLE
Fix handling of tokens with credential helpers

### DIFF
--- a/config/credhelper_test.go
+++ b/config/credhelper_test.go
@@ -6,22 +6,61 @@ import (
 )
 
 func TestCredHelper(t *testing.T) {
-	testHost := "testhost.example.com"
-	expectUser, expectPass := "hello", "world"
+	tests := []struct {
+		name        string
+		host        string
+		credhelper  string
+		expectUser  string
+		expectPass  string
+		expectToken string
+		expectErr   bool
+	}{
+		{
+			name:       "user/pass",
+			host:       "testhost.example.com",
+			credhelper: "docker-credential-test",
+			expectUser: "hello",
+			expectPass: "world",
+		},
+		{
+			name:        "token",
+			host:        "testtoken.example.com",
+			credhelper:  "docker-credential-test",
+			expectToken: "deadbeefcafe",
+		},
+		{
+			name:       "missing helper",
+			credhelper: "./testdata/docker-credential-missing",
+			expectErr:  true,
+		},
+	}
 	curPath := os.Getenv("PATH")
 	os.Setenv("PATH", "testdata"+string(os.PathListSeparator)+curPath)
 	defer os.Setenv("PATH", curPath)
-	ch := newCredHelper("docker-credential-test", map[string]string{})
-	h := HostNewName(testHost)
-	h.CredHelper = "docker-credential-test"
-	err := ch.get(h)
-	if err != nil {
-		t.Errorf("error running get: %v", err)
-	}
-	if expectUser != h.User {
-		t.Errorf("user mismatch: expected %s, received %s", expectUser, h.User)
-	}
-	if expectPass != h.Pass {
-		t.Errorf("password mismatch: expected %s, received %s", expectPass, h.Pass)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := HostNewName(tt.host)
+			h.CredHelper = tt.credhelper
+			ch := newCredHelper(tt.credhelper, map[string]string{})
+			err := ch.get(h)
+			if tt.expectErr {
+				if err == nil {
+					t.Errorf("expected error not encountered")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("error running get: %v", err)
+			}
+			if tt.expectUser != h.User {
+				t.Errorf("user mismatch: expected %s, received %s", tt.expectUser, h.User)
+			}
+			if tt.expectPass != h.Pass {
+				t.Errorf("password mismatch: expected %s, received %s", tt.expectPass, h.Pass)
+			}
+			if tt.expectToken != h.Token {
+				t.Errorf("token mismatch: expected %s, received %s", tt.expectToken, h.Token)
+			}
+		})
 	}
 }

--- a/config/docker.go
+++ b/config/docker.go
@@ -142,7 +142,7 @@ func dockerAuthToHost(name string, conf dockerConfig, auth dockerAuthConfig) (Ho
 		TLS:        tls,
 		User:       auth.Username,
 		Pass:       auth.Password,
-		Token:      auth.IdentityToken, // TODO: verify token can be used
+		Token:      auth.IdentityToken,
 		CredHelper: helper,
 	}, nil
 }

--- a/config/host_test.go
+++ b/config/host_test.go
@@ -87,6 +87,16 @@ func TestConfig(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed to merge blank host with exHostCredHelper: %v", err)
 	}
+	exMergeHostHelper := exHost
+	err = (&exMergeHostHelper).Merge(exHostCredHelper, nil)
+	if err != nil {
+		t.Errorf("failed to merge ex host with cred helper: %v", err)
+	}
+	exMergeHelperHost := exHostCredHelper
+	err = (&exMergeHelperHost).Merge(exHost, nil)
+	if err != nil {
+		t.Errorf("failed to merge ex cred helper with host: %v", err)
+	}
 
 	// verify fields in each
 	tests := []struct {
@@ -222,6 +232,46 @@ func TestConfig(t *testing.T) {
 			credExpect: Cred{
 				User:     "hello",
 				Password: "world",
+			},
+		},
+		{
+			name: "exMergeHostHelper",
+			host: exMergeHostHelper,
+			hostExpect: Host{
+				TLS:        TLSInsecure,
+				Hostname:   "testhost.example.com",
+				CredHelper: "docker-credential-test",
+				CredExpire: timejson.Duration(time.Hour),
+				Priority:   42,
+				BlobChunk:  123456,
+				BlobMax:    999999,
+				APIOpts:    map[string]string{"disableHead": "true"},
+				PathPrefix: "hub",
+				Mirrors:    []string{"host1.example.com", "host2.example.com"},
+			},
+			credExpect: Cred{
+				User:     "hello",
+				Password: "world",
+			},
+		},
+		{
+			name: "exMergeHelperHost",
+			host: exMergeHelperHost,
+			hostExpect: Host{
+				TLS:        TLSEnabled,
+				Hostname:   "host.example.com",
+				User:       "user-ex",
+				Pass:       "secret",
+				Priority:   42,
+				BlobChunk:  123456,
+				BlobMax:    999999,
+				APIOpts:    map[string]string{"disableHead": "true"},
+				PathPrefix: "hub",
+				Mirrors:    []string{"host1.example.com", "host2.example.com"},
+			},
+			credExpect: Cred{
+				User:     "user-ex",
+				Password: "secret",
 			},
 		},
 	}

--- a/config/testdata/docker-credential-test
+++ b/config/testdata/docker-credential-test
@@ -6,12 +6,22 @@ registry_testhost='
   "Secret": "world"
 }
 '
+registry_testtoken='
+{ "ServerURL": "testtoken.example.com",
+  "Username": "<token>",
+  "Secret": "deadbeefcafe"
+}
+'
 
 if [ "$1" = "get" ]; then
   read hostname
   case "$hostname" in
     testhost.example.com)
       echo "${registry_testhost}"
+      exit 0
+      ;;
+    testtoken.example.com)
+      echo "${registry_testtoken}"
       exit 0
       ;;
   esac

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -679,9 +679,9 @@ func (b *BearerHandler) tryPost() error {
 	if b.token.RefreshToken != "" {
 		form.Set("grant_type", "refresh_token")
 		form.Set("refresh_token", b.token.RefreshToken)
-	} else if cred.Token != "" { // TODO: verify identity token works as a refresh token
+	} else if cred.Token != "" {
 		form.Set("grant_type", "refresh_token")
-		form.Set("refresh_token", b.token.RefreshToken)
+		form.Set("refresh_token", cred.Token)
 	} else if cred.User != "" && cred.Password != "" {
 		form.Set("grant_type", "password")
 		form.Set("username", cred.User)


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Credential helpers should support the `<token>` user for an identity token, and also when extracting logins from the docker config. These should be used a refresh token when requesting a bearer token.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Authentication with tokens should work. I currently don't have access to any registries that use these.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
