### PR TITLE
Add filtering for artifact referrers

### DIFF
--- a/scheme/scheme.go
+++ b/scheme/scheme.go
@@ -78,10 +78,32 @@ func WithManifestChild() ManifestOpts {
 
 // ReferrerConfig is used by schemes to import ReferrerOpts
 type ReferrerConfig struct {
+	FilterArtifactType string
+	FilterAnnotation   map[string]string
 }
 
 // ReferrerOpts is used to set options on referrer APIs
 type ReferrerOpts func(*ReferrerConfig)
+
+// WithReferrerAT filters by a specific artifactType value
+func WithReferrerAT(at string) ReferrerOpts {
+	return func(config *ReferrerConfig) {
+		config.FilterArtifactType = at
+	}
+}
+
+// WithReferrerAnnotations filters by a list of annotations, all of which must match
+func WithReferrerAnnotations(annotations map[string]string) ReferrerOpts {
+	return func(config *ReferrerConfig) {
+		if config.FilterAnnotation == nil {
+			config.FilterAnnotation = annotations
+		} else {
+			for k, v := range annotations {
+				config.FilterAnnotation[k] = v
+			}
+		}
+	}
+}
 
 // RepoConfig is used by schemes to import RepoOpts
 type RepoConfig struct {


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This adds the ability to filter artifacts from the experimental artifact list methods. It's implemented in `regctl artifact get` and `regctl artifact list`
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```
$ regctl artifact list ocidir://testrepo:latest
Refers:         ocidir://testrepo:latest
                
Referrers:      
                
  Name:         ocidir://testrepo@sha256:5cc04f2ae7ef200ad5f743f2dc5a92db055d5fb133fb92a2b10c5e58e12c429e
  Digest:       sha256:5cc04f2ae7ef200ad5f743f2dc5a92db055d5fb133fb92a2b10c5e58e12c429e
  MediaType:    application/vnd.oci.image.manifest.v1+json
  ArtifactType: application/vnd.unknown.config.v1+json
  Annotations:  
    hello:      world

$ echo "hi OCI" | regctl artifact put --refers ocidir://testrepo:latest --annotation hello=OCI

$ regctl artifact list ocidir://testrepo:latest
Refers:         ocidir://testrepo:latest
                
Referrers:      
                
  Name:         ocidir://testrepo@sha256:5cc04f2ae7ef200ad5f743f2dc5a92db055d5fb133fb92a2b10c5e58e12c429e
  Digest:       sha256:5cc04f2ae7ef200ad5f743f2dc5a92db055d5fb133fb92a2b10c5e58e12c429e
  MediaType:    application/vnd.oci.image.manifest.v1+json
  ArtifactType: application/vnd.unknown.config.v1+json
  Annotations:  
    hello:      world
                
  Name:         ocidir://testrepo@sha256:d5ee73c0229467f8c6868ac9d423876204ec9d177ea11cc8a36728d626daf317
  Digest:       sha256:d5ee73c0229467f8c6868ac9d423876204ec9d177ea11cc8a36728d626daf317
  MediaType:    application/vnd.oci.image.manifest.v1+json
  ArtifactType: application/vnd.unknown.config.v1+json
  Annotations:  
    hello:      OCI

$ regctl artifact list ocidir://testrepo:latest --filter-annotation hello=OCI
Refers:         ocidir://testrepo:latest
                
Referrers:      
                
  Name:         ocidir://testrepo@sha256:d5ee73c0229467f8c6868ac9d423876204ec9d177ea11cc8a36728d626daf317
  Digest:       sha256:d5ee73c0229467f8c6868ac9d423876204ec9d177ea11cc8a36728d626daf317
  MediaType:    application/vnd.oci.image.manifest.v1+json
  ArtifactType: application/vnd.unknown.config.v1+json
  Annotations:  
    hello:      OCI

$ regctl artifact get --refers ocidir://testrepo:latest --filter-annotation hello=OCI
hi OCI
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Adding support for client side filters on artifact list
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

This is considered experimental until approved by OCI, so documentation is not included.
<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
