### PR TITLE
Support Link header in tag pagination

### DIFF
--- a/internal/httplink/httplink.go
+++ b/internal/httplink/httplink.go
@@ -1,0 +1,196 @@
+// Package httplink parses the Link header from HTTP responses according to RFC5988
+package httplink
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/regclient/regclient/types"
+)
+
+type Links []Link
+type Link struct {
+	URI   string
+	Param map[string]string
+}
+
+type charLU byte
+
+var charLUs [256]charLU
+
+const (
+	isSpace charLU = 1 << iota
+	isToken
+	isAlphaNum
+)
+
+func init() {
+	for c := 0; c < 256; c++ {
+		charLUs[c] = 0
+		if strings.ContainsRune(" \t\r\n", rune(c)) {
+			charLUs[c] |= isSpace
+		}
+		if (rune('a') <= rune(c) && rune(c) <= rune('z')) || (rune('A') <= rune(c) && rune(c) <= rune('Z') || (rune('0') <= rune(c) && rune(c) <= rune('9'))) {
+			charLUs[c] |= isAlphaNum | isToken
+		}
+		if strings.ContainsRune("!#$%&'()*+-./:<=>?@[]^_`{|}~", rune(c)) {
+			charLUs[c] |= isToken
+		}
+	}
+}
+
+// Parse reads "Link" http headers into an array of Link structs.
+// Header array should be the output of resp.Header.Values("link").
+func Parse(headers []string) (Links, error) {
+	links := []Link{}
+	for _, h := range headers {
+		state := "init"
+		var ub, pnb, pvb []byte
+		parms := map[string]string{}
+		endLink := func() {
+			links = append(links, Link{
+				URI:   string(ub),
+				Param: parms,
+			})
+			// reset state
+			ub, pnb, pvb = []byte{}, []byte{}, []byte{}
+			parms = map[string]string{}
+		}
+		endParm := func() {
+			if _, ok := parms[string(pnb)]; !ok {
+				parms[string(pnb)] = string(pvb)
+			}
+			// reset parm
+			pnb, pvb = []byte{}, []byte{}
+		}
+		for i, b := range []byte(h) {
+			switch state {
+			case "init":
+				if b == '<' {
+					state = "uriQuoted"
+				} else if charLUs[b]&isToken != 0 {
+					state = "uri"
+					ub = append(ub, b)
+				} else if charLUs[b]&isSpace != 0 || b == ',' {
+					// noop
+				} else {
+					// unknown character
+					return nil, fmt.Errorf("unknown character in position %d of %s: %w", i, h, types.ErrParsingFailed)
+				}
+			case "uri":
+				// parse tokens until space or comma
+				if charLUs[b]&isToken != 0 {
+					ub = append(ub, b)
+				} else if charLUs[b]&isSpace != 0 {
+					state = "fieldSep"
+				} else if b == ';' {
+					state = "parmName"
+				} else if b == ',' {
+					state = "init"
+					endLink()
+				} else {
+					// unknown character
+					return nil, fmt.Errorf("unknown character in position %d of %s: %w", i, h, types.ErrParsingFailed)
+				}
+			case "uriQuoted":
+				// parse tokens until quote
+				if b == '>' {
+					state = "fieldSep"
+				} else {
+					ub = append(ub, b)
+				}
+			case "fieldSep":
+				if b == ';' {
+					state = "parmName"
+				} else if b == ',' {
+					state = "init"
+					endLink()
+				} else if charLUs[b]&isSpace != 0 {
+					// noop
+				} else {
+					// unknown character
+					return nil, fmt.Errorf("unknown character in position %d of %s: %w", i, h, types.ErrParsingFailed)
+				}
+			case "parmName":
+				if len(pnb) > 0 && b == '=' {
+					state = "parmValue"
+				} else if len(pnb) > 0 && b == '*' {
+					state = "parmNameStar"
+				} else if charLUs[b]&isAlphaNum != 0 {
+					pnb = append(pnb, b)
+				} else if len(pnb) == 0 && charLUs[b]&isSpace != 0 {
+					// noop
+				} else {
+					// unknown character
+					return nil, fmt.Errorf("unknown character in position %d of %s: %w", i, h, types.ErrParsingFailed)
+				}
+			case "parmNameStar":
+				if b == '=' {
+					state = "parmValue"
+				} else {
+					// unknown character
+					return nil, fmt.Errorf("unknown character in position %d of %s: %w", i, h, types.ErrParsingFailed)
+				}
+			case "parmValue":
+				if len(pvb) == 0 {
+					if charLUs[b]&isToken != 0 {
+						pvb = append(pvb, b)
+					} else if b == '"' {
+						state = "parmValueQuoted"
+					} else {
+						// unknown character
+						return nil, fmt.Errorf("unknown character in position %d of %s: %w", i, h, types.ErrParsingFailed)
+					}
+				} else {
+					if charLUs[b]&isToken != 0 {
+						pvb = append(pvb, b)
+					} else if charLUs[b]&isSpace != 0 {
+						state = "fieldSep"
+						endParm()
+					} else if b == ';' {
+						state = "parmName"
+						endParm()
+					} else if b == ',' {
+						state = "init"
+						endParm()
+						endLink()
+					} else {
+						// unknown character
+						return nil, fmt.Errorf("unknown character in position %d of %s: %w", i, h, types.ErrParsingFailed)
+					}
+				}
+			case "parmValueQuoted":
+				if b == '"' {
+					state = "fieldSep"
+					endParm()
+				} else {
+					pvb = append(pvb, b)
+				}
+			}
+		}
+		// check for valid state at end of header
+		switch state {
+		case "parmValue":
+			endParm()
+			endLink()
+		case "uri", "fieldSep":
+			endLink()
+		case "init":
+			// noop
+		default:
+			return nil, fmt.Errorf("unexpected end state %s for header %s: %w", state, h, types.ErrParsingFailed)
+		}
+	}
+
+	return links, nil
+}
+
+// Get returns a link with a specific parm value, e.g. rel="next"
+func (links Links) Get(parm, val string) (Link, error) {
+	for _, link := range links {
+		if link.Param != nil && link.Param[parm] == val {
+			return link, nil
+		}
+	}
+	return Link{}, types.ErrNotFound
+}

