### PR TITLE
Do not depend on local platform for regbot tests

### DIFF
--- a/cmd/regbot/regbot_test.go
+++ b/cmd/regbot/regbot_test.go
@@ -74,7 +74,8 @@ func TestRegbot(t *testing.T) {
 			script: ConfigScript{
 				Name: "GetConfig",
 				Script: `
-				ic = image.config("ocidir://testrepo:v1")
+				m = manifest.get("ocidir://testrepo:v1", "linux/amd64")
+				ic = image.config(m)
 				if ic.Config.Labels["version"] ~= "1" then
 				  log("Config version: " .. ic.Config.Labels["version"])
 					error "version label missing/invalid"


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Fixes #297
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

The regbot test should not depend on the local platform. This fetches a specific platform manifest.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

`go test ./cmd/regbot`
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Fixing regbot tests to run on other platforms
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
