### PR TITLE
Include various token characters from rfc7235

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -31,7 +31,7 @@ var tokenBuffer = time.Second * 5
 
 const (
 	isSpace charLU = 1 << iota
-	isAlphaNum
+	isToken
 )
 
 func init() {
@@ -40,8 +40,8 @@ func init() {
 		if strings.ContainsRune(" \t\r\n", rune(c)) {
 			charLUs[c] |= isSpace
 		}
-		if (rune('a') <= rune(c) && rune(c) <= rune('z')) || (rune('A') <= rune(c) && rune(c) <= rune('Z') || (rune('0') <= rune(c) && rune(c) <= rune('9'))) {
-			charLUs[c] |= isAlphaNum
+		if (rune('a') <= rune(c) && rune(c) <= rune('z')) || (rune('A') <= rune(c) && rune(c) <= rune('Z') || (rune('0') <= rune(c) && rune(c) <= rune('9')) || strings.ContainsRune("-._~+/", rune(c))) {
+			charLUs[c] |= isToken
 		}
 	}
 }
@@ -346,8 +346,8 @@ func ParseAuthHeader(ah string) ([]Challenge, error) {
 				// beginning of string
 				if b == '"' { // TODO: Invalid?
 					state = "quoted"
-				} else if charLUs[b]&isAlphaNum != 0 {
-					// read any alphanum
+				} else if charLUs[b]&isToken != 0 {
+					// read any token
 					eb = append(eb, b)
 				} else if charLUs[b]&isSpace != 0 {
 					// ignore leading whitespace
@@ -356,8 +356,8 @@ func ParseAuthHeader(ah string) ([]Challenge, error) {
 					return nil, ErrParseFailure
 				}
 			} else {
-				if charLUs[b]&isAlphaNum != 0 {
-					// read any alphanum
+				if charLUs[b]&isToken != 0 {
+					// read any token
 					eb = append(eb, b)
 				} else if b == '=' && len(atb) > 0 {
 					// equals when authtype is defined makes this a key
@@ -377,8 +377,8 @@ func ParseAuthHeader(ah string) ([]Challenge, error) {
 			}
 
 		case "value":
-			if charLUs[b]&isAlphaNum != 0 {
-				// read any alphanum
+			if charLUs[b]&isToken != 0 {
+				// read any token
 				vb = append(vb, b)
 			} else if b == '"' && len(vb) == 0 {
 				// quoted value

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -44,6 +44,12 @@ func TestParseAuthHeader(t *testing.T) {
 			wantE: nil,
 		},
 		{
+			name:  "Basic unquoted token",
+			in:    `Basic realm=/`,
+			wantC: []Challenge{{authType: "basic", params: map[string]string{"realm": "/"}}},
+			wantE: nil,
+		},
+		{
 			name:  "Missing close quote",
 			in:    `Basic realm="GitHub Package Registry`,
 			wantC: []Challenge{},


### PR DESCRIPTION
https://datatracker.ietf.org/doc/html/rfc7235#section-2.1
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Fixes #265 
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

The auth header parsing should accept bare token characters without a quote, in addition to the alpha-numeric characters.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Perform authenticated requests with a realm set to `/` without quotes.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Fix support for authentication parsing of token characters without quotes.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
