### PR TITLE
Separate manifest interfaces and add set methods

### DIFF
--- a/cmd/regbot/sandbox/image.go
+++ b/cmd/regbot/sandbox/image.go
@@ -84,7 +84,11 @@ func (s *Sandbox) configGet(ls *lua.LState) int {
 		"script": s.name,
 		"image":  m.r.CommonName(),
 	}).Debug("Retrieve image config")
-	confDesc, err := m.m.GetConfig()
+	mi, ok := m.m.(manifest.Imager)
+	if !ok {
+		ls.RaiseError("Image methods are not available for manifest")
+	}
+	confDesc, err := mi.GetConfig()
 	if err != nil {
 		ls.RaiseError("Failed looking up \"%s\" config digest: %v", m.r.CommonName(), err)
 	}

--- a/cmd/regctl/artifact.go
+++ b/cmd/regctl/artifact.go
@@ -163,10 +163,14 @@ func runArtifactGet(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	mi, ok := mm.(manifest.Imager)
+	if !ok {
+		return fmt.Errorf("manifest does not support image methods%.0w", types.ErrUnsupportedMediaType)
+	}
 
 	// if config-file defined, create file as writer, perform a blob get
 	if artifactOpts.configFile != "" {
-		d, err := mm.GetConfig()
+		d, err := mi.GetConfig()
 		if err != nil {
 			return err
 		}
@@ -184,7 +188,7 @@ func runArtifactGet(cmd *cobra.Command, args []string) error {
 	}
 
 	// get list of layers
-	layers, err := mm.GetLayers()
+	layers, err := mi.GetLayers()
 	if err != nil {
 		return err
 	}

--- a/cmd/regctl/image.go
+++ b/cmd/regctl/image.go
@@ -13,6 +13,7 @@ import (
 	"github.com/regclient/regclient"
 	"github.com/regclient/regclient/mod"
 	"github.com/regclient/regclient/pkg/template"
+	"github.com/regclient/regclient/types"
 	"github.com/regclient/regclient/types/manifest"
 	"github.com/regclient/regclient/types/ref"
 	"github.com/sirupsen/logrus"
@@ -522,7 +523,11 @@ func runImageInspect(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	cd, err := m.GetConfig()
+	mi, ok := m.(manifest.Imager)
+	if !ok {
+		return fmt.Errorf("manifest does not support image methods%.0w", types.ErrUnsupportedMediaType)
+	}
+	cd, err := mi.GetConfig()
 	if err != nil {
 		return err
 	}

--- a/scheme/ocidir/blob_test.go
+++ b/scheme/ocidir/blob_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/regclient/regclient/internal/rwfs"
 	"github.com/regclient/regclient/types"
+	"github.com/regclient/regclient/types/manifest"
 	"github.com/regclient/regclient/types/ref"
 )
 
@@ -33,7 +34,12 @@ func TestBlob(t *testing.T) {
 		t.Errorf("expected manifest list")
 		return
 	}
-	dl, err := ml.GetManifestList()
+	mli, ok := ml.(manifest.Indexer)
+	if !ok {
+		t.Errorf("manifest doesn't support index methods")
+		return
+	}
+	dl, err := mli.GetManifestList()
 	if err != nil || len(dl) < 1 {
 		t.Errorf("descriptor list (%d): %v", len(dl), err)
 		return
@@ -49,7 +55,12 @@ func TestBlob(t *testing.T) {
 		t.Errorf("manifest get: %v", err)
 		return
 	}
-	cd, err := m.GetConfig()
+	mi, ok := m.(manifest.Imager)
+	if !ok {
+		t.Errorf("manifest doesn't support image methods")
+		return
+	}
+	cd, err := mi.GetConfig()
 	if err != nil {
 		t.Errorf("config digest: %v", err)
 		return

--- a/scheme/ocidir/close.go
+++ b/scheme/ocidir/close.go
@@ -74,9 +74,9 @@ func (o *OCIDir) Close(ctx context.Context, r ref.Ref) error {
 }
 
 func (o *OCIDir) closeProcManifest(ctx context.Context, r ref.Ref, m manifest.Manifest, dl *map[string]bool) error {
-	if m.IsList() {
+	if mi, ok := m.(manifest.Indexer); ok {
 		// go through manifest list, updating dl, and recursively processing nested manifests
-		ml, err := m.GetManifestList()
+		ml, err := mi.GetManifestList()
 		if err != nil {
 			return err
 		}
@@ -99,14 +99,15 @@ func (o *OCIDir) closeProcManifest(ctx context.Context, r ref.Ref, m manifest.Ma
 				return err
 			}
 		}
-	} else {
+	}
+	if mi, ok := m.(manifest.Imager); ok {
 		// get config from manifest if it exists
-		cd, err := m.GetConfig()
+		cd, err := mi.GetConfig()
 		if err == nil {
 			(*dl)[cd.Digest.String()] = true
 		}
 		// finally add all layers to digest list
-		layers, err := m.GetLayers()
+		layers, err := mi.GetLayers()
 		if err != nil {
 			return err
 		}

--- a/scheme/ocidir/manifest_test.go
+++ b/scheme/ocidir/manifest_test.go
@@ -50,7 +50,12 @@ func TestManifest(t *testing.T) {
 	if !ml.IsList() {
 		t.Errorf("expected manifest list")
 	}
-	dl, err := ml.GetManifestList()
+	mli, ok := ml.(manifest.Indexer)
+	if !ok {
+		t.Errorf("manifest doesn't support index methods")
+		return
+	}
+	dl, err := mli.GetManifestList()
 	if err != nil || len(dl) < 1 {
 		t.Errorf("descriptor list (%d): %v", len(dl), err)
 	}
@@ -77,7 +82,12 @@ func TestManifest(t *testing.T) {
 		t.Errorf("manifest get: %v", err)
 		return
 	}
-	_, err = m.GetConfig()
+	mi, ok := m.(manifest.Imager)
+	if !ok {
+		t.Errorf("manifest doesn't support image methods")
+		return
+	}
+	_, err = mi.GetConfig()
 	if err != nil {
 		t.Errorf("config: %v", err)
 	}

--- a/scheme/reg/referrer.go
+++ b/scheme/reg/referrer.go
@@ -189,8 +189,12 @@ func (reg *Reg) referrerListExtAPI(ctx context.Context, r ref.Ref) (referrer.Ref
 	if m.GetDescriptor().MediaType != types.MediaTypeOCI1ManifestList {
 		return rl, fmt.Errorf("unexpected media type for referrers: %s, %w", m.GetDescriptor().MediaType, types.ErrUnsupportedMediaType)
 	}
+	mi, ok := m.(manifest.Indexer)
+	if !ok {
+		return rl, fmt.Errorf("manifest doesn't support index methods: %w", types.ErrUnsupportedMediaType)
+	}
 	rl.Manifest = m
-	rl.Descriptors, err = m.GetManifestList()
+	rl.Descriptors, err = mi.GetManifestList()
 	if err != nil {
 		return rl, err
 	}

--- a/types/docker/schema2/manifestlist.go
+++ b/types/docker/schema2/manifestlist.go
@@ -15,7 +15,7 @@ var ManifestListSchemaVersion = docker.Versioned{
 type ManifestList struct {
 	docker.Versioned
 
-	// Config references the image configuration as a blob.
+	// Manifests lists descriptors in the manifest list
 	Manifests []types.Descriptor `json:"manifests"`
 
 	// Annotations contains arbitrary metadata for the image index.

--- a/types/manifest/docker1.go
+++ b/types/manifest/docker1.go
@@ -125,6 +125,22 @@ func (m *docker1SignedManifest) MarshalPretty() ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
+func (m *docker1Manifest) SetConfig(d types.Descriptor) error {
+	return wraperr.New(fmt.Errorf("set methods not supported for for media type %s", m.desc.MediaType), types.ErrUnsupportedMediaType)
+}
+
+func (m *docker1SignedManifest) SetConfig(d types.Descriptor) error {
+	return wraperr.New(fmt.Errorf("set methods not supported for for media type %s", m.desc.MediaType), types.ErrUnsupportedMediaType)
+}
+
+func (m *docker1Manifest) SetLayers(dl []types.Descriptor) error {
+	return wraperr.New(fmt.Errorf("set methods not supported for for media type %s", m.desc.MediaType), types.ErrUnsupportedMediaType)
+}
+
+func (m *docker1SignedManifest) SetLayers(dl []types.Descriptor) error {
+	return wraperr.New(fmt.Errorf("set methods not supported for for media type %s", m.desc.MediaType), types.ErrUnsupportedMediaType)
+}
+
 func (m *docker1Manifest) SetOrig(origIn interface{}) error {
 	orig, ok := origIn.(schema1.Manifest)
 	if !ok {

--- a/types/manifest/docker2.go
+++ b/types/manifest/docker2.go
@@ -245,6 +245,30 @@ func (m *docker2ManifestList) SetAnnotation(key, val string) error {
 	return m.updateDesc()
 }
 
+func (m *docker2Manifest) SetConfig(d types.Descriptor) error {
+	if !m.manifSet {
+		return fmt.Errorf("manifest is not set")
+	}
+	m.Config = d
+	return m.updateDesc()
+}
+
+func (m *docker2Manifest) SetLayers(dl []types.Descriptor) error {
+	if !m.manifSet {
+		return fmt.Errorf("manifest is not set")
+	}
+	m.Layers = dl
+	return m.updateDesc()
+}
+
+func (m *docker2ManifestList) SetManifestList(dl []types.Descriptor) error {
+	if !m.manifSet {
+		return fmt.Errorf("manifest is not set")
+	}
+	m.Manifests = dl
+	return m.updateDesc()
+}
+
 func (m *docker2Manifest) SetOrig(origIn interface{}) error {
 	orig, ok := origIn.(schema2.Manifest)
 	if !ok {

--- a/types/manifest/manifest.go
+++ b/types/manifest/manifest.go
@@ -27,10 +27,7 @@ import (
 // Manifest interface is implemented by all supported manifests but
 // many calls are only supported by certain underlying media types.
 type Manifest interface {
-	GetConfig() (types.Descriptor, error)
 	GetDescriptor() types.Descriptor
-	GetLayers() ([]types.Descriptor, error)
-	GetManifestList() ([]types.Descriptor, error)
 	GetOrig() interface{}
 	GetRef() ref.Ref
 	IsList() bool
@@ -39,6 +36,14 @@ type Manifest interface {
 	RawBody() ([]byte, error)
 	RawHeaders() (http.Header, error)
 	SetOrig(interface{}) error
+
+	// Deprecated: GetConfig should be accessed using Imager interface
+	GetConfig() (types.Descriptor, error)
+	// Deprecated: GetLayers should be accessed using Imager interface
+	GetLayers() ([]types.Descriptor, error)
+
+	// Deprecated: GetManifestList should be accessed using Indexer interface
+	GetManifestList() ([]types.Descriptor, error)
 
 	// Deprecated: GetConfigDigest should be replaced with GetConfig
 	GetConfigDigest() (digest.Digest, error)
@@ -61,9 +66,21 @@ type Annotator interface {
 	SetAnnotation(key, val string) error
 }
 
+type Indexer interface {
+	GetManifestList() ([]types.Descriptor, error)
+	SetManifestList(dl []types.Descriptor) error
+}
+
+type Imager interface {
+	GetConfig() (types.Descriptor, error)
+	GetLayers() ([]types.Descriptor, error)
+	SetConfig(d types.Descriptor) error
+	SetLayers(dl []types.Descriptor) error
+}
+
 type Referrer interface {
 	GetRefers() (*types.Descriptor, error)
-	SetRefers(*types.Descriptor) error
+	SetRefers(d *types.Descriptor) error
 }
 
 type manifestConfig struct {

--- a/types/manifest/oci1.go
+++ b/types/manifest/oci1.go
@@ -355,6 +355,42 @@ func (m *oci1Artifact) SetAnnotation(key, val string) error {
 	return m.updateDesc()
 }
 
+func (m *oci1Artifact) SetConfig(d types.Descriptor) error {
+	return wraperr.New(fmt.Errorf("set config not available for media type %s", m.desc.MediaType), types.ErrUnsupportedMediaType)
+}
+
+func (m *oci1Manifest) SetConfig(d types.Descriptor) error {
+	if !m.manifSet {
+		return fmt.Errorf("manifest is not set")
+	}
+	m.Config = d
+	return m.updateDesc()
+}
+
+func (m *oci1Artifact) SetLayers(dl []types.Descriptor) error {
+	if !m.manifSet {
+		return fmt.Errorf("manifest is not set")
+	}
+	m.Blobs = dl
+	return m.updateDesc()
+}
+
+func (m *oci1Manifest) SetLayers(dl []types.Descriptor) error {
+	if !m.manifSet {
+		return fmt.Errorf("manifest is not set")
+	}
+	m.Layers = dl
+	return m.updateDesc()
+}
+
+func (m *oci1Index) SetManifestList(dl []types.Descriptor) error {
+	if !m.manifSet {
+		return fmt.Errorf("manifest is not set")
+	}
+	m.Manifests = dl
+	return m.updateDesc()
+}
+
 func (m *oci1Manifest) SetOrig(origIn interface{}) error {
 	orig, ok := origIn.(v1.Manifest)
 	if !ok {


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This splits out Image and Index/ManifestList specific methods into separate interfaces. Set methods were also added for updating the config, layers, and manifests descriptors.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Old manifest methods will now be flagged as deprecated by staticcheck. Usage of the new `Set*` methods will be added in future PRs.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Manifest methods specific to Images and Indexes/ManifestLists have a different interface.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
