### PR TITLE
Add regctl index to create/mutate manifest lists

### DIFF
--- a/cmd/regctl/index.go
+++ b/cmd/regctl/index.go
@@ -1,0 +1,436 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/regclient/regclient"
+	"github.com/regclient/regclient/pkg/template"
+	"github.com/regclient/regclient/types"
+	"github.com/regclient/regclient/types/docker/schema2"
+	"github.com/regclient/regclient/types/manifest"
+	v1 "github.com/regclient/regclient/types/oci/v1"
+	"github.com/regclient/regclient/types/platform"
+	"github.com/regclient/regclient/types/ref"
+	"github.com/spf13/cobra"
+)
+
+var indexKnownTypes = []string{
+	types.MediaTypeOCI1ManifestList,
+	types.MediaTypeDocker2ManifestList,
+}
+
+var indexCmd = &cobra.Command{
+	Use:   "index <cmd>",
+	Short: "manage manifest lists and OCI index",
+}
+
+var indexAddCmd = &cobra.Command{
+	Use:       "add <image_ref>",
+	Aliases:   []string{"append", "insert"},
+	Short:     "add an index entry",
+	Long:      `Add an entry to a manifest list or OCI Index.`,
+	Args:      cobra.ExactArgs(1),
+	ValidArgs: []string{}, // do not auto complete digests
+	RunE:      runIndexAdd,
+}
+
+var indexCreateCmd = &cobra.Command{
+	Use:       "create <image_ref>",
+	Aliases:   []string{"init", "new"},
+	Short:     "create an index",
+	Long:      `Create a manifest list or OCI Index.`,
+	Args:      cobra.ExactArgs(1),
+	ValidArgs: []string{}, // do not auto complete digests
+	RunE:      runIndexCreate,
+}
+
+var indexDeleteCmd = &cobra.Command{
+	Use:       "delete <image_ref>",
+	Aliases:   []string{"del", "rm", "remove"},
+	Short:     "delete an index entry",
+	Long:      `Delete an entry from a manifest list or OCI Index.`,
+	Args:      cobra.ExactArgs(1),
+	ValidArgs: []string{}, // do not auto complete digests
+	RunE:      runIndexDelete,
+}
+
+var indexOpts struct {
+	annotations     []string
+	byDigest        bool
+	descAnnotations []string
+	digests         []string
+	format          string
+	mediaType       string
+	platforms       []string
+	refs            []string
+}
+
+func init() {
+	indexAddCmd.Flags().StringArrayVarP(&indexOpts.descAnnotations, "desc-annotation", "", []string{}, "Annotation to add to descriptors of new entries")
+	indexAddCmd.Flags().StringArrayVarP(&indexOpts.digests, "digest", "", []string{}, "Digest to add")
+	indexAddCmd.Flags().StringArrayVarP(&indexOpts.refs, "ref", "", []string{}, "References to add")
+
+	indexCreateCmd.Flags().StringArrayVarP(&indexOpts.annotations, "annotation", "", []string{}, "Annotation to set on manifest")
+	indexCreateCmd.Flags().BoolVarP(&indexOpts.byDigest, "by-digest", "", false, "Push manifest by digest instead of tag")
+	indexCreateCmd.Flags().StringArrayVarP(&indexOpts.descAnnotations, "desc-annotation", "", []string{}, "Annotation to add to descriptors of new entries")
+	indexCreateCmd.Flags().StringArrayVarP(&indexOpts.digests, "digest", "", []string{}, "Digest to include in new index")
+	indexCreateCmd.Flags().StringVarP(&indexOpts.format, "format", "", "", "Format output with go template syntax")
+	indexCreateCmd.Flags().StringVarP(&indexOpts.mediaType, "media-type", "m", types.MediaTypeOCI1ManifestList, "Media-type for manifest list or OCI Index")
+	indexCreateCmd.Flags().StringArrayVarP(&indexOpts.refs, "ref", "", []string{}, "References to include in new index")
+	indexCreateCmd.RegisterFlagCompletionFunc("media-type", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return indexKnownTypes, cobra.ShellCompDirectiveNoFileComp
+	})
+
+	indexDeleteCmd.Flags().StringArrayVarP(&indexOpts.digests, "digest", "", []string{}, "Digest to delete")
+	indexDeleteCmd.Flags().StringArrayVarP(&indexOpts.platforms, "platform", "", []string{}, "Platform to delete")
+
+	indexCmd.AddCommand(indexAddCmd)
+	indexCmd.AddCommand(indexCreateCmd)
+	indexCmd.AddCommand(indexDeleteCmd)
+	rootCmd.AddCommand(indexCmd)
+}
+
+func runIndexAdd(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+
+	// parse ref
+	r, err := ref.New(args[0])
+	if err != nil {
+		return err
+	}
+
+	// setup regclient
+	rc := newRegClient()
+	defer rc.Close(ctx, r)
+
+	// pull existing index
+	m, err := rc.ManifestGet(ctx, r)
+	if err != nil {
+		return err
+	}
+	mi, ok := m.(manifest.Indexer)
+	if !ok {
+		return fmt.Errorf("current manifest is not an index/manifest list, \"%s\": %w", m.GetDescriptor().MediaType, types.ErrUnsupportedMediaType)
+	}
+	curDesc, err := mi.GetManifestList()
+	if err != nil {
+		return err
+	}
+
+	// generate a list of descriptors from CLI args
+	descList, err := indexBuildDescList(ctx, rc, r)
+	if err != nil {
+		return err
+	}
+
+	// append list
+	curDesc = append(curDesc, descList...)
+	curDesc = indexDescListRmDup(curDesc)
+	err = mi.SetManifestList(curDesc)
+	if err != nil {
+		return err
+	}
+
+	// push the index
+	if r.Tag == "" && r.Digest != "" {
+		r.Digest = m.GetDescriptor().Digest.String()
+	}
+	err = rc.ManifestPut(ctx, r, m)
+	if err != nil {
+		return err
+	}
+
+	// format output
+	result := struct {
+		Manifest manifest.Manifest
+	}{
+		Manifest: m,
+	}
+	if r.Tag == "" && r.Digest != "" && indexOpts.format == "" {
+		indexOpts.format = "{{ printf \"%s\\n\" .Manifest.GetDescriptor.Digest }}"
+	}
+	return template.Writer(os.Stdout, indexOpts.format, result)
+}
+
+func runIndexCreate(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+
+	// validate media type
+	if indexOpts.mediaType != types.MediaTypeOCI1ManifestList && indexOpts.mediaType != types.MediaTypeDocker2ManifestList {
+		return fmt.Errorf("unsupported manifest media type: %s%.0w", indexOpts.mediaType, types.ErrUnsupportedMediaType)
+	}
+
+	// parse ref
+	r, err := ref.New(args[0])
+	if err != nil {
+		return err
+	}
+
+	// setup regclient
+	rc := newRegClient()
+	defer rc.Close(ctx, r)
+
+	// parse annotations
+	annotations := map[string]string{}
+	for _, a := range indexOpts.annotations {
+		aSplit := strings.SplitN(a, "=", 2)
+		if len(aSplit) == 1 {
+			annotations[aSplit[0]] = ""
+		} else {
+			annotations[aSplit[0]] = aSplit[1]
+		}
+	}
+
+	// generate a list of descriptors from CLI args
+	descList, err := indexBuildDescList(ctx, rc, r)
+	if err != nil {
+		return err
+	}
+	descList = indexDescListRmDup(descList)
+
+	// build the index
+	mOpts := []manifest.Opts{}
+	switch indexOpts.mediaType {
+	case types.MediaTypeOCI1ManifestList:
+		m := v1.Index{
+			Versioned: v1.IndexSchemaVersion,
+			MediaType: types.MediaTypeOCI1ManifestList,
+			Manifests: descList,
+		}
+		if len(annotations) > 0 {
+			m.Annotations = annotations
+		}
+		mOpts = append(mOpts, manifest.WithOrig(m))
+	case types.MediaTypeDocker2ManifestList:
+		m := schema2.ManifestList{
+			Versioned: schema2.ManifestListSchemaVersion,
+			Manifests: descList,
+		}
+		if len(annotations) > 0 {
+			m.Annotations = annotations
+		}
+		mOpts = append(mOpts, manifest.WithOrig(m))
+	}
+	mm, err := manifest.New(mOpts...)
+	if err != nil {
+		return err
+	}
+
+	// push the index
+	if indexOpts.byDigest {
+		r.Tag = ""
+		r.Digest = mm.GetDescriptor().Digest.String()
+	}
+	err = rc.ManifestPut(ctx, r, mm)
+	if err != nil {
+		return err
+	}
+
+	// format output
+	result := struct {
+		Manifest manifest.Manifest
+	}{
+		Manifest: mm,
+	}
+	if indexOpts.byDigest && indexOpts.format == "" {
+		indexOpts.format = "{{ printf \"%s\\n\" .Manifest.GetDescriptor.Digest }}"
+	}
+	return template.Writer(os.Stdout, indexOpts.format, result)
+}
+
+func runIndexDelete(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+
+	// parse ref
+	r, err := ref.New(args[0])
+	if err != nil {
+		return err
+	}
+
+	// setup regclient
+	rc := newRegClient()
+	defer rc.Close(ctx, r)
+
+	// pull existing index
+	m, err := rc.ManifestGet(ctx, r)
+	if err != nil {
+		return err
+	}
+	mi, ok := m.(manifest.Indexer)
+	if !ok {
+		return fmt.Errorf("current manifest is not an index/manifest list, \"%s\": %w", m.GetDescriptor().MediaType, types.ErrUnsupportedMediaType)
+	}
+	curDesc, err := mi.GetManifestList()
+	if err != nil {
+		return err
+	}
+
+	// for each CLI arg, find and delete matching entries
+	for _, dig := range indexOpts.digests {
+		i := len(curDesc) - 1
+		for i >= 0 {
+			if curDesc[i].Digest.String() == dig {
+				if i < len(curDesc)-1 {
+					curDesc = append(curDesc[:i], curDesc[i+1:]...)
+				} else {
+					curDesc = curDesc[:i]
+				}
+			}
+			i--
+		}
+	}
+	for _, platStr := range indexOpts.platforms {
+		plat, err := platform.Parse(platStr)
+		if err != nil {
+			return err
+		}
+		i := len(curDesc) - 1
+		for i >= 0 {
+			if curDesc[i].Platform != nil && platform.Match(plat, *curDesc[i].Platform) {
+				if i < len(curDesc)-1 {
+					curDesc = append(curDesc[:i], curDesc[i+1:]...)
+				} else {
+					curDesc = curDesc[:i]
+				}
+			}
+			i--
+		}
+	}
+
+	// update manifest
+	err = mi.SetManifestList(curDesc)
+	if err != nil {
+		return err
+	}
+
+	// push the index
+	if r.Tag == "" && r.Digest != "" {
+		r.Digest = m.GetDescriptor().Digest.String()
+	}
+	err = rc.ManifestPut(ctx, r, m)
+	if err != nil {
+		return err
+	}
+
+	// format output
+	result := struct {
+		Manifest manifest.Manifest
+	}{
+		Manifest: m,
+	}
+	if r.Tag == "" && r.Digest != "" && indexOpts.format == "" {
+		indexOpts.format = "{{ printf \"%s\\n\" .Manifest.GetDescriptor.Digest }}"
+	}
+	return template.Writer(os.Stdout, indexOpts.format, result)
+}
+
+func indexBuildDescList(ctx context.Context, rc *regclient.RegClient, r ref.Ref) ([]types.Descriptor, error) {
+	descAnnotations := map[string]string{}
+	for _, a := range indexOpts.descAnnotations {
+		aSplit := strings.SplitN(a, "=", 2)
+		if len(aSplit) == 1 {
+			descAnnotations[aSplit[0]] = ""
+		} else {
+			descAnnotations[aSplit[0]] = aSplit[1]
+		}
+	}
+
+	// copy each ref by digest to the destination repository
+	if indexOpts.digests == nil {
+		indexOpts.digests = []string{}
+	}
+	for _, rStr := range indexOpts.refs {
+		srcRef, err := ref.New(rStr)
+		if err != nil {
+			return nil, err
+		}
+		mCopy, err := rc.ManifestHead(ctx, srcRef)
+		if err != nil {
+			return nil, err
+		}
+		desc := mCopy.GetDescriptor()
+		tgtRef := r
+		tgtRef.Tag = ""
+		tgtRef.Digest = desc.Digest.String()
+		err = rc.ImageCopy(ctx, srcRef, tgtRef, regclient.ImageWithChild())
+		if err != nil {
+			return nil, err
+		}
+		indexOpts.digests = append(indexOpts.digests, desc.Digest.String())
+	}
+
+	// parse each digest, pull manifest, get config, append to list of descriptors
+	descList := []types.Descriptor{}
+	for _, dig := range indexOpts.digests {
+		rDig := r
+		rDig.Tag = ""
+		rDig.Digest = dig
+
+		mDig, err := getManifest(ctx, rc, rDig)
+		if err != nil {
+			return nil, err
+		}
+		desc := mDig.GetDescriptor()
+		plat, err := indexGetPlatform(ctx, rc, rDig, mDig)
+		if err == nil {
+			desc.Platform = plat
+		}
+		if len(descAnnotations) > 0 && desc.Annotations == nil {
+			desc.Annotations = map[string]string{}
+		}
+		for k, v := range descAnnotations {
+			desc.Annotations[k] = v
+		}
+		descList = append(descList, desc)
+	}
+	return descList, nil
+}
+
+func indexGetPlatform(ctx context.Context, rc *regclient.RegClient, r ref.Ref, m manifest.Manifest) (*platform.Platform, error) {
+	if mi, ok := m.(manifest.Imager); ok {
+		cd, err := mi.GetConfig()
+		if err != nil {
+			return nil, err
+		}
+		blobConfig, err := rc.BlobGetOCIConfig(ctx, r, cd)
+		if err != nil {
+			return nil, err
+		}
+		ociConfig := blobConfig.GetConfig()
+		if ociConfig.OS == "" {
+			return nil, nil
+		}
+		plat := platform.Platform{
+			OS:           ociConfig.OS,
+			Architecture: ociConfig.Architecture,
+			OSVersion:    ociConfig.OSVersion,
+			OSFeatures:   ociConfig.OSFeatures,
+			Variant:      ociConfig.Variant,
+			Features:     ociConfig.OSFeatures,
+		}
+		return &plat, nil
+	}
+	return nil, nil
+}
+
+func indexDescListRmDup(dl []types.Descriptor) []types.Descriptor {
+	i := 0
+	for i < len(dl)-1 {
+		j := len(dl) - 1
+		for j > i {
+			if dl[i].Equal(dl[j]) {
+				if j < len(dl)-1 {
+					dl = append(dl[:j], dl[j+1:]...)
+				} else {
+					dl = dl[:j]
+				}
+			}
+			j--
+		}
+		i++
+	}
+	return dl
+}

