### PR TITLE
regctl artifact put refer as arg

### DIFF
--- a/cmd/regctl/artifact.go
+++ b/cmd/regctl/artifact.go
@@ -76,7 +76,7 @@ var artifactPutCmd = &cobra.Command{
 	Aliases:   []string{"push"},
 	Short:     "upload artifacts",
 	Long:      `Upload artifacts to the registry.`,
-	Args:      cobra.ExactArgs(1),
+	Args:      cobra.RangeArgs(0, 1),
 	ValidArgs: []string{}, // do not auto complete repository/tag
 	RunE:      runArtifactPut,
 }
@@ -93,7 +93,7 @@ var artifactOpts struct {
 	formatPut    string
 	manifestMT   string
 	outputDir    string
-	refers       bool
+	refers       string
 	stripDirs    bool
 }
 
@@ -128,7 +128,7 @@ func init() {
 		return manifestKnownTypes, cobra.ShellCompDirectiveNoFileComp
 	})
 	// TODO: remove experimental label when stable
-	artifactPutCmd.Flags().BoolVarP(&artifactOpts.refers, "refers", "", false, "EXPERIMENTAL: Create a referrer to the reference")
+	artifactPutCmd.Flags().StringVarP(&artifactOpts.refers, "refers", "", "", "EXPERIMENTAL: Create a referrer to the reference")
 	artifactPutCmd.Flags().BoolVarP(&artifactOpts.stripDirs, "strip-dirs", "", false, "Strip directories from filenames in artifact")
 
 	artifactCmd.AddCommand(artifactGetCmd)
@@ -348,6 +348,8 @@ func runArtifactPut(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 	mOpts := []manifest.Opts{}
 	hasConfig := false
+	var r, rMan, rArt ref.Ref
+	var err error
 
 	switch artifactOpts.manifestMT {
 	case types.MediaTypeOCI1Artifact:
@@ -359,9 +361,27 @@ func runArtifactPut(cmd *cobra.Command, args []string) error {
 	}
 
 	// validate inputs
-	r, err := ref.New(args[0])
-	if err != nil {
-		return err
+	if len(args) == 0 && artifactOpts.refers == "" {
+		return fmt.Errorf("reference and both refers missing")
+	}
+	if len(args) > 0 {
+		rMan, err = ref.New(args[0])
+		if err != nil {
+			return err
+		}
+		r = rMan
+	}
+	if artifactOpts.refers != "" {
+		rArt, err = ref.New(artifactOpts.refers)
+		if err != nil {
+			return err
+		}
+		r = rArt
+	}
+	if rMan.IsZero() && rArt.IsZero() {
+		return fmt.Errorf("either a reference or refers must be provided")
+	} else if !rMan.IsZero() && !rArt.IsZero() && !ref.EqualRepository(rMan, rArt) {
+		return fmt.Errorf("reference and refers must be in the same repository")
 	}
 	if len(artifactOpts.artifactFile) == 1 && len(artifactOpts.artifactMT) == 0 {
 		// default media-type for a single file, same is used for stdin
@@ -392,8 +412,8 @@ func runArtifactPut(cmd *cobra.Command, args []string) error {
 	defer rc.Close(ctx, r)
 
 	var refDesc *types.Descriptor
-	if artifactOpts.refers {
-		rmh, err := rc.ManifestHead(ctx, r)
+	if !rArt.IsZero() {
+		rmh, err := rc.ManifestHead(ctx, rArt)
 		if err != nil {
 			return fmt.Errorf("unable to find referenced manifest: %w", err)
 		}
@@ -552,18 +572,22 @@ func runArtifactPut(cmd *cobra.Command, args []string) error {
 	}
 
 	if artifactOpts.byDigest {
-		r.Tag = ""
-		r.Digest = mm.GetDescriptor().Digest.String()
+		rMan.Tag = ""
+		rMan.Digest = mm.GetDescriptor().Digest.String()
 	}
 
 	// push manifest
-	if artifactOpts.refers {
-		err = rc.ReferrerPut(ctx, r, mm)
-	} else {
-		err = rc.ManifestPut(ctx, r, mm)
+	if !rMan.IsZero() {
+		err = rc.ManifestPut(ctx, rMan, mm)
+		if err != nil {
+			return err
+		}
 	}
-	if err != nil {
-		return err
+	if !rArt.IsZero() {
+		err = rc.ReferrerPut(ctx, rArt, mm)
+		if err != nil {
+			return err
+		}
 	}
 
 	result := struct {

--- a/types/ref/ref.go
+++ b/types/ref/ref.go
@@ -153,6 +153,14 @@ func (r Ref) CommonName() string {
 	return cn
 }
 
+// IsZero returns true if ref is unset
+func (r *Ref) IsZero() bool {
+	if r.Scheme == "" && r.Registry == "" && r.Repository == "" && r.Path == "" && r.Tag == "" && r.Digest == "" {
+		return true
+	}
+	return false
+}
+
 // EqualRegistry compares the registry between two references
 func EqualRegistry(a, b Ref) bool {
 	if a.Scheme != b.Scheme {


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

`regctl artifact put --refers ...` now takes an argument, and the reference to push is now option to support pushing a refers entry. Either a reference to push or a refers reference is required, and pushing both is also supported.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```
echo "test" | regctl artifact put --refers ${image_name}
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

This feature is still considered experimental, so there are no tests or documentation provided.
<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
