### PR TITLE
Make image builds reproducible

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -119,11 +119,49 @@ jobs:
           org.opencontainers.image.version=${{ steps.prep.outputs.version }}
           org.opencontainers.image.revision=${{ github.sha }}
 
+    # Dogfooding, use regctl to modify regclient images to improve reproducibility
+    - name: Install regctl
+      uses: regclient/actions/regctl-installer@main
+      if: github.event_name != 'pull_request' && github.repository_owner == 'regclient'
+      with:
+        release: main
+
+    - name: Mutate
+      if: github.event_name != 'pull_request' && github.repository_owner == 'regclient'
+      id: mutate
+      run: |
+        vcs_date="$(date -d "@$(git log -1 --format=%at)" +%Y-%m-%dT%H:%M:%SZ --utc)"
+        base_name=""
+        mkdir -p "output/${{matrix.image}}"
+        if [ "${{matrix.type}}" = "alpine" ]; then
+          base_name="alpine:3"
+          base_digest="$(regctl image digest "${base_name}")"
+        fi
+        # mutate the image locally
+        local_tag="ocidir://output:${{matrix.image}}:${{matrix.type}}"
+        regctl image copy "${{ steps.prep.outputs.image_ghcr }}@${{ steps.build.outputs.digest }}" "${local_tag}"
+        regctl image mod "${local_tag}" --replace \
+          --time-max "${vcs_date}" \
+          --annotation "oci.opencontainers.image.created=${vcs_date}" \
+          --annotation "oci.opencontainers.image.source=${{ github.repositoryUrl }}" \
+          --annotation "oci.opencontainers.image.revision=${{ github.sha }}"
+        if [ -n "$base_name" ] && [ -n "$base_digest" ]; then
+          regctl image mod "${local_tag}" --replace \
+            --annotation "oci.opencontainers.image.base.name=${base_name}" \
+            --annotation "oci.opencontainers.image.base.digest=${base_digest}"
+        fi
+        # loop over the tags
+        for tag in $(echo ${{ steps.prep.outputs.tags }} | tr , ' '); do
+          echo "Updating ${tag}"
+          regctl image copy "${local_tag}" "${tag}"
+        done
+        echo "::set-output name=digest::$(regctl image digest ${local_tag})"
+
     - name: Sign the container image
       if: github.event_name != 'pull_request' && github.repository_owner == 'regclient'
       env:
         # experimental support needed for GitHub OIDC signing
         COSIGN_EXPERIMENTAL: "true"
       run: |
-        cosign sign ${{ steps.prep.outputs.image_hub }}@${{ steps.build.outputs.digest }}
-        cosign sign ${{ steps.prep.outputs.image_ghcr }}@${{ steps.build.outputs.digest }}
+        cosign sign ${{ steps.prep.outputs.image_hub }}@${{ steps.mutate.outputs.digest }}
+        cosign sign ${{ steps.prep.outputs.image_ghcr }}@${{ steps.mutate.outputs.digest }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ hack
 /regctl
 artifacts/
 bin/
+output/
 vendor/

--- a/build/oci-image.sh
+++ b/build/oci-image.sh
@@ -1,0 +1,84 @@
+#!/bin/sh
+
+set -e
+image="regctl"
+platforms="linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/ppc64le,linux/s390x"
+base_name=""
+release="scratch"
+push_tags=""
+
+# CLI options to override image, platform, base digest, and comma separated list of tags to push
+opt_h=0
+while getopts 'b:d:hi:p:r:t:' option; do
+  case $option in
+    b) base_name="$OPTARG";;
+    d) base_digest="$OPTARG";;
+    h) opt_h=1;;
+    i) image="$OPTARG";;
+    p) platforms="$OPTARG";;
+    r) release="$OPTARG";;
+    t) push_tags="$OPTARG";;
+  esac
+done
+set +e
+shift $(expr $OPTIND - 1)
+if [ $# -gt 0 -o "$opt_h" = "1" ]; then
+  echo "Usage: $0 [opts]"
+  echo " -b: base image name"
+  echo " -d: base image digest"
+  echo " -h: this help message"
+  echo " -i: image to build (${image})"
+  echo " -p: platforms to build (${platforms})"
+  echo " -r: release target (${release})"
+  echo " -t: tags to push (comma separated image list)"
+  exit 1
+fi
+set -e
+
+# cd to repo root, gather details from git, and build images
+git_root="$(git rev-parse --show-toplevel)"
+cd "${git_root}"
+export PATH="$PATH:${git_root}/bin"
+vcs_date="$(date -d "@$(git log -1 --format=%at)" +%Y-%m-%dT%H:%M:%SZ --utc)"
+vcs_repo="https://github.com/regclient/regclient.git"
+vcs_sha="$(git rev-list -1 HEAD)"
+buildx_opts=""
+if [ -n "$base_name" ] && [ -z "$base_digest" ]; then
+  base_digest="$(regctl image digest "${base_name}")"
+  echo "Base image digest: ${base_digest}"
+elif [ -n "$base_name" ] && [ -n "$base_digest" ]; then
+  buildx_opts=--build-context "${base_name}=docker-image://${base_name}@${base_digest}"
+fi
+
+[ -d "output" ] || mkdir -p output
+docker buildx build --platform="$platforms" -f "build/Dockerfile.${image}.buildkit" \
+  -o "type=oci,dest=output/${image}-${release}.tar" --metadata-file "output/${image}-${release}.json" \
+  --target "release-${release}" ${buildx_opts} .
+echo "Importing tar"
+regctl image import "ocidir://output/${image}:${release}" "output/${image}-${release}.tar"
+echo "Modding image"
+regctl image mod \
+  "ocidir://output/${image}:${release}" --replace \
+  --time-max "${vcs_date}" \
+  --annotation "oci.opencontainers.image.created=${vcs_date}" \
+  --annotation "oci.opencontainers.image.source=${vcs_repo}" \
+  --annotation "oci.opencontainers.image.revision=${vcs_sha}" \
+  >/dev/null
+
+if [ -n "$base_name" ] && [ -n "$base_digest" ]; then
+  regctl image mod \
+    "ocidir://output/${image}:${release}" --replace \
+    --annotation "oci.opencontainers.image.base.name=${base_name}" \
+    --annotation "oci.opencontainers.image.base.digest=${base_digest}" \
+    >/dev/null
+fi
+
+echo "\033[32mDigest for ${image}-${release}:\033[0m $(regctl image digest "ocidir://output/${image}:${release}")"
+
+# split tags by comma and push each tag
+if [ -n "$push_tags" ]; then
+  for push_tag in $(echo "$push_tags" | tr , " "); do
+    echo "Push: ${push_tag}"
+    regctl image copy -v info "ocidir://output/${image}:${release}" "${push_tag}"
+  done
+fi


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Describe the change

This dogfoods regclient during the image build to backdate timestamps to the commit time and add various annotations with `regctl image mod`.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Unfortunately, this needs to be tested in prod after the merge.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Make image builds reproducible
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
