### PR TITLE
Disable build caching and align labels

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -65,7 +65,6 @@ jobs:
           fi
         fi
         echo "::set-output name=version::${VERSION}"
-        echo "::set-output name=cache::${GHCR_IMAGE}:buildcache${EXT}"
         echo "::set-output name=image_hub::${HUB_IMAGE}"
         echo "::set-output name=image_ghcr::${GHCR_IMAGE}"
         echo "::set-output name=tags::${TAGS}"
@@ -106,13 +105,8 @@ jobs:
         context: .
         file: ./build/Dockerfile.${{ matrix.image }}.buildkit
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/ppc64le,linux/s390x
-        push: ${{ github.event_name != 'pull_request' && github.repository_owner == 'regclient' }}
         target: release-${{ matrix.type }}
-        tags: ${{ steps.prep.outputs.tags }}
-        cache-from: type=registry,ref=${{ steps.prep.outputs.cache }}
-        cache-to: ${{ github.repository_owner == 'regclient' && format('type=registry,ref={0},mode=max', steps.prep.outputs.cache) || 'type=inline'}}
-        build-args: |
-          VCS_REF=${{ github.sha }}
+        output: "type=oci,dest=output/${{matrix.image}}-${{matrix.type}}.tar"
         labels: |
           org.opencontainers.image.created=${{ steps.prep.outputs.created }}
           org.opencontainers.image.source=${{ github.repositoryUrl }}
@@ -139,7 +133,8 @@ jobs:
         fi
         # mutate the image locally
         local_tag="ocidir://output/${{matrix.image}}:${{matrix.type}}"
-        regctl image copy "${{ steps.prep.outputs.image_ghcr }}@${{ steps.build.outputs.digest }}" "${local_tag}"
+        echo "Loading ${local_tag} from output/${{matrix.image}}-${{matrix.type}}.tar"
+        regctl image import "${local_tag}" "output/${{matrix.image}}-${{matrix.type}}.tar"
         regctl image mod "${local_tag}" --replace \
           --time-max "${vcs_date}" \
           --annotation "oci.opencontainers.image.created=${vcs_date}" \


### PR DESCRIPTION
This is needed for reproducibility since caching will pull in stale timestamps.

Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Builds are reproducible yet. Labels didn't match between the local and GHA builds, and layers had timestamps from cached builds.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This disables build caching and aligns the labels in the GHA and local builds.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Ideally, the images on the registry will be able to be reproduced with `make oci-image`.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
