### PR TITLE
Output digest on blob put, delay GC of blobs

### DIFF
--- a/cmd/regctl/blob.go
+++ b/cmd/regctl/blob.go
@@ -44,9 +44,10 @@ is the digest of the blob.`,
 }
 
 var blobOpts struct {
-	format string
-	mt     string
-	digest string
+	format    string
+	formatPut string
+	mt        string
+	digest    string
 }
 
 func init() {
@@ -62,6 +63,7 @@ func init() {
 
 	blobPutCmd.Flags().StringVarP(&blobOpts.mt, "content-type", "", "", "Set the requested content type (deprecated)")
 	blobPutCmd.Flags().StringVarP(&blobOpts.digest, "digest", "", "", "Set the expected digest")
+	blobPutCmd.Flags().StringVarP(&blobOpts.formatPut, "format", "", "{{println .Digest}}", "Format output with go template syntax")
 	blobPutCmd.RegisterFlagCompletionFunc("content-type", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{
 			"application/octet-stream",
@@ -126,7 +128,6 @@ func runBlobPut(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	rc := newRegClient()
-	defer rc.Close(ctx, r)
 
 	if blobOpts.mt != "" {
 		log.WithFields(logrus.Fields{
@@ -152,5 +153,5 @@ func runBlobPut(cmd *cobra.Command, args []string) error {
 		Size:   dOut.Size,
 	}
 
-	return template.Writer(os.Stdout, blobOpts.format, result)
+	return template.Writer(os.Stdout, blobOpts.formatPut, result)
 }

--- a/docs/regctl.md
+++ b/docs/regctl.md
@@ -239,6 +239,11 @@ The `put` command uploads a blob to the registry.
 The digest of the blob is output.
 Note that blobs should be referenced by a manifest to avoid garbage collection.
 
+The `--format` option to `put` has the following variables available:
+
+- `.Digest`: digest of the pushed blob
+- `.Size`: size of the pushed blob
+
 ## Artifact Commands
 
 The artifact command works with OCI artifacts.


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

The format option for `regctl blob put` was not configurable and reused the `get` format. This change allows the field to be changed and defaults to showing just the digest for easier scripting.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

`echo hello | regctl blob put ocidir://test --format '{{.Digest}} with {{.Size}} bytes'`
<!-- Include steps that can be taken to verify the change -->

### Changelog text

`regctl blob put` supports a format string.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [ ] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
