### PR TITLE
Fix handling of Docker Hub with credential helper

### DIFF
--- a/config/docker_test.go
+++ b/config/docker_test.go
@@ -28,22 +28,32 @@ func TestDocker(t *testing.T) {
 		hostMap[h.Name] = &h
 	}
 	tests := []struct {
-		name       string
-		hostname   string
-		expectUser string
-		expectPass string
+		name             string
+		hostname         string
+		expectUser       string
+		expectPass       string
+		expectCredHelper string
+		expectTLS        TLSConf
+		expectHostname   string
 	}{
 		{
-			name:       "testhost",
-			hostname:   "testhost.example.com",
-			expectUser: "hello",
-			expectPass: "world",
+			name:             "testhost",
+			hostname:         "testhost.example.com",
+			expectCredHelper: "docker-credential-test",
+			expectHostname:   "testhost.example.com",
 		},
 		{
-			name:       "localhost:5001",
-			hostname:   "localhost:5001",
-			expectUser: "hello",
-			expectPass: "docker",
+			name:           "localhost:5001",
+			hostname:       "localhost:5001",
+			expectUser:     "hello",
+			expectPass:     "docker",
+			expectHostname: "localhost:5001",
+		},
+		{
+			name:             "docker.io",
+			hostname:         DockerRegistry,
+			expectCredHelper: "docker-credential-hub",
+			expectHostname:   DockerRegistryDNS,
 		},
 	}
 	for _, tt := range tests {
@@ -53,12 +63,14 @@ func TestDocker(t *testing.T) {
 				t.Errorf("host not found: %s", tt.hostname)
 				return
 			}
-			cred := h.GetCred()
-			if tt.expectUser != cred.User {
-				t.Errorf("user mismatch, expect %s, received %s", tt.expectUser, cred.User)
+			if tt.expectUser != h.User {
+				t.Errorf("user mismatch, expect %s, received %s", tt.expectUser, h.User)
 			}
-			if tt.expectPass != cred.Password {
-				t.Errorf("user mismatch, expect %s, received %s", tt.expectPass, cred.Password)
+			if tt.expectPass != h.Pass {
+				t.Errorf("pass mismatch, expect %s, received %s", tt.expectPass, h.Pass)
+			}
+			if tt.expectCredHelper != h.CredHelper {
+				t.Errorf("credh helper mismatch, expect %s, received %s", tt.expectCredHelper, h.CredHelper)
 			}
 		})
 	}

--- a/config/testdata/docker-config.json
+++ b/config/testdata/docker-config.json
@@ -8,6 +8,7 @@
     }
   },
   "credHelpers": {
-    "testhost.example.com": "test"
+    "testhost.example.com": "test",
+    "https://index.docker.io/v1/": "hub"
   }
 }


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Fixes #245 
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Loading of credential helpers did not account for names with schema's (https/http) and the Docker Hub `https://index.docker.io/v1/` entry. This normalizes the name to parse it the same in both the `auths` and `credHelpers` section of `~/.docker/config.json` file.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Use a `~/.docker/config.json` with a credential helper, e.g.:

```jsonc
cat ~/.docker/config.json
{
  "credHelpers": {
    "https://index.docker.io/v1/": "docker-hub"
  }
}
```

<!-- Include steps that can be taken to verify the change -->

### Changelog text

Fix: credential helper for Docker Hub
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
