### PR TITLE
Fix conversion to OCI media types

### DIFF
--- a/mod/mod.go
+++ b/mod/mod.go
@@ -248,6 +248,7 @@ func WithManifestToOCI() Opts {
 				if err != nil {
 					return err
 				}
+				ociM.Config.MediaType = types.MediaTypeOCI1ImageConfig
 				for i, l := range ociM.Layers {
 					if l.MediaType == types.MediaTypeDocker2LayerGzip {
 						ociM.Layers[i].MediaType = types.MediaTypeOCI1LayerGzip
@@ -255,7 +256,11 @@ func WithManifestToOCI() Opts {
 				}
 				om = ociM
 			}
-			dm.m.SetOrig(om)
+			newM, err := manifest.New(manifest.WithOrig(om))
+			if err != nil {
+				return err
+			}
+			dm.m = newM
 			dm.newDesc = dm.m.GetDescriptor()
 			dm.mod = replaced
 			return nil


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

The conversion to OCI media types wasn't working in various scenarios.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This creates a new manifest object instead of modifying the existing one since modifying the manifest doesn't support changing the underlying object.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

`regctl image mod --to-oci $some_image`
<!-- Include steps that can be taken to verify the change -->

### Changelog text

<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

Since `regctl image mod` is considered experimental, there's no documentation for this yet.
<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
