### PR TITLE
Copy missing tags on regsync server start

### DIFF
--- a/cmd/regsync/root.go
+++ b/cmd/regsync/root.go
@@ -241,6 +241,27 @@ func runServer(cmd *cobra.Command, args []string) error {
 					mainErr = err
 				}
 			})
+			// immediately copy any images that are missing from target
+			if conf.Defaults.Parallel > 0 {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					err := s.process(ctx, "missing")
+					if err != nil {
+						if mainErr == nil {
+							mainErr = err
+						}
+						return
+					}
+				}()
+			} else {
+				err := s.process(ctx, "missing")
+				if err != nil {
+					if mainErr == nil {
+						mainErr = err
+					}
+				}
+			}
 		} else {
 			log.WithFields(logrus.Fields{
 				"source": s.Source,
@@ -249,6 +270,8 @@ func runServer(cmd *cobra.Command, args []string) error {
 			}).Error("No schedule or interval found, ignoring")
 		}
 	}
+	// wait for any initial copies to finish before scheduling
+	wg.Wait()
 	c.Start()
 	// wait on interrupt signal
 	sig := make(chan os.Signal, 1)
@@ -578,6 +601,7 @@ func (s ConfigSync) processRef(ctx context.Context, src, tgt ref.Ref, action str
 		return err
 	}
 	mTgt, err := rc.ManifestHead(ctx, tgt)
+	tgtExists := (err == nil)
 	tgtMatches := false
 	if err == nil && manifest.GetDigest(mSrc).String() == manifest.GetDigest(mTgt).String() {
 		tgtMatches = true
@@ -589,7 +613,13 @@ func (s ConfigSync) processRef(ctx context.Context, src, tgt ref.Ref, action str
 		}).Debug("Image matches")
 		return nil
 	}
-	tgtExists := (err == nil)
+	if tgtExists && action == "missing" {
+		log.WithFields(logrus.Fields{
+			"source": src.CommonName(),
+			"target": tgt.CommonName(),
+		}).Debug("target exists")
+		return nil
+	}
 
 	// skip when source manifest is an unsupported type
 	smt := manifest.GetMediaType(mSrc)


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

On regsync server startup, this triggers an immediate sync for any missing tags on the target. Stale tags will be updated on the next timer cycle.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Run `regsync server -v debug` with a config and check for `target exists` lines for entries where the target exists but is stale.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

regsync immediately syncs any tags missing on the target without waiting for first sync schedule
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
