### PR TITLE
Fallback to linux platforms for mac and windows

### DIFF
--- a/types/manifest/manifest.go
+++ b/types/manifest/manifest.go
@@ -547,6 +547,12 @@ func getPlatformDesc(p *platform.Platform, dl []types.Descriptor) (*types.Descri
 			return &d, nil
 		}
 	}
+	// if no platforms match, fall back to searching for a compatible platform (Mac runs Linux images)
+	for _, d := range dl {
+		if d.Platform != nil && platform.Compatible(*p, *d.Platform) {
+			return &d, nil
+		}
+	}
 	return nil, wraperr.New(fmt.Errorf("platform not found: %s", *p), types.ErrNotFound)
 }
 

--- a/types/platform/platform.go
+++ b/types/platform/platform.go
@@ -62,6 +62,35 @@ func (p Platform) String() string {
 	}
 }
 
+// Compatible indicates if a host can run a specified target platform image.
+// This accounts for Docker Desktop for Mac and Windows using a Linux VM.
+func Compatible(host, target Platform) bool {
+	(&host).normalize()
+	(&target).normalize()
+	if host.OS == "linux" {
+		return host.OS == target.OS && host.Architecture == target.Architecture && host.Variant == target.Variant
+	} else if host.OS == "windows" {
+		if target.OS == "windows" {
+			return host.Architecture == target.Architecture && host.Variant == target.Variant &&
+				prefix(host.OSVersion) == prefix(target.OSVersion)
+		} else if target.OS == "linux" {
+			return host.Architecture == target.Architecture && host.Variant == target.Variant
+		}
+		return false
+	} else if host.OS == "darwin" {
+		if target.OS == "darwin" || target.OS == "linux" {
+			return host.Architecture == target.Architecture && host.Variant == target.Variant
+		}
+		return false
+	} else {
+		return host.Architecture == target.Architecture &&
+			host.OSVersion == target.OSVersion &&
+			strSliceEq(host.OSFeatures, target.OSFeatures) &&
+			host.Variant == target.Variant &&
+			strSliceEq(host.Features, target.Features)
+	}
+}
+
 // Match indicates if two platforms are the same
 func Match(a, b Platform) bool {
 	(&a).normalize()

--- a/types/platform/platform_test.go
+++ b/types/platform/platform_test.go
@@ -5,72 +5,107 @@ import (
 	"testing"
 )
 
-func TestMatch(t *testing.T) {
+func TestCompare(t *testing.T) {
 	tests := []struct {
-		name   string
-		a, b   Platform
-		expect bool
+		name         string
+		a, b         Platform
+		expectMatch  bool
+		expectCompat bool
 	}{
 		{
-			name:   "linux match",
-			a:      Platform{OS: "linux", Architecture: "amd64"},
-			b:      Platform{OS: "linux", Architecture: "amd64"},
-			expect: true,
+			name:         "linux match",
+			a:            Platform{OS: "linux", Architecture: "amd64"},
+			b:            Platform{OS: "linux", Architecture: "amd64"},
+			expectMatch:  true,
+			expectCompat: true,
 		},
 		{
-			name:   "linux arch",
-			a:      Platform{OS: "linux", Architecture: "amd64"},
-			b:      Platform{OS: "linux", Architecture: "arm64"},
-			expect: false,
+			name:         "linux arch",
+			a:            Platform{OS: "linux", Architecture: "amd64"},
+			b:            Platform{OS: "linux", Architecture: "arm64"},
+			expectMatch:  false,
+			expectCompat: false,
 		},
 		{
-			name:   "linux normalized",
-			a:      Platform{OS: "linux", Architecture: "arm64"},
-			b:      Platform{OS: "linux", Architecture: "arm64", Variant: "v8"},
-			expect: true,
+			name:         "linux normalized",
+			a:            Platform{OS: "linux", Architecture: "arm64"},
+			b:            Platform{OS: "linux", Architecture: "arm64", Variant: "v8"},
+			expectMatch:  true,
+			expectCompat: true,
 		},
 		{
-			name:   "linux variant",
-			a:      Platform{OS: "linux", Architecture: "arm", Variant: "v6"},
-			b:      Platform{OS: "linux", Architecture: "arm", Variant: "v7"},
-			expect: false,
+			name:         "linux variant",
+			a:            Platform{OS: "linux", Architecture: "arm", Variant: "v6"},
+			b:            Platform{OS: "linux", Architecture: "arm", Variant: "v7"},
+			expectMatch:  false,
+			expectCompat: false,
 		},
 		{
-			name:   "windows match",
-			a:      Platform{OS: "windows", Architecture: "amd64", OSVersion: "10.0.17763.2114"},
-			b:      Platform{OS: "windows", Architecture: "amd64", OSVersion: "10.0.17763.2114"},
-			expect: true,
+			name:         "windows match",
+			a:            Platform{OS: "windows", Architecture: "amd64", OSVersion: "10.0.17763.2114"},
+			b:            Platform{OS: "windows", Architecture: "amd64", OSVersion: "10.0.17763.2114"},
+			expectMatch:  true,
+			expectCompat: true,
 		},
 		{
-			name:   "windows patch",
-			a:      Platform{OS: "windows", Architecture: "amd64", OSVersion: "10.0.17763.2014"},
-			b:      Platform{OS: "windows", Architecture: "amd64", OSVersion: "10.0.17763.2114"},
-			expect: true,
+			name:         "windows patch",
+			a:            Platform{OS: "windows", Architecture: "amd64", OSVersion: "10.0.17763.2014"},
+			b:            Platform{OS: "windows", Architecture: "amd64", OSVersion: "10.0.17763.2114"},
+			expectMatch:  true,
+			expectCompat: true,
 		},
 		{
-			name:   "windows minor",
-			a:      Platform{OS: "windows", Architecture: "amd64", OSVersion: "10.0.14393.4583"},
-			b:      Platform{OS: "windows", Architecture: "amd64", OSVersion: "10.0.17763.2114"},
-			expect: false,
+			name:         "windows minor",
+			a:            Platform{OS: "windows", Architecture: "amd64", OSVersion: "10.0.14393.4583"},
+			b:            Platform{OS: "windows", Architecture: "amd64", OSVersion: "10.0.17763.2114"},
+			expectMatch:  false,
+			expectCompat: false,
 		},
 		{
-			name:   "other",
-			a:      Platform{OS: "other", Architecture: "amd64", Variant: "42"},
-			b:      Platform{OS: "other", Architecture: "amd64", Variant: "42"},
-			expect: true,
+			name:         "darwin compatible",
+			a:            Platform{OS: "darwin", Architecture: "amd64"},
+			b:            Platform{OS: "linux", Architecture: "amd64"},
+			expectMatch:  false,
+			expectCompat: true,
 		},
 		{
-			name:   "other variant",
-			a:      Platform{OS: "other", Architecture: "amd64", Variant: "42"},
-			b:      Platform{OS: "other", Architecture: "amd64", Variant: "45"},
-			expect: false,
+			name:         "darwin target",
+			a:            Platform{OS: "linux", Architecture: "amd64"},
+			b:            Platform{OS: "darwin", Architecture: "amd64"},
+			expectMatch:  false,
+			expectCompat: false,
+		},
+		{
+			name:         "windows compatible",
+			a:            Platform{OS: "windows", Architecture: "amd64"},
+			b:            Platform{OS: "linux", Architecture: "amd64"},
+			expectMatch:  false,
+			expectCompat: true,
+		},
+		{
+			name:         "other",
+			a:            Platform{OS: "other", Architecture: "amd64", Variant: "42"},
+			b:            Platform{OS: "other", Architecture: "amd64", Variant: "42"},
+			expectMatch:  true,
+			expectCompat: true,
+		},
+		{
+			name:         "other variant",
+			a:            Platform{OS: "other", Architecture: "amd64", Variant: "42"},
+			b:            Platform{OS: "other", Architecture: "amd64", Variant: "45"},
+			expectMatch:  false,
+			expectCompat: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := Match(tt.a, tt.b)
-			if result != tt.expect {
+			if result != tt.expectMatch {
 				t.Errorf("unexpected match, result: %v, a: %v, b: %v", result, tt.a, tt.b)
+			}
+			result = Compatible(tt.a, tt.b)
+			if result != tt.expectCompat {
+				t.Errorf("unexpected compatible, result: %v, a: %v, b: %v", result, tt.a, tt.b)
 			}
 		})
 	}


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

When fetching the local platform on mac or windows, this will fail even when Linux images are available for those architectures.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This adds a second comparison for compatible platforms and a fall back query for manifest lists. The exact match is still preferred, and the fall back is only used when an exact match cannot be found.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```
regctl manifest get alpine --platform darwin/amd64
```

<!-- Include steps that can be taken to verify the change -->

### Changelog text

Fallback to using linux platforms on mac and windows when querying manifest lists
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
