### PR TITLE
Bumping to Go 1.19 and GHA versions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -88,16 +88,17 @@ jobs:
         echo "::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
 
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Set embed/version.json
       run: make embed/version.json
 
+    # qemu is not needed for Go cross compiling
     # - name: Set up QEMU
     #   uses: docker/setup-qemu-action@v1
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v2
 
     - name: Install cosign
       uses: sigstore/cosign-installer@main
@@ -111,14 +112,14 @@ jobs:
 
     - name: Login to GHCR
       if: github.repository_owner == 'regclient'
-      uses: docker/login-action@v1 
+      uses: docker/login-action@v2
       with:
         registry: ghcr.io
         username: ${{ secrets.GHCR_USERNAME }}
         password: ${{ secrets.GHCR_TOKEN }}
 
     - name: Build and push regctl scratch
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       id: build-regctl-scratch
       with:
         context: .
@@ -138,7 +139,7 @@ jobs:
           org.opencontainers.image.revision=${{ github.sha }}
 
     - name: Build and push regctl alpine
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       id: build-regctl-alpine
       with:
         context: .
@@ -158,7 +159,7 @@ jobs:
           org.opencontainers.image.revision=${{ github.sha }}
 
     - name: Build and push regsync scratch
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       id: build-regsync-scratch
       with:
         context: .
@@ -178,7 +179,7 @@ jobs:
           org.opencontainers.image.revision=${{ github.sha }}
 
     - name: Build and push regsync alpine
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       id: build-regsync-alpine
       with:
         context: .
@@ -198,7 +199,7 @@ jobs:
           org.opencontainers.image.revision=${{ github.sha }}
 
     - name: Build and push regbot scratch
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       id: build-regbot-scratch
       with:
         context: .
@@ -218,7 +219,7 @@ jobs:
           org.opencontainers.image.revision=${{ github.sha }}
 
     - name: Build and push regbot alpine
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       id: build-regbot-alpine
       with:
         context: .

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,12 +14,16 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    steps:
+    strategy:
+      matrix:
+        gover: ["1.17", "1.18", "1.19"]
+        releasever: ["1.19"]
 
-    - name: Set up Go 1.18
+    steps:
+    - name: "Set up Go ${{ matrix.gover }}"
       uses: actions/setup-go@v3
       with:
-        go-version: 1.18.x
+        go-version: "${{ matrix.gover }}.x"
       id: go
 
     - name: Check out code
@@ -46,7 +50,7 @@ jobs:
       run: make artifacts
 
     - name: Gather release details