--- a/docs/regctl.md
+++ b/docs/regctl.md
@@ -6,6 +6,7 @@
 - [Tag commands](#tag-commands)
 - [Image commands](#image-commands)
 - [Blob commands](#blob-commands)
+- [Index commands](#index-commands)
 - [Artifact commands](#artifact-commands)
 - [Format flag](#format-flag)
 
@@ -243,6 +244,25 @@ The `--format` option to `put` has the following variables available:
 
 - `.Digest`: digest of the pushed blob
 - `.Size`: size of the pushed blob
+
+## Index Commands
+
+The index command creates or manages OCI Indexes and Manifest Lists.
+
+```text
+Usage:
+  regctl index [command]
+
+Available Commands:
+  add         add an index entry
+  create      create an index
+  delete      delete an index entry
+```
+
+The `create` command is used to create a new Index and optionally include an initial set of manifests.
+The `add` and `delete` commands are used to add and remove manifests from the Index.
+When adding manifests to an Index, references in other repositories will first be copied to the local repository.
+The platform will automatically be added when an image has a config containing those fields.
 
 ## Artifact Commands
 

--- a/image.go
+++ b/image.go
@@ -71,6 +71,7 @@ type tarWriteData struct {
 }
 
 type imageOpt struct {
+	child           bool
 	forceRecursive  bool
 	includeExternal bool
 	digestTags      bool
@@ -81,6 +82,13 @@ type imageOpt struct {
 
 // ImageOpts define options for the Image* commands
 type ImageOpts func(*imageOpt)
+
+// ImageWithChild attempts to copy every manifest and blob even if parent manifests already exist.
+func ImageWithChild() ImageOpts {
+	return func(opts *imageOpt) {
+		opts.child = true
+	}
+}
 
 // ImageWithForceRecursive attempts to copy every manifest and blob even if parent manifests already exist.
 func ImageWithForceRecursive() ImageOpts {
@@ -130,7 +138,7 @@ func (rc *RegClient) ImageCopy(ctx context.Context, refSrc ref.Ref, refTgt ref.R
 	for _, optFn := range opts {
 		optFn(&opt)
 	}
-	return rc.imageCopyOpt(ctx, refSrc, refTgt, types.Descriptor{}, false, &opt)
+	return rc.imageCopyOpt(ctx, refSrc, refTgt, types.Descriptor{}, opt.child, &opt)
 }
 
 func (rc *RegClient) imageCopyOpt(ctx context.Context, refSrc ref.Ref, refTgt ref.Ref, d types.Descriptor, child bool, opt *imageOpt) error {

--- a/scheme/ocidir/manifest.go
+++ b/scheme/ocidir/manifest.go
@@ -172,9 +172,11 @@ func (o *OCIDir) ManifestPut(ctx context.Context, r ref.Ref, m manifest.Manifest
 		r.Tag = "latest"
 	}
 
+	indexChanged := false
 	index, err := o.readIndex(r)
 	if err != nil {
 		index = indexCreate()
+		indexChanged = true
 	}
 	desc := m.GetDescriptor()
 	b, err := m.RawBody()
@@ -212,6 +214,10 @@ func (o *OCIDir) ManifestPut(ctx context.Context, r ref.Ref, m manifest.Manifest
 		if err != nil {
 			return fmt.Errorf("failed to update index: %w", err)
 		}
+		indexChanged = true
+	}
+	// write the index.json and oci-layout if it's been changed
+	if indexChanged {
 		err = o.writeIndex(r, index)
 		if err != nil {
 			return fmt.Errorf("failed to write index: %w", err)

--- a/types/descriptor.go
+++ b/types/descriptor.go
@@ -67,6 +67,56 @@ func (d Descriptor) GetData() ([]byte, error) {
 	return dBytes, nil
 }
 
+// Equal indicates the two descriptors are identical, effectively a DeepEqual.
+func (d Descriptor) Equal(d2 Descriptor) bool {
+	if !d.Same(d2) {
+		return false
+	}
+	if d.Platform == nil || d2.Platform == nil {
+		if d.Platform != nil || d2.Platform != nil {
+			return false
+		}
+	} else if !platform.Match(*d.Platform, *d2.Platform) {
+		return false
+	}
+	if d.URLs == nil || d2.URLs == nil {
+		if d.URLs != nil || d2.URLs != nil {
+			return false
+		}
+	} else if len(d.URLs) != len(d2.URLs) {
+		return false
+	} else {
+		for i := range d.URLs {
+			if d.URLs[i] != d2.URLs[i] {
+				return false
+			}
+		}
+	}
+	if d.Annotations == nil || d2.Annotations == nil {
+		if d.Annotations != nil || d2.Annotations != nil {
+			return false
+		}
+	} else if len(d.Annotations) != len(d2.Annotations) {
+		return false
+	} else {
+		for i := range d.Annotations {
+			if d.Annotations[i] != d2.Annotations[i] {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// Same indicates two descriptors point to the same CAS object.
+// This verifies the digest, media type, and size all match
+func (d Descriptor) Same(d2 Descriptor) bool {
+	if d.Digest != d2.Digest || d.MediaType != d2.MediaType || d.Size != d2.Size {
+		return false
+	}
+	return true
+}
+
 func (d Descriptor) MarshalPrettyTW(tw *tabwriter.Writer, prefix string) error {
 	fmt.Fprintf(tw, "%sDigest:\t%s\n", prefix, string(d.Digest))
 	fmt.Fprintf(tw, "%sMediaType:\t%s\n", prefix, d.MediaType)

--- a/types/descriptor_test.go
+++ b/types/descriptor_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/opencontainers/go-digest"
+	"github.com/regclient/regclient/types/platform"
 )
 
 func TestDescriptorData(t *testing.T) {
@@ -38,9 +39,9 @@ func TestDescriptorData(t *testing.T) {
 			name: "Bad Digest",
 			d: Descriptor{
 				MediaType: MediaTypeOCI1LayerGzip,
-				Size:      1234,
-				Digest:    digest.Digest("sha256:f6e2d7fa40092cf3d9817bf6ff54183d68d108a47fdf5a5e476c612626c80e14"),
-				Data:      []byte("QmFkIGRpZ2VzdCBkYXRhCg=="),
+				Size:      10,
+				Digest:    digest.Digest("sha256:e4a380728755139f156563e8b795581d5915dcc947fe937c524c6d52fd604b99"),
+				Data:      []byte("R29vZCBkYXRhCg=="),
 			},
 			wantErr: ErrParsingFailed,
 		},
@@ -80,6 +81,308 @@ func TestDescriptorData(t *testing.T) {
 			}
 			if !bytes.Equal(out, tt.wantData) {
 				t.Errorf("data mismatch, expected %s, received %s", string(tt.wantData), string(out))
+			}
+		})
+	}
+}
+
+func TestDescriptorEq(t *testing.T) {
+	digA := digest.FromString("test A")
+	digB := digest.FromString("test B")
+	tests := []struct {
+		name        string
+		d1, d2      Descriptor
+		expectEqual bool
+		expectSame  bool
+	}{
+		{
+			name:        "empty",
+			expectEqual: true,
+			expectSame:  true,
+		},
+		{
+			name: "empty d1",
+			d2: Descriptor{
+				MediaType: MediaTypeDocker2Manifest,
+				Size:      1234,
+				Digest:    digA,
+			},
+			expectEqual: false,
+			expectSame:  false,
+		},
+		{
+			name: "empty d2",
+			d1: Descriptor{
+				MediaType: MediaTypeDocker2Manifest,
+				Size:      1234,
+				Digest:    digA,
+			},
+			expectEqual: false,
+			expectSame:  false,
+		},
+		{
+			name: "same simple manifest",
+			d1: Descriptor{
+				MediaType: MediaTypeDocker2Manifest,
+				Size:      1234,
+				Digest:    digA,
+			},
+			d2: Descriptor{
+				MediaType: MediaTypeDocker2Manifest,
+				Size:      1234,
+				Digest:    digA,
+			},
+			expectEqual: true,
+			expectSame:  true,
+		},
+		{
+			name: "different media type",
+			d1: Descriptor{
+				MediaType: MediaTypeDocker2Manifest,
+				Size:      1234,
+				Digest:    digA,
+			},
+			d2: Descriptor{
+				MediaType: MediaTypeDocker2ManifestList,
+				Size:      1234,
+				Digest:    digA,
+			},
+			expectEqual: false,
+			expectSame:  false,
+		},
+		{
+			name: "different size",
+			d1: Descriptor{
+				MediaType: MediaTypeDocker2Manifest,
+				Size:      1234,
+				Digest:    digA,
+			},
+			d2: Descriptor{
+				MediaType: MediaTypeDocker2Manifest,
+				Size:      4321,
+				Digest:    digA,
+			},
+			expectEqual: false,
+			expectSame:  false,
+		},
+		{
+			name: "different digest",
+			d1: Descriptor{
+				MediaType: MediaTypeDocker2Manifest,
+				Size:      1234,
+				Digest:    digA,
+			},
+			d2: Descriptor{
+				MediaType: MediaTypeDocker2Manifest,
+				Size:      1234,
+				Digest:    digB,
+			},
+			expectEqual: false,
+			expectSame:  false,
+		},
+		{
+			name: "annotation eq",
+			d1: Descriptor{
+				MediaType: MediaTypeDocker2Manifest,
+				Size:      1234,
+				Digest:    digA,
+				Annotations: map[string]string{
+					"key a": "value a",
+					"key b": "value b",
+				},
+			},
+			d2: Descriptor{
+				MediaType: MediaTypeDocker2Manifest,
+				Size:      1234,
+				Digest:    digA,
+				Annotations: map[string]string{
+					"key b": "value b",
+					"key a": "value a",
+				},
+			},
+			expectEqual: true,
+			expectSame:  true,
+		},
+		{
+			name: "annotation diff",
+			d1: Descriptor{
+				MediaType: MediaTypeDocker2Manifest,
+				Size:      1234,
+				Digest:    digA,
+				Annotations: map[string]string{
+					"key a": "value a",
+					"key b": "value b",
+				},
+			},
+			d2: Descriptor{
+				MediaType: MediaTypeDocker2Manifest,
+				Size:      1234,
+				Digest:    digA,
+				Annotations: map[string]string{
+					"key a": "value c",
+					"key d": "value b",
+				},
+			},
+			expectEqual: false,
+			expectSame:  true,
+		},
+		{
+			name: "annotation missing",
+			d1: Descriptor{
+				MediaType: MediaTypeDocker2Manifest,
+				Size:      1234,
+				Digest:    digA,
+				Annotations: map[string]string{
+					"key a": "value a",
+					"key b": "value b",
+				},
+			},
+			d2: Descriptor{
+				MediaType: MediaTypeDocker2Manifest,
+				Size:      1234,
+				Digest:    digA,
+			},
+			expectEqual: false,
+			expectSame:  true,
+		},
+		{
+			name: "urls eq",
+			d1: Descriptor{
+				MediaType: MediaTypeDocker2Manifest,
+				Size:      1234,
+				Digest:    digA,
+				URLs: []string{
+					"url a",
+					"url b",
+				},
+			},
+			d2: Descriptor{
+				MediaType: MediaTypeDocker2Manifest,
+				Size:      1234,
+				Digest:    digA,
+				URLs: []string{
+					"url a",
+					"url b",
+				},
+			},
+			expectEqual: true,
+			expectSame:  true,
+		},
+		{
+			name: "urls diff",
+			d1: Descriptor{
+				MediaType: MediaTypeDocker2Manifest,
+				Size:      1234,
+				Digest:    digA,
+				URLs: []string{
+					"url a",
+					"url b",
+				},
+			},
+			d2: Descriptor{
+				MediaType: MediaTypeDocker2Manifest,
+				Size:      1234,
+				Digest:    digA,
+				URLs: []string{
+					"url c",
+					"url d",
+				},
+			},
+			expectEqual: false,
+			expectSame:  true,
+		},
+		{
+			name: "urls missing",
+			d1: Descriptor{
+				MediaType: MediaTypeDocker2Manifest,
+				Size:      1234,
+				Digest:    digA,
+				URLs: []string{
+					"url a",
+					"url b",
+				},
+			},
+			d2: Descriptor{
+				MediaType: MediaTypeDocker2Manifest,
+				Size:      1234,
+				Digest:    digA,
+			},
+			expectEqual: false,
+			expectSame:  true,
+		},
+		{
+			name: "platform eq",
+			d1: Descriptor{
+				MediaType: MediaTypeDocker2Manifest,
+				Size:      1234,
+				Digest:    digA,
+				Platform: &platform.Platform{
+					OS:           "linux",
+					Architecture: "amd64",
+				},
+			},
+			d2: Descriptor{
+				MediaType: MediaTypeDocker2Manifest,
+				Size:      1234,
+				Digest:    digA,
+				Platform: &platform.Platform{
+					OS:           "linux",
+					Architecture: "amd64",
+				},
+			},
+			expectEqual: true,
+			expectSame:  true,
+		},
+		{
+			name: "platform diff",
+			d1: Descriptor{
+				MediaType: MediaTypeDocker2Manifest,
+				Size:      1234,
+				Digest:    digA,
+				Platform: &platform.Platform{
+					OS:           "linux",
+					Architecture: "amd64",
+				},
+			},
+			d2: Descriptor{
+				MediaType: MediaTypeDocker2Manifest,
+				Size:      1234,
+				Digest:    digA,
+				Platform: &platform.Platform{
+					OS:           "linux",
+					Architecture: "arm64",
+				},
+			},
+			expectEqual: false,
+			expectSame:  true,
+		},
+		{
+			name: "platform missing",
+			d1: Descriptor{
+				MediaType: MediaTypeDocker2Manifest,
+				Size:      1234,
+				Digest:    digA,
+				Platform: &platform.Platform{
+					OS:           "linux",
+					Architecture: "amd64",
+				},
+			},
+			d2: Descriptor{
+				MediaType: MediaTypeDocker2Manifest,
+				Size:      1234,
+				Digest:    digA,
+			},
+			expectEqual: false,
+			expectSame:  true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.d1.Equal(tt.d2) != tt.expectEqual {
+				t.Errorf("equal is not %v", tt.expectEqual)
+			}
+			if tt.d1.Same(tt.d2) != tt.expectSame {
+				t.Errorf("same is not %v", tt.expectSame)
 			}
 		})
 	}


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This adds a new `regctl index` command. This can be used to create or modify an OCI Index or Docker Manifest List.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Deleting a platform:

```
regctl image copy localhost:5000/regclient/regctl ocidir://testregctl
regctl manifest get ocidir://testregctl
regctl index del ocidir://testregctl --platform linux/s390x
regctl manifest get ocidir://testregctl
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Adding `regctl index` command to create and mutate an Index or Manifest List
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
