### PR TITLE
Normalize host definition and fix cred helper

### DIFF
--- a/cmd/regctl/config.go
+++ b/cmd/regctl/config.go
@@ -30,15 +30,6 @@ type Config struct {
 	IncDockerCert *bool                   `json:"incDockerCert,omitempty"`
 }
 
-// ConfigHostNew creates a default Host entry
-func ConfigHostNew() *config.Host {
-	h := config.Host{
-		TLS:     config.TLSEnabled,
-		APIOpts: map[string]string{},
-	}
-	return &h
-}
-
 // ConfigNew creates an empty configuration
 func ConfigNew() *Config {
 	c := Config{
@@ -73,12 +64,17 @@ func ConfigLoadConfFile(cf *conffile.File) (*Config, error) {
 		if c.Hosts[h].TLS == config.TLSUndefined {
 			c.Hosts[h].TLS = config.TLSEnabled
 		}
-		if h == config.DockerRegistryDNS || h == config.DockerRegistry {
+		if h == config.DockerRegistryDNS || h == config.DockerRegistry || h == config.DockerRegistryAuth {
+			// Docker Hub
 			c.Hosts[h].Name = config.DockerRegistry
 			if c.Hosts[h].Hostname == h {
 				c.Hosts[h].Hostname = config.DockerRegistryDNS
 			}
+			if c.Hosts[h].CredHost == h {
+				c.Hosts[h].CredHost = config.DockerRegistryAuth
+			}
 		}
+		// ensure key matches Name
 		if c.Hosts[h].Name != h {
 			c.Hosts[c.Hosts[h].Name] = c.Hosts[h]
 			delete(c.Hosts, h)

--- a/config/credhelper.go
+++ b/config/credhelper.go
@@ -40,7 +40,11 @@ type credStore struct {
 }
 
 func (ch *credHelper) get(host *Host) error {
-	hostIn := strings.NewReader(host.Hostname)
+	hostname := host.Hostname
+	if host.CredHost != "" {
+		hostname = host.CredHost
+	}
+	hostIn := strings.NewReader(hostname)
 	credOut := credStore{
 		Username: host.User,
 		Secret:   host.Pass,

--- a/config/credhelper_test.go
+++ b/config/credhelper_test.go
@@ -9,7 +9,8 @@ func TestCredHelper(t *testing.T) {
 	tests := []struct {
 		name        string
 		host        string
-		credhelper  string
+		credHelper  string
+		credHost    string
 		expectUser  string
 		expectPass  string
 		expectToken string
@@ -18,19 +19,35 @@ func TestCredHelper(t *testing.T) {
 		{
 			name:       "user/pass",
 			host:       "testhost.example.com",
-			credhelper: "docker-credential-test",
+			credHelper: "docker-credential-test",
 			expectUser: "hello",
 			expectPass: "world",
 		},
 		{
 			name:        "token",
 			host:        "testtoken.example.com",
-			credhelper:  "docker-credential-test",
+			credHelper:  "docker-credential-test",
 			expectToken: "deadbeefcafe",
 		},
 		{
+			name:       DockerRegistry,
+			host:       DockerRegistryDNS,
+			credHost:   DockerRegistryAuth,
+			credHelper: "docker-credential-test",
+			expectUser: "hubuser",
+			expectPass: "password123",
+		},
+		{
+			name:       "http.example.com",
+			host:       "http.example.com",
+			credHost:   "http://http.example.com/",
+			credHelper: "docker-credential-test",
+			expectUser: "hello",
+			expectPass: "universe",
+		},
+		{
 			name:       "missing helper",
-			credhelper: "./testdata/docker-credential-missing",
+			credHelper: "./testdata/docker-credential-missing",
 			expectErr:  true,
 		},
 	}
@@ -40,8 +57,9 @@ func TestCredHelper(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			h := HostNewName(tt.host)
-			h.CredHelper = tt.credhelper
-			ch := newCredHelper(tt.credhelper, map[string]string{})
+			h.CredHelper = tt.credHelper
+			h.CredHost = tt.credHost
+			ch := newCredHelper(tt.credHelper, map[string]string{})
 			err := ch.get(h)
 			if tt.expectErr {
 				if err == nil {

--- a/config/docker.go
+++ b/config/docker.go
@@ -84,12 +84,12 @@ func dockerParse(cf *conffile.File) ([]Host, error) {
 	}
 	// also include default entries for credential helpers
 	for name, helper := range dc.CredentialHelpers {
-		h := dockerNameNormalize(name)
+		h := HostNewName(name)
 		h.CredHelper = dockerHelperPre + helper
 		if _, ok := dc.AuthConfigs[h.Name]; ok {
 			continue // skip fields with auth config
 		}
-		hosts = append(hosts, h)
+		hosts = append(hosts, *h)
 	}
 	return hosts, nil
 }
@@ -113,34 +113,12 @@ func dockerAuthToHost(name string, conf dockerConfig, auth dockerAuthConfig) (Ho
 		return Host{}, fmt.Errorf("no credentials found for %s", name)
 	}
 
-	h := dockerNameNormalize(name)
+	h := HostNewName(name)
 	h.User = auth.Username
 	h.Pass = auth.Password
 	h.Token = auth.IdentityToken
 	h.CredHelper = helper
-	return h, nil
-}
-
-func dockerNameNormalize(name string) Host {
-	h := HostNewName(name)
-	// Docker Hub is a special case
-	if name == DockerRegistryAuth {
-		h.Name = DockerRegistry
-		h.Hostname = DockerRegistryDNS
-		return *h
-	}
-	// handle http/https prefix
-	i := strings.Index(name, "://")
-	if i > 0 {
-		scheme := name[:i]
-		name = name[i+3:]
-		if scheme == "http" {
-			h.TLS = TLSDisabled
-		}
-	}
-	h.Name = name
-	h.Hostname = name
-	return *h
+	return *h, nil
 }
 
 func decodeAuth(authStr string) (string, string, error) {

--- a/config/docker_test.go
+++ b/config/docker_test.go
@@ -35,12 +35,14 @@ func TestDocker(t *testing.T) {
 		expectCredHelper string
 		expectTLS        TLSConf
 		expectHostname   string
+		expectCredHost   string
 	}{
 		{
 			name:             "testhost",
 			hostname:         "testhost.example.com",
 			expectCredHelper: "docker-credential-test",
 			expectHostname:   "testhost.example.com",
+			expectTLS:        TLSEnabled,
 		},
 		{
 			name:           "localhost:5001",
@@ -48,12 +50,23 @@ func TestDocker(t *testing.T) {
 			expectUser:     "hello",
 			expectPass:     "docker",
 			expectHostname: "localhost:5001",
+			expectTLS:      TLSEnabled,
 		},
 		{
 			name:             "docker.io",
 			hostname:         DockerRegistry,
-			expectCredHelper: "docker-credential-hub",
+			expectCredHelper: "docker-credential-test",
 			expectHostname:   DockerRegistryDNS,
+			expectTLS:        TLSEnabled,
+			expectCredHost:   DockerRegistryAuth,
+		},
+		{
+			name:             "http.example.com",
+			hostname:         "http.example.com",
+			expectCredHelper: "docker-credential-test",
+			expectHostname:   "http.example.com",
+			expectTLS:        TLSDisabled,
+			expectCredHost:   "http://http.example.com/",
 		},
 	}
 	for _, tt := range tests {
@@ -69,8 +82,16 @@ func TestDocker(t *testing.T) {
 			if tt.expectPass != h.Pass {
 				t.Errorf("pass mismatch, expect %s, received %s", tt.expectPass, h.Pass)
 			}
+			if tt.expectTLS != h.TLS {
+				eTLS, _ := tt.expectTLS.MarshalText()
+				hTLS, _ := h.TLS.MarshalText()
+				t.Errorf("tls mismatch, expect %s, received %s", eTLS, hTLS)
+			}
 			if tt.expectCredHelper != h.CredHelper {
-				t.Errorf("credh helper mismatch, expect %s, received %s", tt.expectCredHelper, h.CredHelper)
+				t.Errorf("cred helper mismatch, expect %s, received %s", tt.expectCredHelper, h.CredHelper)
+			}
+			if tt.expectCredHost != h.CredHost {
+				t.Errorf("cred host mismatch, expect %s, received %s", tt.expectCredHost, h.CredHost)
 			}
 		})
 	}

--- a/config/testdata/docker-config.json
+++ b/config/testdata/docker-config.json
@@ -9,6 +9,7 @@
   },
   "credHelpers": {
     "testhost.example.com": "test",
-    "https://index.docker.io/v1/": "hub"
+    "https://index.docker.io/v1/": "test",
+    "http://http.example.com/": "test"
   }
 }

--- a/config/testdata/docker-credential-test
+++ b/config/testdata/docker-credential-test
@@ -1,5 +1,17 @@
 #!/bin/sh
 
+registry_hub='
+{ "ServerURL": "https://index.docker.io/v1/",
+  "Username": "hubuser",
+  "Secret": "password123"
+}
+'
+registry_http='
+{ "ServerURL": "http://http.example.com/",
+  "Username": "hello",
+  "Secret": "universe"
+}
+'
 registry_testhost='
 { "ServerURL": "testhost.example.com",
   "Username": "hello",
@@ -16,6 +28,14 @@ registry_testtoken='
 if [ "$1" = "get" ]; then
   read hostname
   case "$hostname" in
+    https://index.docker.io/v1/)
+      echo "${registry_hub}"
+      exit 0
+      ;;
+    http://http.example.com/)
+      echo "${registry_http}"
+      exit 0
+      ;;
     testhost.example.com)
       echo "${registry_testhost}"
       exit 0

--- a/regclient.go
+++ b/regclient.go
@@ -78,11 +78,7 @@ func New(opts ...Opt) *RegClient {
 	}
 
 	// inject Docker Hub settings
-	rc.hostSet(config.Host{
-		Name:     DockerRegistry,
-		TLS:      config.TLSEnabled,
-		Hostname: DockerRegistryDNS,
-	})
+	rc.hostSet(*config.HostNewName(config.DockerRegistryAuth))
 
 	for _, opt := range opts {
 		opt(&rc)


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Addresses #245 
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Host entries are now parsed through the same method regardless of how they are loaded. And cred helpers should now be called with the original hostname, not the normalized name that strips off schemes and repositories.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

A credential helper for docker hub defined in `~/.docker/config.json` should work.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Normalize parsing of registry names in various components.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