-      if: startsWith( github.ref, 'refs/tags/v' ) && github.repository_owner == 'regclient'
+      if: startsWith( github.ref, 'refs/tags/v' ) && github.repository_owner == 'regclient' && matrix.gover == matrix.releasever
       id: release_details
       run: |
         VERSION=${GITHUB_REF#refs/tags/}
@@ -64,7 +68,7 @@ jobs:
         echo ::set-output name=release_notes::${RELEASE_NOTES}
 
     - name: Create release
-      if: steps.release_details.outputs.valid == 'true'
+      if: steps.release_details.outputs.valid == 'true' && matrix.gover == matrix.releasever
       id: release_create
       uses: softprops/action-gh-release@v1
       env:
@@ -98,9 +102,9 @@ jobs:
           ./artifacts/regsync-windows-amd64.exe
 
     - name: Save artifacts
-      if: github.ref == 'refs/heads/main'
-      uses: actions/upload-artifact@v2
+      if: github.ref == 'refs/heads/main' && matrix.gover == matrix.releasever
+      uses: actions/upload-artifact@v3
       with:
         name: binaries
         path: ./artifacts/
-        retention-days: 7
+        retention-days: 30

--- a/blob_test.go
+++ b/blob_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -189,7 +189,7 @@ func TestBlobGet(t *testing.T) {
 			return
 		}
 		defer br.Close()
-		brBlob, err := ioutil.ReadAll(br)
+		brBlob, err := io.ReadAll(br)
 		if err != nil {
 			t.Errorf("Failed reading blob: %v", err)
 			return
@@ -216,7 +216,7 @@ func TestBlobGet(t *testing.T) {
 			return
 		}
 		defer br.Close()
-		brBlob, err := ioutil.ReadAll(br)
+		brBlob, err := io.ReadAll(br)
 		if err != nil {
 			t.Errorf("Failed reading blob: %v", err)
 			return
@@ -269,7 +269,7 @@ func TestBlobGet(t *testing.T) {
 			return
 		}
 		defer br.Close()
-		brBlob, err := ioutil.ReadAll(br)
+		brBlob, err := io.ReadAll(br)
 		if err != nil {
 			t.Errorf("Failed reading blob: %v", err)
 			return

--- a/build/Dockerfile.regbot
+++ b/build/Dockerfile.regbot
@@ -1,6 +1,6 @@
 ARG REGISTRY=docker.io
 ARG ALPINE_VER=3
-ARG GO_VER=1.18-alpine
+ARG GO_VER=1.19-alpine
 
 FROM ${REGISTRY}/library/golang:${GO_VER} as golang
 RUN apk add --no-cache \

--- a/build/Dockerfile.regbot.buildkit
+++ b/build/Dockerfile.regbot.buildkit
@@ -2,7 +2,7 @@
 
 ARG REGISTRY=docker.io
 ARG ALPINE_VER=3
-ARG GO_VER=1.18-alpine
+ARG GO_VER=1.19-alpine
 
 FROM --platform=$BUILDPLATFORM ${REGISTRY}/library/golang:${GO_VER} as golang
 RUN apk add --no-cache \

--- a/build/Dockerfile.regctl
+++ b/build/Dockerfile.regctl
@@ -1,6 +1,6 @@
 ARG REGISTRY=docker.io
 ARG ALPINE_VER=3
-ARG GO_VER=1.18-alpine
+ARG GO_VER=1.19-alpine
 
 FROM ${REGISTRY}/library/golang:${GO_VER} as golang
 RUN apk add --no-cache \

--- a/build/Dockerfile.regctl.buildkit
+++ b/build/Dockerfile.regctl.buildkit
@@ -2,7 +2,7 @@
 
 ARG REGISTRY=docker.io
 ARG ALPINE_VER=3
-ARG GO_VER=1.18-alpine
+ARG GO_VER=1.19-alpine
 
 FROM --platform=$BUILDPLATFORM ${REGISTRY}/library/golang:${GO_VER} as golang
 RUN apk add --no-cache \

--- a/build/Dockerfile.regsync
+++ b/build/Dockerfile.regsync
@@ -1,6 +1,6 @@
 ARG REGISTRY=docker.io
 ARG ALPINE_VER=3
-ARG GO_VER=1.18-alpine
+ARG GO_VER=1.19-alpine
 
 FROM ${REGISTRY}/library/golang:${GO_VER} as golang
 RUN apk add --no-cache \

--- a/build/Dockerfile.regsync.buildkit
+++ b/build/Dockerfile.regsync.buildkit
@@ -2,7 +2,7 @@
 
 ARG REGISTRY=docker.io
 ARG ALPINE_VER=3
-ARG GO_VER=1.18-alpine
+ARG GO_VER=1.19-alpine
 
 FROM --platform=$BUILDPLATFORM ${REGISTRY}/library/golang:${GO_VER} as golang
 RUN apk add --no-cache \

--- a/cmd/regctl/manifest.go
+++ b/cmd/regctl/manifest.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 
@@ -379,7 +379,7 @@ func runManifestPut(cmd *cobra.Command, args []string) error {
 	rc := newRegClient()
 	defer rc.Close(ctx, r)
 
-	raw, err := ioutil.ReadAll(os.Stdin)
+	raw, err := io.ReadAll(os.Stdin)
 	if err != nil {
 		return err
 	}

--- a/config/credhelper_test.go
+++ b/config/credhelper_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -51,8 +52,13 @@ func TestCredHelper(t *testing.T) {
 			expectErr:  true,
 		},
 	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Errorf("failed checking current directory: %v", err)
+		return
+	}
 	curPath := os.Getenv("PATH")
-	os.Setenv("PATH", "testdata"+string(os.PathListSeparator)+curPath)
+	os.Setenv("PATH", filepath.Join(cwd, "testdata")+string(os.PathListSeparator)+curPath)
 	defer os.Setenv("PATH", curPath)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/config/host_test.go
+++ b/config/host_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"encoding/json"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -10,8 +11,13 @@ import (
 )
 
 func TestConfig(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Errorf("failed checking current directory: %v", err)
+		return
+	}
 	curPath := os.Getenv("PATH")
-	os.Setenv("PATH", "testdata"+string(os.PathListSeparator)+curPath)
+	os.Setenv("PATH", filepath.Join(cwd, "testdata")+string(os.PathListSeparator)+curPath)
 	defer os.Setenv("PATH", curPath)
 
 	// generate new/blank
@@ -58,7 +64,7 @@ func TestConfig(t *testing.T) {
 	}
 	`
 	var exHost, exHost2, exHostCredHelper Host
-	err := json.Unmarshal([]byte(exJSON), &exHost)
+	err = json.Unmarshal([]byte(exJSON), &exHost)
 	if err != nil {
 		t.Errorf("failed unmarshaling exJson: %v", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/regclient/regclient
 
-go 1.18
+go 1.19
 
 require (
 	github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7

--- a/image.go
+++ b/image.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"path/filepath"
 	"strings"
 	"time"
@@ -830,7 +829,7 @@ func (rc *RegClient) imageImportOCIHandleManifest(ctx context.Context, ref ref.R
 		filename := tarOCILayoutDescPath(d)
 		if !trd.processed[filename] && trd.handlers[filename] == nil {
 			trd.handlers[filename] = func(header *tar.Header, trd *tarReadData) error {
-				b, err := ioutil.ReadAll(trd.tr)
+				b, err := io.ReadAll(trd.tr)
 				if err != nil {
 					return err
 				}
@@ -1051,7 +1050,7 @@ func (trd *tarReadData) tarReadAll(rs io.ReadSeeker) error {
 
 // tarReadFileJSON reads the current tar entry and unmarshals json into provided interface
 func (trd *tarReadData) tarReadFileJSON(data interface{}) error {
-	b, err := ioutil.ReadAll(trd.tr)
+	b, err := io.ReadAll(trd.tr)
 	if err != nil {
 		return err
 	}

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -6,7 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -825,7 +825,7 @@ func (j *JWTHubHandler) ProcessChallenge(c Challenge) error {
 		return err
 	}
 	defer resp.Body.Close()
-	body, _ := ioutil.ReadAll(resp.Body)
+	body, _ := io.ReadAll(resp.Body)
 
 	if resp.StatusCode != 200 || resp.StatusCode >= 300 {
 		return ErrUnauthorized

--- a/internal/reqresp/reqresp.go
+++ b/internal/reqresp/reqresp.go
@@ -4,7 +4,6 @@ package reqresp
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"regexp"
@@ -91,7 +90,7 @@ func stateMatch(state string, list []string) bool {
 }
 
 func (r *rrHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
-	reqBody, err := ioutil.ReadAll(req.Body)
+	reqBody, err := io.ReadAll(req.Body)
 	if err != nil {
 		r.t.Errorf("Error reading request body: %v", err)
 		rw.WriteHeader(http.StatusInternalServerError)

--- a/internal/retryable/retryable.go
+++ b/internal/retryable/retryable.go
@@ -7,6 +7,7 @@ package retryable
 import (
 	"bytes"
 	"context"
+	"os"
 	"sync"
 
 	// crypto libraries included for go-digest
@@ -16,7 +17,6 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"time"
@@ -78,7 +78,7 @@ func NewRetryable(opts ...Opts) Retryable {
 		limit:      defaultLimit,
 		delayInit:  defaultDelayInit,
 		delayMax:   defaultDelayMax,
-		log:        &logrus.Logger{Out: ioutil.Discard},
+		log:        &logrus.Logger{Out: io.Discard},
 		rootCAPool: [][]byte{},
 	}
 
@@ -140,7 +140,7 @@ func WithCerts(certs [][]byte) Opts {
 func WithCertFiles(files []string) Opts {
 	return func(r *retryable) {
 		for _, f := range files {
-			c, err := ioutil.ReadFile(f)
+			c, err := os.ReadFile(f)
 			if err != nil {
 				r.log.WithFields(logrus.Fields{
 					"err":  err,
@@ -311,7 +311,7 @@ func WithBodyBytes(body []byte) OptsReq {
 	return func(req *request) {
 		req.contentLen = int64(len(body))
 		req.getBody = func() (io.ReadCloser, error) {
-			return ioutil.NopCloser(bytes.NewReader(body)), nil
+			return io.NopCloser(bytes.NewReader(body)), nil
 		}
 	}
 }
@@ -485,7 +485,7 @@ func (req *request) retryLoop() error {
 			}).Debug("Gateway timeout")
 			runBackoff = true
 		default:
-			body, _ := ioutil.ReadAll(lastResp.Body)
+			body, _ := io.ReadAll(lastResp.Body)
 			req.log.WithFields(logrus.Fields{
 				"URL":    lastURL.String(),
 				"Status": lastResp.Status,

--- a/internal/wraperr/error.go
+++ b/internal/wraperr/error.go
@@ -5,13 +5,14 @@ package wraperr
 // WrapErr wraps an underlying error with another error
 //
 // Example usage:
-//   var ErrLimit = errors.New("Limit reached")
-//   ...
-//   func someFunc() error {
-//     return wrapper.WrapErr{Err: fmt.Errorf("Limit %d reached on %s", limit, instance), Wrap: ErrLimit}
-//   }
-//   ...
-//   if errors.Is(err, ErrLimit) { ... }
+//
+//	var ErrLimit = errors.New("Limit reached")
+//	...
+//	func someFunc() error {
+//	  return wrapper.WrapErr{Err: fmt.Errorf("Limit %d reached on %s", limit, instance), Wrap: ErrLimit}
+//	}
+//	...
+//	if errors.Is(err, ErrLimit) { ... }
 //
 // This makes it easier to include a custom error message while also allowing
 type WrapErr struct {

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"strings"
@@ -23,7 +22,7 @@ var tmplFuncs = gotemplate.FuncMap{
 		return os.Getenv(key)
 	},
 	"file": func(filename string) string {
-		b, err := ioutil.ReadFile(filename)
+		b, err := os.ReadFile(filename)
 		if err != nil {
 			return ""
 		}

--- a/regclient.go
+++ b/regclient.go
@@ -5,8 +5,8 @@ import (
 	"embed"
 	"encoding/json"
 	"errors"
+	"io"
 	"io/fs"
-	"io/ioutil"
 	"time"
 
 	"fmt"
@@ -66,7 +66,7 @@ func New(opts ...Opt) *RegClient {
 		hosts:     map[string]*config.Host{},
 		userAgent: DefaultUserAgent,
 		// logging is disabled by default
-		log:     &logrus.Logger{Out: ioutil.Discard},
+		log:     &logrus.Logger{Out: io.Discard},
 		regOpts: []reg.Opts{},
 		schemes: map[string]scheme.API{},
 		fs:      rwfs.OSNew(""),

--- a/scheme/ocidir/ocidir.go
+++ b/scheme/ocidir/ocidir.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"path"
 	"strings"
 	"sync"
@@ -47,7 +46,7 @@ type Opts func(*ociConf)
 // New creates a new OCIDir with options
 func New(opts ...Opts) *OCIDir {
 	conf := ociConf{
-		log: &logrus.Logger{Out: ioutil.Discard},
+		log: &logrus.Logger{Out: io.Discard},
 		gc:  true,
 	}
 	for _, opt := range opts {

--- a/scheme/reg/blob.go
+++ b/scheme/reg/blob.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 
@@ -345,7 +344,7 @@ func (reg *Reg) blobPutUploadFull(ctx context.Context, r ref.Ref, d types.Descri
 			}
 		}
 		readOnce = true
-		return ioutil.NopCloser(rdr), nil
+		return io.NopCloser(rdr), nil
 	}
 
 	// build/send request
@@ -399,7 +398,7 @@ func (reg *Reg) blobPutUploadChunked(ctx context.Context, r ref.Ref, putURL *url
 		if err != nil {
 			return nil, err
 		}
-		return ioutil.NopCloser(bufRdr), nil
+		return io.NopCloser(bufRdr), nil
 	}
 	chunkURL := *putURL
 

--- a/scheme/reg/blob_test.go
+++ b/scheme/reg/blob_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -242,7 +242,7 @@ func TestBlobGet(t *testing.T) {
 			return
 		}
 		defer br.Close()
-		brBlob, err := ioutil.ReadAll(br)
+		brBlob, err := io.ReadAll(br)
 		if err != nil {
 			t.Errorf("Failed reading blob: %v", err)
 			return
@@ -280,7 +280,7 @@ func TestBlobGet(t *testing.T) {
 			return
 		}
 		defer br.Close()
-		brBlob, err := ioutil.ReadAll(br)
+		brBlob, err := io.ReadAll(br)
 		if err != nil {
 			t.Errorf("Failed reading external blob: %v", err)
 			return
@@ -333,7 +333,7 @@ func TestBlobGet(t *testing.T) {
 			return
 		}
 		defer br.Close()
-		brBlob, err := ioutil.ReadAll(br)
+		brBlob, err := io.ReadAll(br)
 		if err != nil {
 			t.Errorf("Failed reading blob: %v", err)
 			return

--- a/scheme/reg/repo.go
+++ b/scheme/reg/repo.go
@@ -3,7 +3,7 @@ package reg
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -55,7 +55,7 @@ func (reg *Reg) RepoList(ctx context.Context, hostname string, opts ...scheme.Re
 		return nil, fmt.Errorf("failed to list repositories for %s: %w", hostname, reghttp.HTTPError(resp.HTTPResponse().StatusCode))
 	}
 
-	respBody, err := ioutil.ReadAll(resp)
+	respBody, err := io.ReadAll(resp)
 	if err != nil {
 		reg.log.WithFields(logrus.Fields{
 			"err":  err,

--- a/scheme/reg/tag.go
+++ b/scheme/reg/tag.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -251,7 +251,7 @@ func (reg *Reg) tagListOCI(ctx context.Context, r ref.Ref, config scheme.TagConf
 	if resp.HTTPResponse().StatusCode != 200 {
 		return nil, fmt.Errorf("failed to list tags for %s: %w", r.CommonName(), reghttp.HTTPError(resp.HTTPResponse().StatusCode))
 	}
-	respBody, err := ioutil.ReadAll(resp)
+	respBody, err := io.ReadAll(resp)
 	if err != nil {
 		reg.log.WithFields(logrus.Fields{
 			"err": err,
@@ -299,7 +299,7 @@ func (reg *Reg) tagListLink(ctx context.Context, r ref.Ref, config scheme.TagCon
 	if resp.HTTPResponse().StatusCode != 200 {
 		return nil, fmt.Errorf("failed to list tags for %s: %w", r.CommonName(), reghttp.HTTPError(resp.HTTPResponse().StatusCode))
 	}
-	respBody, err := ioutil.ReadAll(resp)
+	respBody, err := io.ReadAll(resp)
 	if err != nil {
 		reg.log.WithFields(logrus.Fields{
 			"err": err,

--- a/types/blob/reader.go
+++ b/types/blob/reader.go
@@ -3,7 +3,6 @@ package blob
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strconv"
 
 	// crypto libraries included for go-digest
@@ -90,7 +89,7 @@ func (b *reader) Close() error {
 
 // RawBody returns the original body from the request
 func (b *reader) RawBody() ([]byte, error) {
-	return ioutil.ReadAll(b)
+	return io.ReadAll(b)
 }
 
 // Read passes through the read operation while computing the digest and tracking the size
@@ -152,7 +151,7 @@ func (b *reader) ToOCIConfig() (OCIConfig, error) {
 	if b.readBytes != 0 {
 		return nil, fmt.Errorf("unable to convert after read has been performed")
 	}
-	blobBody, err := ioutil.ReadAll(b)
+	blobBody, err := io.ReadAll(b)
 	if err != nil {
 		return nil, fmt.Errorf("error reading image config for %s: %w", b.r.CommonName(), err)
 	}

--- a/types/blob/tar.go
+++ b/types/blob/tar.go
@@ -4,7 +4,6 @@ import (
 	"archive/tar"
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"github.com/opencontainers/go-digest"
 	"github.com/regclient/regclient/pkg/archive"
@@ -93,7 +92,7 @@ func (tr *tarReader) RawBody() ([]byte, error) {
 	if tr.tr != nil {
 		return []byte{}, fmt.Errorf("RawBody cannot be returned after TarReader returned")
 	}
-	b, err := ioutil.ReadAll(tr.reader)
+	b, err := io.ReadAll(tr.reader)
 	if err != nil {
 		return b, err
 	}


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This bumps Go to 1.19 and several Github Actions versions. Deprecated methods from `ioutil` were fixed.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

No visible change, nothing should break.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Upgrade to Go 1.19
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
