### PR TITLE
Support a full ref in the ocidir index annotation

### DIFF
--- a/scheme/ocidir/manifest.go
+++ b/scheme/ocidir/manifest.go
@@ -189,7 +189,7 @@ func (o *OCIDir) ManifestPut(ctx context.Context, r ref.Ref, m manifest.Manifest
 	}
 	if r.Tag != "" {
 		desc.Annotations = map[string]string{
-			aRefName: r.Tag,
+			aOCIRefName: r.Tag,
 		}
 	}
 	// create manifest CAS file

--- a/scheme/ocidir/ocidir_test.go
+++ b/scheme/ocidir/ocidir_test.go
@@ -1,5 +1,16 @@
 package ocidir
 
+import (
+	"errors"
+	"testing"
+
+	"github.com/opencontainers/go-digest"
+	"github.com/regclient/regclient/internal/rwfs"
+	"github.com/regclient/regclient/types"
+	v1 "github.com/regclient/regclient/types/oci/v1"
+	"github.com/regclient/regclient/types/ref"
+)
+
 func cmpSliceString(a, b []string) bool {
 	if len(a) != len(b) {
 		return false
@@ -10,4 +21,179 @@ func cmpSliceString(a, b []string) bool {
 		}
 	}
 	return true
+}
+
+func TestIndex(t *testing.T) {
+	// ctx := context.Background()
+	fsMem := rwfs.MemNew()
+	o := New(WithFS(fsMem))
+	dig1 := digest.FromString("test digest 1")
+	dig2 := digest.FromString("test digest 2")
+	dig3 := digest.FromString("test digest 3")
+	r, err := ref.New("ocidir://testrepo")
+	if err != nil {
+		t.Errorf("failed to generate ref: %v", err)
+	}
+	rA, err := ref.New("ocidir://testrepo:tag-a")
+	if err != nil {
+		t.Errorf("failed to generate ref: %v", err)
+	}
+	rB, err := ref.New("ocidir://testrepo:tag-b")
+	if err != nil {
+		t.Errorf("failed to generate ref: %v", err)
+	}
+	rC, err := ref.New("ocidir://testrepo:tag-c")
+	if err != nil {
+		t.Errorf("failed to generate ref: %v", err)
+	}
+	rDig, err := ref.New("ocidir://testrepo@" + dig1.String())
+	if err != nil {
+		t.Errorf("failed to generate ref: %v", err)
+	}
+	descNoTag := types.Descriptor{
+		MediaType: types.MediaTypeDocker2Manifest,
+		Size:      1234,
+		Digest:    dig1,
+	}
+	descA := types.Descriptor{
+		MediaType: types.MediaTypeDocker2Manifest,
+		Size:      1234,
+		Digest:    dig2,
+		Annotations: map[string]string{
+			aOCIRefName: "tag-a",
+		},
+	}
+	descB := types.Descriptor{
+		MediaType: types.MediaTypeDocker2Manifest,
+		Size:      1234,
+		Digest:    dig2,
+		Annotations: map[string]string{
+			aOCIRefName: "tag-b",
+		},
+	}
+	descC := types.Descriptor{
+		MediaType: types.MediaTypeDocker2Manifest,
+		Size:      1234,
+		Digest:    dig3,
+		Annotations: map[string]string{
+			aOCIRefName: rC.CommonName(),
+		},
+	}
+	tests := []struct {
+		name         string
+		index        v1.Index
+		get          ref.Ref
+		expectGet    types.Descriptor
+		expectGetErr error
+		set          ref.Ref
+		setDesc      types.Descriptor
+		expectLen    int
+	}{
+		{
+			name:         "empty",
+			get:          rA,
+			expectGetErr: types.ErrNotFound,
+		},
+		{
+			name: "no tag",
+			index: v1.Index{
+				Versioned: v1.IndexSchemaVersion,
+				MediaType: types.MediaTypeOCI1ManifestList,
+				Manifests: []types.Descriptor{
+					descNoTag,
+				},
+			},
+			get:       rDig,
+			expectGet: descNoTag,
+			set:       rA,
+			setDesc:   descA,
+			expectLen: 2,
+		},
+		{
+			name: "tag a",
+			index: v1.Index{
+				Versioned: v1.IndexSchemaVersion,
+				MediaType: types.MediaTypeOCI1ManifestList,
+				Manifests: []types.Descriptor{
+					descNoTag,
+					descA,
+				},
+			},
+			get:       rDig,
+			expectGet: descNoTag,
+			set:       rC,
+			setDesc:   descNoTag,
+			expectLen: 2,
+		},
+		{
+			name: "tag b",
+			index: v1.Index{
+				Versioned: v1.IndexSchemaVersion,
+				MediaType: types.MediaTypeOCI1ManifestList,
+				Manifests: []types.Descriptor{
+					descNoTag,
+					descB,
+				},
+			},
+			get:       rB,
+			expectGet: descB,
+			set:       rB,
+			setDesc:   descNoTag,
+			expectLen: 1,
+		},
+		{
+			name: "tag c",
+			index: v1.Index{
+				Versioned: v1.IndexSchemaVersion,
+				MediaType: types.MediaTypeOCI1ManifestList,
+				Manifests: []types.Descriptor{
+					descA,
+					descC,
+				},
+			},
+			get:       rC,
+			expectGet: descC,
+			set:       rA,
+			setDesc:   descNoTag,
+			expectLen: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := o.writeIndex(r, tt.index)
+			if err != nil {
+				t.Errorf("failed to write index: %v", err)
+			}
+			index, err := o.readIndex(r)
+			if err != nil {
+				t.Errorf("failed to read index: %v", err)
+			}
+			if !tt.get.IsZero() {
+				d, err := indexGet(index, tt.get)
+				if tt.expectGetErr != nil {
+					if err == nil {
+						t.Errorf("indexGet did not fail")
+					} else if !errors.Is(err, tt.expectGetErr) && err.Error() != tt.expectGetErr.Error() {
+						t.Errorf("unexpected error from indexGet, expected %v, received %v", tt.expectGetErr, err)
+					}
+				} else {
+					if err != nil {
+						t.Errorf("indexGet failed: %v", err)
+					} else if !d.Equal(tt.expectGet) {
+						t.Errorf("indexGet descriptor, expected %v, received %v", tt.expectGet, d)
+					}
+				}
+			}
+			if !tt.set.IsZero() {
+				err := indexSet(&index, tt.set, tt.setDesc)
+				if err != nil {
+					t.Errorf("indexSet failed: %v", err)
+				}
+			}
+			if len(index.Manifests) != tt.expectLen {
+				t.Errorf("unexpected length, expected %d, found %d, index: %v", tt.expectLen, len(index.Manifests), index)
+			}
+		})
+	}
 }

