### PR TITLE
remove of 'darwin/arch' from platform.Local/Parse

### DIFF
--- a/types/platform/platform.go
+++ b/types/platform/platform.go
@@ -120,11 +120,13 @@ func Parse(platStr string) (Platform, error) {
 	}
 	switch plat.OS {
 	case "macos":
-		plat.OS = "darwin"
+		fallthrough
+	case "darwin":
+		plat.OS = "linux"
 	}
-	if len(platSplit) < 2 && plat.OS == runtime.GOOS {
+	if len(platSplit) < 2 && (plat.OS == runtime.GOOS || runtime.GOOS == "darwin") {
 		switch plat.OS {
-		case "linux", "darwin":
+		case "linux":
 			// automatically expand local architecture with recognized OS
 			plat.Architecture = platLocal.Architecture
 		case "windows":

--- a/types/platform/platform_other.go
+++ b/types/platform/platform_other.go
@@ -7,8 +7,19 @@ import "runtime"
 
 // Local retrieves the local platform details
 func Local() Platform {
+	var platform string
+	switch runtime.GOOS {
+	case "darwin":
+		// there are no darwin-docker images as macOS uses Docker for Mac based on linux
+		fallthrough
+	case "linux":
+		platform = "linux"
+	default:
+		platform = "other"
+	}
+
 	return Platform{
-		OS:           runtime.GOOS,
+		OS:           platform,
 		Architecture: runtime.GOARCH,
 		Variant:      cpuVariant(),
 	}


### PR DESCRIPTION
### Fixes issue

fixes: https://github.com/regclient/regclient/issues/297

### Describe the change

bug fix: unittest `cmd/regbot/regbot_test.py:TestRegbot` was breaking when run with MacOS/darwin, as platformStr argument isn't passed along and the test-data is hard-coded to linux-OS
The functionality of `types/platform.go:Local()` was changed. MacOS runs Docker with a Linux Hypervisor, so there is no docker/oci Platform `darwin/amd64` / `darwin/arm64` in reality.
The Issue was solved by rewriting `darwin` to `linux`

### How to verify it

Run Unittests

### Changelog text

- Local Platform Determination has been fixed for MacOS/Darwin. It defaults to Linux-Platform now

### Please verify and check that the pull request fulfills the following requirements

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

### Sidenote
This is my first PR and i'm open minded for discussion and feedback. Thank you very much for the awesome project
