### PR TITLE
Track tags used by refers

### DIFF
--- a/types/referrer/referrer.go
+++ b/types/referrer/referrer.go
@@ -13,10 +13,11 @@ import (
 )
 
 type ReferrerList struct {
-	Ref         ref.Ref            `json:"ref"`
-	Descriptors []types.Descriptor `json:"descriptors"`
-	Annotations map[string]string  `json:"annotations,omitempty"`
-	Manifest    manifest.Manifest  `json:"-"`
+	Ref         ref.Ref            `json:"ref"`                   // reference queried
+	Descriptors []types.Descriptor `json:"descriptors"`           // descriptors found in Index
+	Annotations map[string]string  `json:"annotations,omitempty"` // annotations extracted from Index
+	Manifest    manifest.Manifest  `json:"-"`                     // returned OCI Index
+	Tags        []string           `json:"-"`                     // tags matched when fetching referrers
 }
 
 // MarshalPretty is used for printPretty template formatting


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Make the referrers listing more strict based on manifest media types and the tag regex. Also include the matching tags in the returned referrer list so a recursive image copy with digest tags can copy the tags not included as a referrer.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Copying an image with both a reference and a signature should work without modifying the signature tag and without duplicating manifest copies.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Exclude tags from referrers when copying digest tags.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
