### PR TITLE
regctl: Add tips on common errors

### DIFF
--- a/cmd/regctl/main.go
+++ b/cmd/regctl/main.go
@@ -3,11 +3,17 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 )
 
 func main() {
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
+		// provide tips for common error messages
+		switch {
+		case strings.Contains(err.Error(), "http: server gave HTTP response to HTTPS client"):
+			fmt.Fprintf(os.Stderr, "Try updating your registry with \"regctl registry set --tls disabled <registry>\"\n")
+		}
 		os.Exit(1)
 	}
 	os.Exit(0)

--- a/docs/README.md
+++ b/docs/README.md
@@ -64,6 +64,22 @@ The following functions have been added in addition to the defaults available in
 
 ## FAQ
 
+1. Q: How do I use HTTP instead of HTTPS? I'm getting `http: server gave HTTP response to HTTPS client`.
+
+   A: With `regctl` use:
+
+   ```shell
+   regctl registry set --tls disabled <registry>
+   ```
+
+   For `regsync` and `regbot` use:
+
+   ```yaml
+   creds:
+     - registry: registry.example.org:5000
+       tls: disabled
+   ```
+
 1. Q: After deleting tags and images on the registry, I'm still seeing disk space being used.
 
    A: Registries require garbage collection to run to cleanup untagged manifests and unused blobs.


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This adds a tip to the error message when querying an HTTP registry without disabling TLS.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
$ regctl manifest get 127.0.0.1:5000/library/alpine
WARN[0000] Sleeping for backoff                          Host="127.0.0.1:5000" Seconds=1.999998004
WARN[0002] Sleeping for backoff                          Host="127.0.0.1:5000" Seconds=3.999992055
failed to get manifest 127.0.0.1:5000/library/alpine:latest: Get "https://127.0.0.1:5000/v2/library/alpine/manifests/latest": http: server gave HTTP response to HTTPS client
Try updating your registry with "regctl registry set --tls disabled <registry>"
```

### Changelog text

regctl: add tips to common errors
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
