### PR TITLE
Use a registry like reference in docker export

### DIFF
--- a/types/ref/ref.go
+++ b/types/ref/ref.go
@@ -5,6 +5,7 @@ package ref
 
 import (
 	"fmt"
+	"path"
 	"regexp"
 	"strings"
 )
@@ -154,11 +155,27 @@ func (r Ref) CommonName() string {
 }
 
 // IsZero returns true if ref is unset
-func (r *Ref) IsZero() bool {
+func (r Ref) IsZero() bool {
 	if r.Scheme == "" && r.Registry == "" && r.Repository == "" && r.Path == "" && r.Tag == "" && r.Digest == "" {
 		return true
 	}
 	return false
+}
+
+// ToReg converts a reference to a registry like syntax
+func (r Ref) ToReg() Ref {
+	switch r.Scheme {
+	case "ocidir":
+		r.Scheme = "reg"
+		r.Registry = "localhost"
+		// clean the path to strip leading ".."
+		r.Repository = path.Clean("/" + r.Path)[1:]
+		r.Repository = strings.ToLower(r.Repository)
+		// convert any unsupported characters to "-" in the path
+		re := regexp.MustCompile(`[^/a-z0-9]+`)
+		r.Repository = string(re.ReplaceAll([]byte(r.Repository), []byte("-")))
+	}
+	return r
 }
 
 // EqualRegistry compares the registry between two references

--- a/types/ref/ref_test.go
+++ b/types/ref/ref_test.go
@@ -558,3 +558,46 @@ func TestEqual(t *testing.T) {
 		})
 	}
 }
+
+func TestToReg(t *testing.T) {
+	tests := []struct {
+		name   string
+		inRef  string
+		expect string
+	}{
+		{
+			name:   "simple path",
+			inRef:  "ocidir://test",
+			expect: "localhost/test",
+		},
+		{
+			name:   "relative path",
+			inRef:  "ocidir://../test",
+			expect: "localhost/test",
+		},
+		{
+			name:   "upper case",
+			inRef:  "ocidir://Test",
+			expect: "localhost/test",
+		},
+		{
+			name:   "other characters",
+			inRef:  "ocidir://test_-_hello world",
+			expect: "localhost/test-hello-world",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r, err := New(tt.inRef)
+			if err != nil {
+				t.Errorf("failed parsing input ref: %v", err)
+				return
+			}
+			outRef := r.ToReg()
+			if outRef.CommonName() != tt.expect {
+				t.Errorf("convert expected %s, received %s", tt.expect, outRef.CommonName())
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

An export from an ocidir of a single image cannot be loaded into docker because of an invalid reference.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This converts the reference to something resembling a registry reference when exporting the docker specific manifest.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```
regctl image export ocidir://path file.tar
docker load <file.tar
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Fix reference for ocidir exports for importing into docker
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
