### PR TITLE
Deprecating redundant methods

### DIFF
--- a/mod/mod_test.go
+++ b/mod/mod_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/opencontainers/go-digest"
 	"github.com/regclient/regclient"
 	"github.com/regclient/regclient/internal/rwfs"
+	"github.com/regclient/regclient/types/manifest"
 	"github.com/regclient/regclient/types/platform"
 	"github.com/regclient/regclient/types/ref"
 )
@@ -49,7 +50,7 @@ func TestMod(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed to parse platform: %v", err)
 	}
-	m3DescAmd, err := m3.GetPlatformDesc(&pAMD)
+	m3DescAmd, err := manifest.GetPlatformDesc(m3, &pAMD)
 	if err != nil {
 		t.Errorf("failed to get amd64 descriptor: %v", err)
 	}

--- a/scheme/ocidir/referrer.go
+++ b/scheme/ocidir/referrer.go
@@ -181,7 +181,7 @@ func (o *OCIDir) ReferrerPut(ctx context.Context, r ref.Ref, m manifest.Manifest
 	}
 	rPush := r
 	rPush.Digest = ""
-	rPush.Tag = fmt.Sprintf("%s-%s.%s", desc.Algorithm().String(), stringMax(desc.Hex(), 64), stringMax(m.GetDigest().Hex(), 16))
+	rPush.Tag = fmt.Sprintf("%s-%s.%s", desc.Algorithm().String(), stringMax(desc.Hex(), 64), stringMax(m.GetDescriptor().Digest.Hex(), 16))
 	if refType != "" {
 		rPush.Tag = fmt.Sprintf("%s.%s", rPush.Tag, stringMax(refType, 5))
 	}

--- a/scheme/reg/referrer.go
+++ b/scheme/reg/referrer.go
@@ -186,8 +186,8 @@ func (reg *Reg) referrerListExtAPI(ctx context.Context, r ref.Ref) (referrer.Ref
 	if err != nil {
 		return rl, err
 	}
-	if m.GetMediaType() != types.MediaTypeOCI1ManifestList {
-		return rl, fmt.Errorf("unexpected media type for referrers: %s, %w", m.GetMediaType(), types.ErrUnsupportedMediaType)
+	if m.GetDescriptor().MediaType != types.MediaTypeOCI1ManifestList {
+		return rl, fmt.Errorf("unexpected media type for referrers: %s, %w", m.GetDescriptor().MediaType, types.ErrUnsupportedMediaType)
 	}
 	rl.Manifest = m
 	rl.Descriptors, err = m.GetManifestList()
@@ -277,7 +277,7 @@ func (reg *Reg) ReferrerPut(ctx context.Context, r ref.Ref, m manifest.Manifest)
 			return fmt.Errorf("digest could not be parsed for %s: %w", r.CommonName(), err)
 		}
 		rPush.Digest = ""
-		rPush.Tag = fmt.Sprintf("%s-%s.%s", desc.Algorithm().String(), stringMax(desc.Hex(), 64), stringMax(m.GetDigest().Hex(), 16))
+		rPush.Tag = fmt.Sprintf("%s-%s.%s", desc.Algorithm().String(), stringMax(desc.Hex(), 64), stringMax(m.GetDescriptor().Digest.Hex(), 16))
 		if refType != "" {
 			rPush.Tag = fmt.Sprintf("%s.%s", rPush.Tag, stringMax(refType, 5))
 		}

--- a/types/blob/common.go
+++ b/types/blob/common.go
@@ -18,9 +18,12 @@ type Common interface {
 	Response() *http.Response
 	RawHeaders() http.Header
 
-	Digest() digest.Digest // TODO: deprecate
-	Length() int64         // TODO: deprecate
-	MediaType() string     // TODO: deprecate
+	// Deprecated: Digest should be replaced by GetDescriptor().Digest
+	Digest() digest.Digest
+	// Deprecated: Length should be replaced by GetDescriptor().Size
+	Length() int64
+	// Deprecated: MediaType should be replaced by GetDescriptor().MediaType
+	MediaType() string
 }
 
 type common struct {

--- a/types/manifest/manifest.go
+++ b/types/manifest/manifest.go
@@ -40,13 +40,20 @@ type Manifest interface {
 	RawHeaders() (http.Header, error)
 	SetOrig(interface{}) error
 
-	GetConfigDigest() (digest.Digest, error)                         // TODO: deprecate
-	GetDigest() digest.Digest                                        // TODO: deprecate
-	GetMediaType() string                                            // TODO: deprecate
-	GetPlatformDesc(p *platform.Platform) (*types.Descriptor, error) // TODO: deprecate
-	GetPlatformList() ([]*platform.Platform, error)                  // TODO: deprecate
-	GetRateLimit() types.RateLimit                                   // TODO: deprecate
-	HasRateLimit() bool                                              // TODO: deprecate
+	// Deprecated: GetConfigDigest should be replaced with GetConfig
+	GetConfigDigest() (digest.Digest, error)
+	// Deprecated: GetDigest should be replaced with GetDescriptor().Digest
+	GetDigest() digest.Digest
+	// Deprecated: GetMediaType should be replaced with GetDescriptor().MediaType
+	GetMediaType() string
+	// Deprecated: GetPlatformDesc method should be replaced with manifest.GetPlatformDesc function
+	GetPlatformDesc(p *platform.Platform) (*types.Descriptor, error)
+	// Deprecated: GetPlatformList method should be replaced with manifest.GetPlatformList function
+	GetPlatformList() ([]*platform.Platform, error)
+	// Deprecated: GetRateLimit method should be replaced with manifest.GetRateLimit function
+	GetRateLimit() types.RateLimit
+	// Deprecated: HasRateLimit method should be replaced with manifest.HasRateLimit function
+	HasRateLimit() bool
 }
 
 type Annotator interface {


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Several manifest methods are redundant and can be removed.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Tools like staticcheck will report usage of deprecated methods.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Redundant manifest methods have been deprecated
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
