### PR TITLE
Using runtime/debug for git version details

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,7 +3,6 @@
 !build/root.tgz
 !cmd/
 !config/
-!embed/
 !internal/
 !mod/
 !pkg/

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -90,9 +90,6 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v3
 
-    - name: Set embed/version.json
-      run: make embed/version.json
-
     # qemu is not needed for Go cross compiling
     # - name: Set up QEMU
     #   uses: docker/setup-qemu-action@v1

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,3 @@ hack
 artifacts/
 bin/
 vendor/
-embed/version.json
-cmd/**/embed/version.json

--- a/cmd/regbot/embed/.git-keep
+++ b/cmd/regbot/embed/.git-keep
@@ -1,2 +1,0 @@
-This folder should not be deleted.
-The Makefile will create a version.json for including versions in binaries.

--- a/cmd/regctl/embed/.git-keep
+++ b/cmd/regctl/embed/.git-keep
@@ -1,2 +1,0 @@
-This folder should not be deleted.
-The Makefile will create a version.json for including versions in binaries.

--- a/cmd/regsync/embed/.git-keep
+++ b/cmd/regsync/embed/.git-keep
@@ -1,2 +1,0 @@
-This folder should not be deleted.
-The Makefile will create a version.json for including versions in binaries.

--- a/embed/.git-keep
+++ b/embed/.git-keep
@@ -1,2 +1,0 @@
-This folder should not be deleted.
-The Makefile will create a version.json for including versions in binaries.

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,31 @@
+// Package version returns details on the Go and Git repo used in the build
+package version
+
+import (
+	"bytes"
+	"fmt"
+	"text/tabwriter"
+)
+
+const (
+	stateClean    = "clean"
+	stateDirty    = "dirty"
+	unknown       = "unknown"
+	biVCSDate     = "vcs.time"
+	biVCSCommit   = "vcs.revision"
+	biVCSModified = "vcs.modified"
+)
+
+func (i Info) MarshalPretty() ([]byte, error) {
+	buf := &bytes.Buffer{}
+	tw := tabwriter.NewWriter(buf, 0, 0, 1, ' ', 0)
+	fmt.Fprintf(tw, "VCSRef:\t%s\n", i.VCSRef)
+	fmt.Fprintf(tw, "VCSCommit:\t%s\n", i.VCSCommit)
+	fmt.Fprintf(tw, "VCSState:\t%s\n", i.VCSState)
+	fmt.Fprintf(tw, "VCSDate:\t%s\n", i.VCSDate)
+	fmt.Fprintf(tw, "Platform:\t%s\n", i.Platform)
+	fmt.Fprintf(tw, "GoVer:\t%s\n", i.GoVer)
+	fmt.Fprintf(tw, "GoCompiler:\t%s\n", i.GoCompiler)
+	tw.Flush()
+	return buf.Bytes(), nil
+}

--- a/internal/version/version_buildinfo.go
+++ b/internal/version/version_buildinfo.go
@@ -1,0 +1,70 @@
+//go:build go1.18
+// +build go1.18
+
+package version
+
+import (
+	"fmt"
+	"runtime"
+	"runtime/debug"
+	"time"
+)
+
+type Info struct {
+	GoVer      string           `json:"goVersion"`       // go version
+	GoCompiler string           `json:"goCompiler"`      // go compiler
+	Platform   string           `json:"platform"`        // os/arch
+	VCSCommit  string           `json:"vcsCommit"`       // commit sha
+	VCSDate    string           `json:"vcsDate"`         // commit date in RFC3339 format
+	VCSRef     string           `json:"vcsRef"`          // commit sha + dirty if state is not clean
+	VCSState   string           `json:"vcsState"`        // clean or dirty
+	VCSTag     string           `json:"-"`               // tag is not available from Go
+	Debug      *debug.BuildInfo `json:"debug,omitempty"` // build info debugging data
+}
+
+func GetInfo() Info {
+	i := Info{
+		GoVer:     unknown,
+		Platform:  unknown,
+		VCSCommit: unknown,
+		VCSDate:   unknown,
+		VCSRef:    unknown,
+		VCSState:  unknown,
+		VCSTag:    "",
+	}
+
+	i.GoVer = runtime.Version()
+	i.GoCompiler = runtime.Compiler
+	i.Platform = fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH)
+
+	if bi, ok := debug.ReadBuildInfo(); ok && bi != nil {
+		i.Debug = bi
+		date := biSetting(bi, biVCSDate)
+		if t, err := time.Parse(time.RFC3339, date); err == nil {
+			i.VCSDate = t.UTC().Format(time.RFC3339)
+		}
+		i.VCSCommit = biSetting(bi, biVCSCommit)
+		i.VCSRef = i.VCSCommit
+		modified := biSetting(bi, biVCSModified)
+		if modified == "true" {
+			i.VCSState = stateDirty
+			i.VCSRef += "-" + stateDirty
+		} else if modified == "false" {
+			i.VCSState = stateClean
+		}
+	}
+
+	return i
+}
+
+func biSetting(bi *debug.BuildInfo, key string) string {
+	if bi == nil {
+		return unknown
+	}
+	for _, setting := range bi.Settings {
+		if setting.Key == key {
+			return setting.Value
+		}
+	}
+	return unknown
+}

--- a/internal/version/version_old.go
+++ b/internal/version/version_old.go
@@ -1,0 +1,38 @@
+//go:build !go1.18
+// +build !go1.18
+
+package version
+
+import (
+	"fmt"
+	"runtime"
+)
+
+type Info struct {
+	GoVer      string `json:"goVersion"`  // go version
+	GoCompiler string `json:"goCompiler"` // go compiler
+	Platform   string `json:"platform"`   // os/arch
+	VCSCommit  string `json:"vcsCommit"`  // commit sha
+	VCSDate    string `json:"vcsDate"`    // commit date in RFC3339 format
+	VCSRef     string `json:"vcsRef"`     // commit sha + dirty if state is not clean
+	VCSState   string `json:"vcsState"`   // clean or dirty
+	VCSTag     string `json:"-"`          // tag
+}
+
+func GetInfo() Info {
+	i := Info{
+		GoVer:     unknown,
+		Platform:  unknown,
+		VCSCommit: unknown,
+		VCSDate:   unknown,
+		VCSRef:    unknown,
+		VCSState:  unknown,
+		VCSTag:    "",
+	}
+
+	i.GoVer = runtime.Version()
+	i.GoCompiler = runtime.Compiler
+	i.Platform = fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH)
+
+	return i
+}

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,0 +1,16 @@
+package version
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestVersion(t *testing.T) {
+	i := GetInfo()
+	ij, err := json.MarshalIndent(i, "", "  ")
+	if err != nil {
+		t.Errorf("failed to marshal info: %v", err)
+		return
+	}
+	t.Logf("received info:\n%s", string(ij))
+}


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Fixes #304 
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This removes the `embed/version.json` and associated calls, replacing with `runtime/debug` calls.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```
$ regctl version 
VCSRef:     89bfc2db3b9eca816c970af951b0a5db7a7f7d3f     
VCSCommit:  89bfc2db3b9eca816c970af951b0a5db7a7f7d3f  
VCSState:   clean                               
VCSDate:    2022-09-21T00:10:00Z   
Platform:   linux/amd64                       
GoVer:      go1.19                                
GoCompiler: gc    
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Breaking: tag details are no longer available in version commands.
Breaking: `regclient.VCSRef` and `VCSTag` variables removed.
Breaking: detailed version support removed for Go 1.17 and earlier.

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
