### PR TITLE
Include user-agent header in auth requests

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -654,6 +654,7 @@ func (b *BearerHandler) tryGet() error {
 		req.SetBasicAuth(cred.User, cred.Password)
 	}
 
+	req.Header.Add("User-Agent", b.clientID)
 	req.URL.RawQuery = reqParams.Encode()
 
 	resp, err := b.client.Do(req)
@@ -693,6 +694,7 @@ func (b *BearerHandler) tryPost() error {
 		return err
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded; charset=utf-8")
+	req.Header.Add("User-Agent", b.clientID)
 
 	resp, err := b.client.Do(req)
 	if err != nil {

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -90,6 +90,7 @@ func TestParseAuthHeader(t *testing.T) {
 
 // TestAuth checks the auth interface using a mock http server
 func TestAuth(t *testing.T) {
+	clientID := "testClient"
 	token1Resp, _ := json.Marshal(BearerToken{
 		Token:     "token1",
 		ExpiresIn: 900,
@@ -108,6 +109,9 @@ func TestAuth(t *testing.T) {
 				Name:   "req token1",
 				Method: "POST",
 				Path:   "/token1",
+				Headers: http.Header{
+					"User-Agent": []string{clientID},
+				},
 			},
 			RespEntry: reqresp.RespEntry{
 				Status: 200,
@@ -119,6 +123,9 @@ func TestAuth(t *testing.T) {
 				Name:   "req token2 POST",
 				Method: "POST",
 				Path:   "/token2",
+				Headers: http.Header{
+					"User-Agent": []string{clientID},
+				},
 			},
 			RespEntry: reqresp.RespEntry{
 				Status: http.StatusNotFound,
@@ -131,6 +138,7 @@ func TestAuth(t *testing.T) {
 				Path:   "/token2",
 				Headers: http.Header{
 					"Authorization": {"Basic dXNlcjpwYXNz"},
+					"User-Agent":    []string{clientID},
 				},
 				Query: map[string][]string{
 					"scope": {"repository:reponame:pull,push"},
@@ -198,6 +206,7 @@ func TestAuth(t *testing.T) {
 		{
 			name: "bearer1",
 			auth: NewAuth(
+				WithClientID(clientID),
 				WithCreds(func(s string) Cred {
 					return Cred{User: "user", Password: "pass"}
 				}),
@@ -222,6 +231,7 @@ func TestAuth(t *testing.T) {
 		{
 			name: "bearer2",
 			auth: NewAuth(
+				WithClientID(clientID),
 				WithCreds(func(s string) Cred {
 					return Cred{User: "user", Password: "pass"}
 				}),


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

The user-agent header in auth requests was defaulting to the Go user agent.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This updates the user-agent header in auth requests to match other HTTP requests.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Check the headers on auth requests by sniffing the network traffic or server logs.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
