### PR TITLE
Move TLS logic to handle auth requests

### DIFF
--- a/internal/reghttp/http.go
+++ b/internal/reghttp/http.go
@@ -403,35 +403,6 @@ func (resp *clientResp) Next() error {
 			if h.httpClient != nil {
 				// if we have previously setup a http client for this host, reuse it
 				httpClient = *h.httpClient
-			} else if h.config.TLS == config.TLSInsecure || len(c.rootCAPool) > 0 || len(c.rootCADirs) > 0 || h.config.RegCert != "" {
-				if httpClient.Transport == nil {
-					httpClient.Transport = http.DefaultTransport.(*http.Transport).Clone()
-				}
-				t, ok := httpClient.Transport.(*http.Transport)
-				if ok {
-					var tlsc *tls.Config
-					if t.TLSClientConfig != nil {
-						tlsc = t.TLSClientConfig.Clone()
-					} else {
-						tlsc = &tls.Config{}
-					}
-					if h.config.TLS == config.TLSInsecure {
-						tlsc.InsecureSkipVerify = true
-					} else {
-						rootPool, err := makeRootPool(c.rootCAPool, c.rootCADirs, h.config.Hostname, h.config.RegCert)
-						if err != nil {
-							c.log.WithFields(logrus.Fields{
-								"err": err,
-							}).Warn("failed to setup CA pool")
-						} else {
-							tlsc.RootCAs = rootPool
-						}
-					}
-					t.TLSClientConfig = tlsc
-					httpClient.Transport = t
-				}
-				// cache the resulting client
-				h.httpClient = &httpClient
 			}
 
 			// send request
@@ -657,11 +628,48 @@ func (c *Client) getHost(host string) *clientHost {
 	if h.auth == nil {
 		h.auth = map[string]auth.Auth{}
 	}
+
+	// update http client for insecure requests and root certs
+	httpClient := *c.httpClient
+	if h.httpClient != nil {
+		// if we have previously setup a http client for this host, reuse it
+		httpClient = *h.httpClient
+	} else if h.config.TLS == config.TLSInsecure || len(c.rootCAPool) > 0 || len(c.rootCADirs) > 0 || h.config.RegCert != "" {
+		if httpClient.Transport == nil {
+			httpClient.Transport = http.DefaultTransport.(*http.Transport).Clone()
+		}
+		t, ok := httpClient.Transport.(*http.Transport)
+		if ok {
+			var tlsc *tls.Config
+			if t.TLSClientConfig != nil {
+				tlsc = t.TLSClientConfig.Clone()
+			} else {
+				tlsc = &tls.Config{}
+			}
+			if h.config.TLS == config.TLSInsecure {
+				tlsc.InsecureSkipVerify = true
+			} else {
+				rootPool, err := makeRootPool(c.rootCAPool, c.rootCADirs, h.config.Hostname, h.config.RegCert)
+				if err != nil {
+					c.log.WithFields(logrus.Fields{
+						"err": err,
+					}).Warn("failed to setup CA pool")
+				} else {
+					tlsc.RootCAs = rootPool
+				}
+			}
+			t.TLSClientConfig = tlsc
+			httpClient.Transport = t
+		}
+		// cache the resulting client
+		h.httpClient = &httpClient
+	}
+
 	if h.newAuth == nil {
 		h.newAuth = func() auth.Auth {
 			return auth.NewAuth(
 				auth.WithLog(c.log),
-				auth.WithHTTPClient(c.httpClient),
+				auth.WithHTTPClient(&httpClient),
 				auth.WithCreds(h.AuthCreds()),
 				auth.WithClientID(c.userAgent),
 			)


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Auth requests are not handled with the same TLS settings as other registry requests. (See #251)
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This moves to custom TLS logic for a host into the getHost method before the newAuth method is defined.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Access a registry with custom TLS settings and authentication required.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Fix handling of custom TLS settings on a registry with authentication
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

Unit or e2e testing with custom TLS in reghttp is still needed. This PR was verified with manual tests.
<!-- Mark the following with an [X] to verify they are included -->

- [ ] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
