### PR TITLE
Refactoring referrers support

### DIFF
--- a/image.go
+++ b/image.go
@@ -18,7 +18,6 @@ import (
 
 	digest "github.com/opencontainers/go-digest"
 	"github.com/regclient/regclient/pkg/archive"
-	"github.com/regclient/regclient/scheme"
 	"github.com/regclient/regclient/types"
 	"github.com/regclient/regclient/types/docker/schema2"
 	"github.com/regclient/regclient/types/manifest"
@@ -142,9 +141,9 @@ func (rc *RegClient) ImageCopy(ctx context.Context, refSrc ref.Ref, refTgt ref.R
 }
 
 func (rc *RegClient) imageCopyOpt(ctx context.Context, refSrc ref.Ref, refTgt ref.Ref, d types.Descriptor, child bool, opt *imageOpt) error {
-	mOpts := []scheme.ManifestOpts{}
+	mOpts := []ManifestOpts{}
 	if child {
-		mOpts = append(mOpts, scheme.WithManifestChild())
+		mOpts = append(mOpts, WithManifestChild())
 	}
 	// check if scheme/refTgt prefers parent manifests pushed first
 	// if so, this should automatically set forceRecursive
@@ -178,7 +177,7 @@ func (rc *RegClient) imageCopyOpt(ctx context.Context, refSrc ref.Ref, refTgt re
 	}
 
 	// get the manifest for the source
-	m, err := rc.ManifestGet(ctx, refSrc, ManifestWithDesc(d))
+	m, err := rc.ManifestGet(ctx, refSrc, WithManifestDesc(d))
 	if err != nil {
 		rc.log.WithFields(logrus.Fields{
 			"ref": refSrc.Reference,
@@ -331,7 +330,7 @@ func (rc *RegClient) imageCopyOpt(ctx context.Context, refSrc ref.Ref, refTgt re
 		}
 	}
 
-	// experimental support for referrers
+	// EXPERIMENTAL support for referrers
 	referTags := []string{}
 	if opt.referrers {
 		rl, err := rc.ReferrerList(ctx, refSrc)
@@ -353,19 +352,6 @@ func (rc *RegClient) imageCopyOpt(ctx context.Context, refSrc ref.Ref, refTgt re
 					"src":    referSrc.CommonName(),
 					"tgt":    referTgt.CommonName(),
 				}).Warn("Failed to copy referrer")
-				return err
-			}
-			referM, err := rc.ManifestGet(ctx, referTgt)
-			if err != nil {
-				rc.log.WithFields(logrus.Fields{
-					"digest": rDesc.Digest.String(),
-					"src":    referSrc.CommonName(),
-					"tgt":    referTgt.CommonName(),
-				}).Warn("Failed to copy referrer")
-				return err
-			}
-			err = rc.ReferrerPut(ctx, refTgt, referM)
-			if err != nil {
 				return err
 			}
 		}
@@ -536,7 +522,7 @@ func (rc *RegClient) imageExportDescriptor(ctx context.Context, ref ref.Ref, des
 	case types.MediaTypeDocker1Manifest, types.MediaTypeDocker1ManifestSigned, types.MediaTypeDocker2Manifest, types.MediaTypeOCI1Manifest:
 		// Handle single platform manifests
 		// retrieve manifest
-		m, err := rc.ManifestGet(ctx, ref, ManifestWithDesc(desc))
+		m, err := rc.ManifestGet(ctx, ref, WithManifestDesc(desc))
 		if err != nil {
 			return err
 		}
@@ -589,7 +575,7 @@ func (rc *RegClient) imageExportDescriptor(ctx context.Context, ref ref.Ref, des
 	case types.MediaTypeDocker2ManifestList, types.MediaTypeOCI1ManifestList:
 		// handle OCI index and Docker manifest list
 		// retrieve manifest
-		m, err := rc.ManifestGet(ctx, ref, ManifestWithDesc(desc))
+		m, err := rc.ManifestGet(ctx, ref, WithManifestDesc(desc))
 		if err != nil {
 			return err
 		}
@@ -971,9 +957,9 @@ func (rc *RegClient) imageImportOCIHandleManifest(ctx context.Context, ref ref.R
 			if err == nil {
 				return nil
 			}
-			opts := []scheme.ManifestOpts{}
+			opts := []ManifestOpts{}
 			if child {
-				opts = append(opts, scheme.WithManifestChild())
+				opts = append(opts, WithManifestChild())
 			}
 			return rc.ManifestPut(ctx, mRef, m, opts...)
 		})

--- a/internal/reqresp/reqresp.go
+++ b/internal/reqresp/reqresp.go
@@ -132,7 +132,7 @@ func (r *rrHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		}
 		return
 	}
-	r.t.Errorf("Unhandled request: %v, body: %s", req, reqBody)
+	r.t.Errorf("Unhandled request: %v, body: %s, state: %s", req, reqBody, r.state)
 	rw.WriteHeader(http.StatusInternalServerError)
 	rw.Write([]byte("Unsupported request"))
 }

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -264,7 +264,7 @@ func TestManifest(t *testing.T) {
 			Digest:    mDigest,
 			Data:      []byte(base64.StdEncoding.EncodeToString(mBody)),
 		}
-		mGet, err := rc.ManifestGet(ctx, dataRef, ManifestWithDesc(d))
+		mGet, err := rc.ManifestGet(ctx, dataRef, WithManifestDesc(d))
 		if err != nil {
 			t.Errorf("failed running ManifestGet: %v", err)
 		}
@@ -287,7 +287,7 @@ func TestManifest(t *testing.T) {
 			Digest:    mDigest,
 			Data:      []byte(base64.StdEncoding.EncodeToString([]byte("invalid data"))),
 		}
-		_, err = rc.ManifestGet(ctx, getRef, ManifestWithDesc(d))
+		_, err = rc.ManifestGet(ctx, getRef, WithManifestDesc(d))
 		if err != nil {
 			t.Errorf("Failed running ManifestGet: %v", err)
 			return
@@ -304,7 +304,7 @@ func TestManifest(t *testing.T) {
 			Digest:    mDigest,
 			Data:      []byte(base64.StdEncoding.EncodeToString([]byte("invalid data"))),
 		}
-		_, err = rc.ManifestGet(ctx, missingRef, ManifestWithDesc(d))
+		_, err = rc.ManifestGet(ctx, missingRef, WithManifestDesc(d))
 		if err != nil {
 			t.Errorf("get with descriptor failed, didn't fall back to digest")
 			return
@@ -321,7 +321,7 @@ func TestManifest(t *testing.T) {
 			Digest:    missingDigest,
 			Data:      []byte(base64.StdEncoding.EncodeToString([]byte("invalid data"))),
 		}
-		_, err = rc.ManifestGet(ctx, missingRef, ManifestWithDesc(d))
+		_, err = rc.ManifestGet(ctx, missingRef, WithManifestDesc(d))
 		if err == nil {
 			t.Errorf("Success running ManifestGet on missing ref")
 			return

--- a/mod/dag.go
+++ b/mod/dag.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/opencontainers/go-digest"
 	"github.com/regclient/regclient"
-	"github.com/regclient/regclient/scheme"
 	"github.com/regclient/regclient/types"
 	"github.com/regclient/regclient/types/blob"
 	"github.com/regclient/regclient/types/manifest"
@@ -63,7 +62,7 @@ func dagGet(ctx context.Context, rc *regclient.RegClient, r ref.Ref, d types.Des
 	var err error
 	getOpts := []regclient.ManifestOpts{}
 	if d.Digest != "" {
-		getOpts = append(getOpts, regclient.ManifestWithDesc(d))
+		getOpts = append(getOpts, regclient.WithManifestDesc(d))
 	}
 	dm := dagManifest{}
 	dm.m, err = rc.ManifestGet(ctx, r, getOpts...)
@@ -340,9 +339,9 @@ func dagPut(ctx context.Context, rc *regclient.RegClient, mc dagConfig, r ref.Re
 	}
 	if dm.mod == replaced || dm.mod == added {
 		dm.newDesc = dm.m.GetDescriptor()
-		mpOpts := []scheme.ManifestOpts{}
+		mpOpts := []regclient.ManifestOpts{}
 		if !dm.top {
-			mpOpts = append(mpOpts, scheme.WithManifestChild())
+			mpOpts = append(mpOpts, regclient.WithManifestChild())
 		}
 		rPut := r
 		rPut.Tag = ""

--- a/referrer.go
+++ b/referrer.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/regclient/regclient/scheme"
-	"github.com/regclient/regclient/types/manifest"
 	"github.com/regclient/regclient/types/ref"
 	"github.com/regclient/regclient/types/referrer"
 )
@@ -16,14 +15,4 @@ func (rc *RegClient) ReferrerList(ctx context.Context, r ref.Ref, opts ...scheme
 		return referrer.ReferrerList{}, err
 	}
 	return schemeAPI.ReferrerList(ctx, r, opts...)
-}
-
-// ReferrerPut pushes a manifest
-// Any descriptors referenced by the manifest typically need to be pushed first
-func (rc *RegClient) ReferrerPut(ctx context.Context, r ref.Ref, m manifest.Manifest) error {
-	schemeAPI, err := rc.schemeGet(r.Scheme)
-	if err != nil {
-		return err
-	}
-	return schemeAPI.ReferrerPut(ctx, r, m)
 }

--- a/scheme/ocidir/referrer_test.go
+++ b/scheme/ocidir/referrer_test.go
@@ -37,10 +37,11 @@ func TestReferrer(t *testing.T) {
 	)
 	repo := "ocidir://testrepo"
 	tagName := "v3"
-	aType := "sbom"
-	bType := "notbom"
+	aType := "application/example.sbom"
+	bType := "application/example.sig"
 	extraAnnot := "org.opencontainers.artifact.sbom.format"
-	extraValue := "SPDX json"
+	extraValueA := "json"
+	extraValueB := "yaml"
 	digest1 := digest.FromString("example1")
 	digest2 := digest.FromString("example2")
 	mRef, err := ref.New(repo + ":" + tagName)
@@ -55,16 +56,15 @@ func TestReferrer(t *testing.T) {
 	mDigest := m.GetDescriptor().Digest
 	tagRef := fmt.Sprintf("%s-%s", mDigest.Algorithm().String(), mDigest.Hex())
 	// artifact being attached
-	artifactAnnot := map[string]string{
-		annotType:  aType,
-		extraAnnot: extraValue,
+	artifactAAnnot := map[string]string{
+		extraAnnot: extraValueA,
 	}
 	mDesc := m.GetDescriptor()
-	artifact := v1.Manifest{
+	artifactA := v1.Manifest{
 		Versioned: v1.ManifestSchemaVersion,
 		MediaType: types.MediaTypeOCI1Manifest,
 		Config: types.Descriptor{
-			MediaType: types.MediaTypeOCI1ImageConfig,
+			MediaType: aType,
 			Size:      8,
 			Digest:    digest1,
 		},
@@ -75,25 +75,47 @@ func TestReferrer(t *testing.T) {
 				Digest:    digest2,
 			},
 		},
-		Annotations: artifactAnnot,
+		Annotations: artifactAAnnot,
 		Refers:      &mDesc,
 	}
-	artifactM, err := manifest.New(manifest.WithOrig(artifact))
+	artifactAM, err := manifest.New(manifest.WithOrig(artifactA))
 	if err != nil {
 		t.Errorf("failed creating artifact manifest: %v", err)
 	}
-	artifactBody, err := artifactM.RawBody()
+	artifactABody, err := artifactAM.RawBody()
 	if err != nil {
 		t.Errorf("failed extracting raw body from artifact: %v", err)
 	}
+	artifactBAnnot := map[string]string{
+		extraAnnot: extraValueB,
+	}
+	artifactB := v1.ArtifactManifest{
+		MediaType:    types.MediaTypeOCI1Artifact,
+		ArtifactType: bType,
+		Blobs: []types.Descriptor{
+			{
+				MediaType: types.MediaTypeOCI1LayerGzip,
+				Size:      8,
+				Digest:    digest2,
+			},
+		},
+		Annotations: artifactBAnnot,
+		Refers:      &mDesc,
+	}
+	artifactBM, err := manifest.New(manifest.WithOrig(artifactB))
+	if err != nil {
+		t.Errorf("failed creating artifact manifest: %v", err)
+		return
+	}
+	artifactBBody, err := artifactBM.RawBody()
+	if err != nil {
+		t.Errorf("failed extracting raw body from artifact: %v", err)
+		return
+	}
 
 	// list empty
-	t.Run("List empty NoAPI", func(t *testing.T) {
-		r, err := ref.New(repo + ":" + tagName)
-		if err != nil {
-			t.Errorf("Failed creating getRef: %v", err)
-			return
-		}
+	t.Run("List empty", func(t *testing.T) {
+		r := mRef
 		rl, err := o.ReferrerList(ctx, r)
 		if err != nil {
 			t.Errorf("Failed running ReferrerList: %v", err)
@@ -107,20 +129,23 @@ func TestReferrer(t *testing.T) {
 
 	// attach to v1 image
 	t.Run("Put", func(t *testing.T) {
-		r, err := ref.New(repo + ":" + tagName)
+		r := mRef
+		r.Tag = ""
+		r.Digest = artifactAM.GetDescriptor().Digest.String()
+		err = o.ManifestPut(ctx, r, artifactAM, scheme.WithManifestChild())
 		if err != nil {
-			t.Errorf("Failed creating getRef: %v", err)
-		}
-		err = o.ReferrerPut(ctx, r, artifactM)
-		if err != nil {
-			t.Errorf("Failed running ReferrerPut: %v", err)
+			t.Errorf("Failed running ManifestPut on Manifest: %v", err)
 			return
 		}
-		rTag2 := r
-		rTag2.Tag = fmt.Sprintf("%s-%s.%s.%s", mDigest.Algorithm().String(), mDigest.Hex(), artifactM.GetDescriptor().Digest.Hex()[:16], bType)
-		err = o.ManifestPut(ctx, rTag2, artifactM)
+		err = o.ManifestPut(ctx, r, artifactAM, scheme.WithManifestChild())
 		if err != nil {
-			t.Errorf("Failed pushing second tag: %v", err)
+			t.Errorf("Failed running ManifestPut on Manifest again: %v", err)
+			return
+		}
+		r.Digest = artifactBM.GetDescriptor().Digest.String()
+		err = o.ManifestPut(ctx, r, artifactBM, scheme.WithManifestChild())
+		if err != nil {
+			t.Errorf("Failed running ManifestPut on Artifact: %v", err)
 			return
 		}
 	})
@@ -137,18 +162,25 @@ func TestReferrer(t *testing.T) {
 			t.Errorf("Failed running ReferrerList: %v", err)
 			return
 		}
-		if len(rl.Descriptors) <= 0 {
-			t.Errorf("descriptor list missing")
+		if len(rl.Descriptors) != 2 {
+			t.Errorf("descriptor list length, expected 2, received %d", len(rl.Descriptors))
 			return
 		}
+		// expecting artifact A in index 0
 		if rl.Descriptors[0].MediaType != types.MediaTypeOCI1Manifest ||
-			rl.Descriptors[0].Size != int64(len(artifactBody)) ||
-			rl.Descriptors[0].Digest != artifactM.GetDescriptor().Digest ||
-			!mapStringStringEq(rl.Descriptors[0].Annotations, artifactAnnot) {
-			t.Errorf("returned descriptor mismatch: %v", rl.Descriptors[0])
+			rl.Descriptors[0].Size != int64(len(artifactABody)) ||
+			rl.Descriptors[0].Digest != artifactAM.GetDescriptor().Digest ||
+			rl.Descriptors[0].ArtifactType != aType ||
+			!mapStringStringEq(rl.Descriptors[0].Annotations, artifactAAnnot) {
+			t.Errorf("returned descriptor A mismatch: %v", rl.Descriptors[0])
 		}
-		if len(rl.Descriptors) > 1 && rl.Descriptors[0].Digest == rl.Descriptors[1].Digest {
-			t.Errorf("descriptor list is not de-duplicated")
+		// expecting artifact B in index 1
+		if rl.Descriptors[1].MediaType != types.MediaTypeOCI1Artifact ||
+			rl.Descriptors[1].Size != int64(len(artifactBBody)) ||
+			rl.Descriptors[1].Digest != artifactBM.GetDescriptor().Digest ||
+			rl.Descriptors[1].ArtifactType != bType ||
+			!mapStringStringEq(rl.Descriptors[1].Annotations, artifactBAnnot) {
+			t.Errorf("returned descriptor B mismatch: %v", rl.Descriptors[1])
 		}
 		if len(rl.Tags) != 1 || rl.Tags[0] != tagRef {
 			t.Errorf("tag list missing entries, received: %v", rl.Tags)
@@ -160,13 +192,13 @@ func TestReferrer(t *testing.T) {
 			t.Errorf("Failed creating getRef: %v", err)
 			return
 		}
-		rl, err := o.ReferrerList(ctx, r, scheme.WithReferrerAT(types.MediaTypeOCI1ImageConfig))
+		rl, err := o.ReferrerList(ctx, r, scheme.WithReferrerAT(aType))
 		if err != nil {
 			t.Errorf("Failed running ReferrerList: %v", err)
 			return
 		}
-		if len(rl.Descriptors) <= 0 {
-			t.Errorf("descriptor list missing")
+		if len(rl.Descriptors) != 1 {
+			t.Errorf("descriptor list length, expected 1, received %d", len(rl.Descriptors))
 			return
 		}
 		rl, err = o.ReferrerList(ctx, r, scheme.WithReferrerAT("application/vnd.example.unknown"))
@@ -185,13 +217,13 @@ func TestReferrer(t *testing.T) {
 			t.Errorf("Failed creating getRef: %v", err)
 			return
 		}
-		rl, err := o.ReferrerList(ctx, r, scheme.WithReferrerAnnotations(map[string]string{extraAnnot: extraValue}))
+		rl, err := o.ReferrerList(ctx, r, scheme.WithReferrerAnnotations(map[string]string{extraAnnot: extraValueB}))
 		if err != nil {
 			t.Errorf("Failed running ReferrerList: %v", err)
 			return
 		}
-		if len(rl.Descriptors) <= 0 {
-			t.Errorf("descriptor list missing")
+		if len(rl.Descriptors) != 1 {
+			t.Errorf("descriptor list length, expected 1, received %d", len(rl.Descriptors))
 			return
 		}
 		rl, err = o.ReferrerList(ctx, r, scheme.WithReferrerAnnotations(map[string]string{extraAnnot: "unknown value"}))
@@ -204,6 +236,39 @@ func TestReferrer(t *testing.T) {
 			return
 		}
 	})
+
+	// delete manifests with refers
+	t.Run("Delete", func(t *testing.T) {
+		r := mRef
+		r.Tag = ""
+		r.Digest = artifactAM.GetDescriptor().Digest.String()
+		err = o.ManifestDelete(ctx, r, scheme.WithManifest(artifactAM))
+		if err != nil {
+			t.Errorf("Failed running ManifestDelete on Manifest: %v", err)
+			return
+		}
+		r.Digest = artifactBM.GetDescriptor().Digest.String()
+		err = o.ManifestDelete(ctx, r, scheme.WithManifestCheckRefers())
+		if err != nil {
+			t.Errorf("Failed running ManifestDelete on Artifact: %v", err)
+			return
+		}
+	})
+
+	// list after delete, verify 0 entries
+	t.Run("List empty after delete", func(t *testing.T) {
+		r := mRef
+		rl, err := o.ReferrerList(ctx, r)
+		if err != nil {
+			t.Errorf("Failed running ReferrerList: %v", err)
+			return
+		}
+		if len(rl.Descriptors) > 0 {
+			t.Errorf("descriptors exist")
+			return
+		}
+	})
+
 }
 
 func mapStringStringEq(a, b map[string]string) bool {

--- a/types/docker/schema2/manifest.go
+++ b/types/docker/schema2/manifest.go
@@ -25,7 +25,4 @@ type Manifest struct {
 	// Annotations contains arbitrary metadata for the image index.
 	// Note, this is not a defined docker schema2 field.
 	Annotations map[string]string `json:"annotations,omitempty"`
-
-	// Refers indicates this manifest references another manifest
-	Refers *types.Descriptor `json:"refers,omitempty"`
 }

--- a/types/manifest/docker2.go
+++ b/types/manifest/docker2.go
@@ -99,13 +99,6 @@ func (m *docker2ManifestList) GetPlatformList() ([]*platform.Platform, error) {
 	return getPlatformList(dl)
 }
 
-func (m *docker2Manifest) GetRefers() (*types.Descriptor, error) {
-	if !m.manifSet {
-		return nil, wraperr.New(fmt.Errorf("Manifest unavailable, perform a ManifestGet first"), types.ErrUnavailable)
-	}
-	return m.Manifest.Refers, nil
-}
-
 func (m *docker2Manifest) MarshalJSON() ([]byte, error) {
 	if !m.manifSet {
 		return []byte{}, wraperr.New(fmt.Errorf("manifest unavailable, perform a ManifestGet first"), types.ErrUnavailable)
@@ -168,14 +161,6 @@ func (m *docker2Manifest) MarshalPretty() ([]byte, error) {
 	for _, d := range m.Layers {
 		fmt.Fprintf(tw, "\t\n")
 		err := d.MarshalPrettyTW(tw, "  ")
-		if err != nil {
-			return []byte{}, err
-		}
-	}
-	if m.Refers != nil {
-		fmt.Fprintf(tw, "\t\n")
-		fmt.Fprintf(tw, "Refers:\t\n")
-		err := m.Refers.MarshalPrettyTW(tw, "  ")
 		if err != nil {
 			return []byte{}, err
 		}
@@ -294,14 +279,6 @@ func (m *docker2ManifestList) SetOrig(origIn interface{}) error {
 	}
 	m.manifSet = true
 	m.ManifestList = orig
-	return m.updateDesc()
-}
-
-func (m *docker2Manifest) SetRefers(d *types.Descriptor) error {
-	if !m.manifSet {
-		return wraperr.New(fmt.Errorf("Manifest unavailable, perform a ManifestGet first"), types.ErrUnavailable)
-	}
-	m.Manifest.Refers = d
 	return m.updateDesc()
 }
 

--- a/types/manifest/manifest.go
+++ b/types/manifest/manifest.go
@@ -78,7 +78,7 @@ type Imager interface {
 	SetLayers(dl []types.Descriptor) error
 }
 
-type Referrer interface {
+type Refers interface {
 	GetRefers() (*types.Descriptor, error)
 	SetRefers(d *types.Descriptor) error
 }

--- a/types/manifest/manifest_test.go
+++ b/types/manifest/manifest_test.go
@@ -380,7 +380,6 @@ func TestNew(t *testing.T) {
 			testAnnot: true,
 			testRefer: true,
 			hasAnnot:  true,
-			hasRefer:  true,
 		},
 		{
 			name: "Docker Schema 2 Manifest full desc",
@@ -401,7 +400,6 @@ func TestNew(t *testing.T) {
 			testRefer: true,
 			wantE:     nil,
 			hasAnnot:  true,
-			hasRefer:  true,
 		},
 		{
 			name: "Docker Schema 2 List from Http",
@@ -564,7 +562,6 @@ func TestNew(t *testing.T) {
 			testAnnot: true,
 			testRefer: true,
 			hasAnnot:  true,
-			hasRefer:  true,
 		},
 		{
 			name: "OCI Artifact Orig",
@@ -658,21 +655,22 @@ func TestNew(t *testing.T) {
 				}
 			}
 			if tt.testRefer {
-				mr, ok := m.(Referrer)
+				mr, ok := m.(Refers)
 				if tt.hasRefer {
 					if !ok {
 						t.Errorf("manifest does not support referrer")
-					}
-					err = mr.SetRefers(&rDesc)
-					if err != nil {
-						t.Errorf("failed setting referrer: %v", err)
-					}
-					getDesc, err := mr.GetRefers()
-					if err != nil {
-						t.Errorf("failed getting referrer: %v", err)
-					}
-					if getDesc == nil || getDesc.MediaType != rDesc.MediaType || getDesc.Digest != rDesc.Digest {
-						t.Errorf("referrer did not match, expected %v, received %v", rDesc, getDesc)
+					} else {
+						err = mr.SetRefers(&rDesc)
+						if err != nil {
+							t.Errorf("failed setting referrer: %v", err)
+						}
+						getDesc, err := mr.GetRefers()
+						if err != nil {
+							t.Errorf("failed getting referrer: %v", err)
+						}
+						if getDesc == nil || getDesc.MediaType != rDesc.MediaType || getDesc.Digest != rDesc.Digest {
+							t.Errorf("referrer did not match, expected %v, received %v", rDesc, getDesc)
+						}
 					}
 				} else if ok {
 					t.Errorf("manifest supports referrer")

--- a/types/referrer/referrer.go
+++ b/types/referrer/referrer.go
@@ -7,17 +7,92 @@ import (
 	"sort"
 	"text/tabwriter"
 
+	"github.com/opencontainers/go-digest"
 	"github.com/regclient/regclient/types"
 	"github.com/regclient/regclient/types/manifest"
+	v1 "github.com/regclient/regclient/types/oci/v1"
 	"github.com/regclient/regclient/types/ref"
 )
 
+// ReferrerList contains the response to a request for referrers
 type ReferrerList struct {
 	Ref         ref.Ref            `json:"ref"`                   // reference queried
 	Descriptors []types.Descriptor `json:"descriptors"`           // descriptors found in Index
 	Annotations map[string]string  `json:"annotations,omitempty"` // annotations extracted from Index
 	Manifest    manifest.Manifest  `json:"-"`                     // returned OCI Index
 	Tags        []string           `json:"-"`                     // tags matched when fetching referrers
+}
+
+// Add appends an entry to rl.Manifest, used to modify the client managed Index
+func (rl *ReferrerList) Add(m manifest.Manifest) error {
+	rlM, ok := rl.Manifest.GetOrig().(v1.Index)
+	if !ok {
+		return fmt.Errorf("referrer list manifest is not an OCI index for %s", rl.Ref.CommonName())
+	}
+	// if entry already exists, return
+	mDesc := m.GetDescriptor()
+	for _, d := range rlM.Manifests {
+		if d.Digest == mDesc.Digest {
+			return nil
+		}
+	}
+	// update descriptor, pulling up artifact type and annotations
+	switch mOrig := m.GetOrig().(type) {
+	case v1.ArtifactManifest:
+		mDesc.Annotations = mOrig.Annotations
+		mDesc.ArtifactType = mOrig.ArtifactType
+	case v1.Manifest:
+		mDesc.Annotations = mOrig.Annotations
+		mDesc.ArtifactType = mOrig.Config.MediaType
+	default:
+		// other types are not supported
+		return fmt.Errorf("invalid manifest for referrer \"%t\": %w", m.GetOrig(), types.ErrUnsupportedMediaType)
+	}
+	// append descriptor to index
+	rlM.Manifests = append(rlM.Manifests, mDesc)
+	err := rl.Manifest.SetOrig(rlM)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Delete removes an entry from rl.Manifest, used to modify the client managed Index
+func (rl *ReferrerList) Delete(m manifest.Manifest) error {
+	rlM, ok := rl.Manifest.GetOrig().(v1.Index)
+	if !ok {
+		return fmt.Errorf("referrer list manifest is not an OCI index for %s", rl.Ref.CommonName())
+	}
+	// delete matching entries from the list
+	mDesc := m.GetDescriptor()
+	found := false
+	for i := len(rlM.Manifests) - 1; i >= 0; i-- {
+		if rlM.Manifests[i].Digest == mDesc.Digest {
+			if i < len(rlM.Manifests)-1 {
+				rlM.Manifests = append(rlM.Manifests[:i], rlM.Manifests[i+1:]...)
+			} else {
+				rlM.Manifests = rlM.Manifests[:i]
+			}
+			found = true
+		}
+	}
+	if !found {
+		return fmt.Errorf("refers not found in referrer list%.0w", types.ErrNotFound)
+	}
+	err := rl.Manifest.SetOrig(rlM)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// IsEmpty reports if the returned Index contains no manifests
+func (rl ReferrerList) IsEmpty() bool {
+	rlM, ok := rl.Manifest.GetOrig().(v1.Index)
+	if !ok || len(rlM.Manifests) == 0 {
+		return true
+	}
+	return false
 }
 
 // MarshalPretty is used for printPretty template formatting
@@ -56,4 +131,22 @@ func (rl ReferrerList) MarshalPretty() ([]byte, error) {
 	}
 	tw.Flush()
 	return buf.Bytes(), nil
+}
+
+// FallbackTag returns the ref that should be used when the registry does not support the referrers API
+func FallbackTag(r ref.Ref) (ref.Ref, error) {
+	rr := r
+	dig, err := digest.Parse(r.Digest)
+	if err != nil {
+		return rr, fmt.Errorf("failed to parse digest for referrers: %w", err)
+	}
+	rr.Digest = ""
+	rr.Tag = fmt.Sprintf("%s-%s", dig.Algorithm(), stringMax(dig.Hex(), 64))
+	return rr, nil
+}
+func stringMax(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max]
 }


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This refactors the referrers support. Updates to the referrers list are handled with `ManifestPut` and `ManifestDelete` directly, instead of requiring a separate `ReferrersPut`. This also adds support for the newer referrers endpoint that OCI is expected to be approved soon.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```
echo hello | regctl artifact put --annotation hello=world --refers $image
regctl artifact list $image
regctl artifact get $artifact_name
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Update refers support for current OCI PR and support delete.
Breaking: `regclient.ManifestWithDesc` has been renamed to `regclient.WithManifestDesc`
Breaking: `manifest.Referrer` interface has been renamed to `manifest.Refers`
Breaking: `ReferrerPut` method has been removed, use `ManifestPut` instead
Breaking: `regclient.ManifestPut` options are now in `regclient` rather than `scheme`
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

This feature is still experimental for a bit longer, documentation will follow when it's considered stable.
<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