--- a/scheme/ocidir/tag.go
+++ b/scheme/ocidir/tag.go
@@ -25,7 +25,7 @@ func (o *OCIDir) TagDelete(ctx context.Context, r ref.Ref) error {
 	}
 	changed := false
 	for i, desc := range index.Manifests {
-		if t, ok := desc.Annotations[aRefName]; ok && t == r.Tag {
+		if t, ok := desc.Annotations[aOCIRefName]; ok && t == r.Tag {
 			// remove matching entry from index
 			index.Manifests = append(index.Manifests[:i], index.Manifests[i+1:]...)
 			changed = true
@@ -52,8 +52,20 @@ func (o *OCIDir) TagList(ctx context.Context, r ref.Ref, opts ...scheme.TagOpts)
 	}
 	tl := []string{}
 	for _, desc := range index.Manifests {
-		if t, ok := desc.Annotations[aRefName]; ok && !strings.Contains(t, ":") {
-			tl = append(tl, t)
+		if t, ok := desc.Annotations[aOCIRefName]; ok {
+			if i := strings.LastIndex(t, ":"); i >= 0 {
+				t = t[i+1:]
+			}
+			found := false
+			for _, cur := range tl {
+				if cur == t {
+					found = true
+					break
+				}
+			}
+			if !found {
+				tl = append(tl, t)
+			}
 		}
 	}
 	sort.Strings(tl)


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Some tools creating an OCI Image Layout will output a full reference in the index.json annotation instead of just the tag.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

If a full reference is included in the OCI Image Layout annotation, parse the tag from that reference in commands like tag list and manifest get.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

`regctl tag ls ocidir://repo` and `regctl manifest get ocidir://repo` will work if repo contains a full reference instead of just the tag in the index.json annotation.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
