### PR TITLE
Fixing image.version label on local builds

### DIFF
--- a/build/oci-image.sh
+++ b/build/oci-image.sh
@@ -48,7 +48,7 @@ if [ "${vcs_describe}" != "${vcs_describe#tags/}" ]; then
   vcs_version="${vcs_describe#tags/}"
 elif [ "${vcs_describe}" != "${vcs_describe#heads/}" ]; then
   vcs_version="${vcs_describe#heads/}"
-  if [ "main" = "$$vcs_version" ]; then
+  if [ "main" = "$vcs_version" ]; then
     vcs_version=edge
   fi
 fi


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

This fixes a small typo in `oci-image.sh` that caused the local image build to have the wrong label.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Typo fix.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

GHA docker images and locally build images should have the same digest.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
