### PR TITLE
Document refers, remove experimental notes on CLI

### DIFF
--- a/cmd/regctl/artifact.go
+++ b/cmd/regctl/artifact.go
@@ -61,10 +61,9 @@ var artifactGetCmd = &cobra.Command{
 	RunE:      runArtifactGet,
 }
 var artifactListCmd = &cobra.Command{
-	Use:     "list <reference>",
-	Aliases: []string{"ls"},
-	// TODO: remove experimental label when stable
-	Short:     "EXPERIMENTAL: list artifacts that refer to the given reference",
+	Use:       "list <reference>",
+	Aliases:   []string{"ls"},
+	Short:     "list artifacts that refer to the given reference",
 	Long:      `List artifacts that refer to the given reference.`,
 	Args:      cobra.ExactArgs(1),
 	ValidArgs: []string{}, // do not auto complete repository/tag
@@ -98,9 +97,9 @@ var artifactOpts struct {
 }
 
 func init() {
-	artifactGetCmd.Flags().StringVarP(&artifactOpts.refers, "refers", "", "", "EXPERIMENTAL: Get a referrer to the reference")
-	artifactGetCmd.Flags().StringVarP(&artifactOpts.filterAT, "filter-artifact-type", "", "", "EXPERIMENTAL: Filter referrers by artifactType")
-	artifactGetCmd.Flags().StringArrayVarP(&artifactOpts.filterAnnot, "filter-annotation", "", []string{}, "EXPERIMENTAL: Filter referrers by annotation (key=value)")
+	artifactGetCmd.Flags().StringVarP(&artifactOpts.refers, "refers", "", "", "Get a referrer to the reference")
+	artifactGetCmd.Flags().StringVarP(&artifactOpts.filterAT, "filter-artifact-type", "", "", "Filter referrers by artifactType")
+	artifactGetCmd.Flags().StringArrayVarP(&artifactOpts.filterAnnot, "filter-annotation", "", []string{}, "Filter referrers by annotation (key=value)")
 	artifactGetCmd.Flags().StringVarP(&artifactOpts.artifactConfig, "config-file", "", "", "Config filename to output")
 	artifactGetCmd.Flags().StringArrayVarP(&artifactOpts.artifactFile, "file", "f", []string{}, "Filter by artifact filename")
 	artifactGetCmd.Flags().StringArrayVarP(&artifactOpts.artifactFileMT, "file-media-type", "m", []string{}, "Filter by artifact media-type")
@@ -131,8 +130,7 @@ func init() {
 	artifactPutCmd.Flags().StringArrayVarP(&artifactOpts.annotations, "annotation", "", []string{}, "Annotation to include on manifest")
 	artifactPutCmd.Flags().BoolVarP(&artifactOpts.byDigest, "by-digest", "", false, "Push manifest by digest instead of tag")
 	artifactPutCmd.Flags().StringVarP(&artifactOpts.formatPut, "format", "", "", "Format output with go template syntax")
-	// TODO: remove experimental label when stable
-	artifactPutCmd.Flags().StringVarP(&artifactOpts.refers, "refers", "", "", "EXPERIMENTAL: Create a referrer to the reference")
+	artifactPutCmd.Flags().StringVarP(&artifactOpts.refers, "refers", "", "", "Create a referrer to the reference")
 	artifactPutCmd.Flags().BoolVarP(&artifactOpts.stripDirs, "strip-dirs", "", false, "Strip directories from filenames in artifact")
 
 	artifactCmd.AddCommand(artifactGetCmd)

--- a/cmd/regctl/image.go
+++ b/cmd/regctl/image.go
@@ -136,7 +136,7 @@ func init() {
 	imageCopyCmd.Flags().BoolVarP(&imageOpts.includeExternal, "include-external", "", false, "Include external layers")
 	imageCopyCmd.Flags().StringArrayVarP(&imageOpts.platforms, "platforms", "", []string{}, "Copy only specific platforms, registry validation must be disabled")
 	imageCopyCmd.Flags().BoolVarP(&imageOpts.digestTags, "digest-tags", "", false, "Include digest tags (\"sha256-<digest>.*\") when copying manifests")
-	imageCopyCmd.Flags().BoolVarP(&imageOpts.referrers, "referrers", "", false, "Experimental: Include referrers")
+	imageCopyCmd.Flags().BoolVarP(&imageOpts.referrers, "referrers", "", false, "Include referrers")
 	// platforms should be treated as experimental since it will break many registries
 	imageCopyCmd.Flags().MarkHidden("platforms")
 

--- a/image.go
+++ b/image.go
@@ -330,7 +330,6 @@ func (rc *RegClient) imageCopyOpt(ctx context.Context, refSrc ref.Ref, refTgt re
 		}
 	}
 
-	// EXPERIMENTAL support for referrers
 	referTags := []string{}
 	if opt.referrers {
 		rl, err := rc.ReferrerList(ctx, refSrc)


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This removes the "experimental" warning on various `regctl artifact` commands and flags. The underlying APIs may still be updated by the CLI should now be stable. Documentation for the options has also be added and updated.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
regctl artifact get --help
regctl artifact list --help
regctl artifact put --help
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

`regctl artifact` commands support the `refers` field.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
