### PR TITLE
Descriptor compare allows OCI conversion

### DIFF
--- a/types/descriptor.go
+++ b/types/descriptor.go
@@ -46,6 +46,20 @@ type Descriptor struct {
 }
 
 var emptyDigest = digest.FromBytes([]byte{})
+var mtToOCI map[string]string
+
+func init() {
+	mtToOCI = map[string]string{
+		MediaTypeDocker2ManifestList: MediaTypeOCI1ManifestList,
+		MediaTypeDocker2Manifest:     MediaTypeOCI1Manifest,
+		MediaTypeDocker2ImageConfig:  MediaTypeOCI1ImageConfig,
+		MediaTypeDocker2LayerGzip:    MediaTypeOCI1LayerGzip,
+		MediaTypeOCI1ManifestList:    MediaTypeOCI1ManifestList,
+		MediaTypeOCI1Manifest:        MediaTypeOCI1Manifest,
+		MediaTypeOCI1ImageConfig:     MediaTypeOCI1ImageConfig,
+		MediaTypeOCI1LayerGzip:       MediaTypeOCI1LayerGzip,
+	}
+}
 
 // GetData decodes the Data field from the descriptor if available
 func (d Descriptor) GetData() ([]byte, error) {
@@ -73,6 +87,9 @@ func (d Descriptor) GetData() ([]byte, error) {
 // Equal indicates the two descriptors are identical, effectively a DeepEqual.
 func (d Descriptor) Equal(d2 Descriptor) bool {
 	if !d.Same(d2) {
+		return false
+	}
+	if d.MediaType != d2.MediaType {
 		return false
 	}
 	if d.ArtifactType != d2.ArtifactType {
@@ -117,8 +134,16 @@ func (d Descriptor) Equal(d2 Descriptor) bool {
 // Same indicates two descriptors point to the same CAS object.
 // This verifies the digest, media type, and size all match
 func (d Descriptor) Same(d2 Descriptor) bool {
-	if d.Digest != d2.Digest || d.MediaType != d2.MediaType || d.Size != d2.Size {
+	if d.Digest != d2.Digest || d.Size != d2.Size {
 		return false
+	}
+	// loosen the check on media type since this can be converted from a build
+	if d.MediaType != d2.MediaType {
+		if _, ok := mtToOCI[d.MediaType]; !ok {
+			return false
+		} else if mtToOCI[d.MediaType] != mtToOCI[d2.MediaType] {
+			return false
+		}
 	}
 	return true
 }

--- a/types/descriptor_test.go
+++ b/types/descriptor_test.go
@@ -136,6 +136,21 @@ func TestDescriptorEq(t *testing.T) {
 			expectSame:  true,
 		},
 		{
+			name: "converting OCI media type",
+			d1: Descriptor{
+				MediaType: MediaTypeDocker2Manifest,
+				Size:      1234,
+				Digest:    digA,
+			},
+			d2: Descriptor{
+				MediaType: MediaTypeOCI1Manifest,
+				Size:      1234,
+				Digest:    digA,
+			},
+			expectEqual: false,
+			expectSame:  true,
+		},
+		{
 			name: "different media type",
 			d1: Descriptor{
 				MediaType: MediaTypeDocker2Manifest,


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Describe the change

When descriptors change the media type for OCI, the `Same` comparison should still match.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Compare two descriptors with the media type changed for OCI.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Descriptor comparison now allows for Docker to OCI conversion.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