--- a/internal/httplink/httplink_test.go
+++ b/internal/httplink/httplink_test.go
@@ -1,0 +1,139 @@
+package httplink
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/regclient/regclient/types"
+)
+
+func TestParseErr(t *testing.T) {
+	tests := []struct {
+		name    string
+		headers []string
+	}{
+		{
+			name:    "open uri",
+			headers: []string{"</path"},
+		},
+		{
+			name:    "open quote",
+			headers: []string{`</path>; rel="next`},
+		},
+		{
+			name:    "backslash",
+			headers: []string{"\\"},
+		},
+		{
+			name:    "backslash uri",
+			headers: []string{"/\\"},
+		},
+		{
+			name:    "missing separator",
+			headers: []string{`</path>; rel="next" media="print"`},
+		},
+		{
+			name:    "invalid parm",
+			headers: []string{`</path>; r&d="nope"`},
+		},
+		{
+			name:    "invalid star",
+			headers: []string{`</path>; r*d="nope"`},
+		},
+		{
+			name:    "invalid val start",
+			headers: []string{`</path>; rel=\`},
+		},
+		{
+			name:    "invalid val mid",
+			headers: []string{`</path>; rel=a\b`},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Parse(tt.headers)
+			if err == nil {
+				t.Error("parse did not fail")
+			}
+		})
+	}
+}
+
+func TestParseGet(t *testing.T) {
+	headerComplex := []string{`</path1>; rel="next", </path2> ; rel="next", / ; rel=index `, `</print>; media=print`, `/link, /reader; media=reader; type=x`}
+	tests := []struct {
+		name          string
+		headers       []string
+		parm, val     string
+		expectURI     string
+		expectMissing bool
+	}{
+		{
+			name:      "quoted rel next",
+			headers:   []string{`</path>; rel="next"`},
+			parm:      "rel",
+			val:       "next",
+			expectURI: "/path",
+		},
+		{
+			name:      "complex rel=next",
+			headers:   headerComplex,
+			parm:      "rel",
+			val:       "next",
+			expectURI: "/path1",
+		},
+		{
+			name:      "complex rel=index",
+			headers:   headerComplex,
+			parm:      "rel",
+			val:       "index",
+			expectURI: "/",
+		},
+		{
+			name:      "complex media=print",
+			headers:   headerComplex,
+			parm:      "media",
+			val:       "print",
+			expectURI: "/print",
+		},
+		{
+			name:          "complex not found",
+			headers:       headerComplex,
+			parm:          "rel",
+			val:           "unknown",
+			expectMissing: true,
+		},
+		{
+			name: "rfc example",
+			headers: []string{`</TheBook/chapter2>;	rel="previous"; title*=UTF-8'de'letztes%20Kapitel,
+			                   </TheBook/chapter4>; rel="next"; title*=UTF-8'de'n%c3%a4chstes%20Kapitel`},
+			parm:      "rel",
+			val:       "next",
+			expectURI: "/TheBook/chapter4",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			links, err := Parse(tt.headers)
+			if err != nil {
+				t.Errorf("parse failed: %v", err)
+				return
+			}
+			link, err := links.Get(tt.parm, tt.val)
+			if tt.expectMissing {
+				if err == nil || !errors.Is(err, types.ErrNotFound) {
+					t.Errorf("did not find missing error: %v, %v", link, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("failed to run get: %v", err)
+				return
+			}
+			if link.URI != tt.expectURI {
+				t.Errorf("URI mismatch: expected %s, received %s", tt.expectURI, link.URI)
+			}
+		})
+	}
+
+}

--- a/scheme/reg/tag.go
+++ b/scheme/reg/tag.go
@@ -17,6 +17,7 @@ import (
 	_ "crypto/sha512"
 
 	"github.com/opencontainers/go-digest"
+	"github.com/regclient/regclient/internal/httplink"
 	"github.com/regclient/regclient/internal/reghttp"
 	"github.com/regclient/regclient/scheme"
 	"github.com/regclient/regclient/types"
@@ -172,6 +173,54 @@ func (reg *Reg) TagList(ctx context.Context, r ref.Ref, opts ...scheme.TagOpts) 
 		opt(&config)
 	}
 
+	tl, err := reg.tagListOCI(ctx, r, config)
+	if err != nil {
+		return tl, err
+	}
+
+	for {
+		// if limit reached, stop searching
+		if config.Limit > 0 && len(tl.Tags) >= config.Limit {
+			break
+		}
+		tlHead, err := tl.RawHeaders()
+		if err != nil {
+			return tl, err
+		}
+		links, err := httplink.Parse(tlHead.Values("Link"))
+		if err != nil {
+			return tl, err
+		}
+		next, err := links.Get("rel", "next")
+		// if Link header with rel="next" is defined
+		if err == nil {
+			link := tl.GetURL()
+			if link == nil {
+				return tl, fmt.Errorf("tag list, failed to get URL of previous request")
+			}
+			link, err = link.Parse(next.URI)
+			if err != nil {
+				return tl, fmt.Errorf("tag list failed to parse Link: %w", err)
+			}
+			tlAdd, err := reg.tagListLink(ctx, r, config, link)
+			if err != nil {
+				return tl, fmt.Errorf("tag list failed to get Link: %w", err)
+			}
+			err = tl.Append(tlAdd)
+			if err != nil {
+				return tl, fmt.Errorf("tag list failed to append entries: %w", err)
+			}
+		} else {
+			// do not automatically expand tags with OCI methods,
+			// OCI registries should send all possible entries up to the specified limit
+			break
+		}
+	}
+
+	return tl, nil
+}
+
+func (reg *Reg) tagListOCI(ctx context.Context, r ref.Ref, config scheme.TagConfig) (*tag.List, error) {
 	query := url.Values{}
 	if config.Last != "" {
 		query.Set("last", config.Last)
@@ -210,12 +259,58 @@ func (reg *Reg) TagList(ctx context.Context, r ref.Ref, opts ...scheme.TagOpts) 
 		}).Warn("Failed to read tag list")
 		return nil, fmt.Errorf("failed to read tags for %s: %w", r.CommonName(), err)
 	}
-	mt := resp.HTTPResponse().Header.Get("Content-Type")
 	tl, err := tag.New(
-		tag.WithMT(mt),
-		tag.WithRaw(respBody),
 		tag.WithRef(r),
-		tag.WithHeaders(resp.HTTPResponse().Header),
+		tag.WithRaw(respBody),
+		tag.WithResp(resp.HTTPResponse()),
+	)
+	if err != nil {
+		reg.log.WithFields(logrus.Fields{
+			"err":  err,
+			"body": respBody,
+			"ref":  r.CommonName(),
+		}).Warn("Failed to unmarshal tag list")
+		return tl, fmt.Errorf("failed to unmarshal tag list for %s: %w", r.CommonName(), err)
+	}
+
+	return tl, nil
+}
+
+func (reg *Reg) tagListLink(ctx context.Context, r ref.Ref, config scheme.TagConfig, link *url.URL) (*tag.List, error) {
+	headers := http.Header{
+		"Accept": []string{"application/json"},
+	}
+	req := &reghttp.Req{
+		Host: r.Registry,
+		APIs: map[string]reghttp.ReqAPI{
+			"": {
+				Method:     "GET",
+				DirectURL:  link,
+				Repository: r.Repository,
+				Headers:    headers,
+			},
+		},
+	}
+	resp, err := reg.reghttp.Do(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list tags for %s: %w", r.CommonName(), err)
+	}
+	defer resp.Close()
+	if resp.HTTPResponse().StatusCode != 200 {
+		return nil, fmt.Errorf("failed to list tags for %s: %w", r.CommonName(), reghttp.HTTPError(resp.HTTPResponse().StatusCode))
+	}
+	respBody, err := ioutil.ReadAll(resp)
+	if err != nil {
+		reg.log.WithFields(logrus.Fields{
+			"err": err,
+			"ref": r.CommonName(),
+		}).Warn("Failed to read tag list")
+		return nil, fmt.Errorf("failed to read tags for %s: %w", r.CommonName(), err)
+	}
+	tl, err := tag.New(
+		tag.WithRef(r),
+		tag.WithRaw(respBody),
+		tag.WithResp(resp.HTTPResponse()),
 	)
 	if err != nil {
 		reg.log.WithFields(logrus.Fields{

--- a/types/ref/ref.go
+++ b/types/ref/ref.go
@@ -188,6 +188,9 @@ func EqualRegistry(a, b Ref) bool {
 		return a.Registry == b.Registry
 	case "ocidir":
 		return a.Path == b.Path
+	case "":
+		// both undefined
+		return true
 	default:
 		return false
 	}
@@ -203,6 +206,9 @@ func EqualRepository(a, b Ref) bool {
 		return a.Registry == b.Registry && a.Repository == b.Repository
 	case "ocidir":
 		return a.Path == b.Path
+	case "":
+		// both undefined
+		return true
 	default:
 		return false
 	}


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Fixes #274 
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

When the link header is seen when reading tag lists, the next link is followed and multiple pages will be assembled until the limit is reached.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```
regctl tag ls quay.io/calico/node
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Support Link header in tag pagination seen on quay.io
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
