### PR TITLE
Strip buildid from binaries to reproduce regbot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ ifneq ($(shell git status --porcelain 2>/dev/null),)
 endif
 VCS_DATE?=$(shell date -d "@$(shell git log -1 --format=%at)" +%Y-%m-%dT%H:%M:%SZ --utc)
 VCS_TAG?=$(shell git describe --tags --abbrev=0 2>/dev/null || true)
-LD_FLAGS?=-s -w -extldflags -static
+LD_FLAGS?=-s -w -extldflags -static -buildid=
 GO_BUILD_FLAGS?=-trimpath -ldflags "$(LD_FLAGS)" -tags nolegacy
 DOCKERFILE_EXT?=$(shell if docker build --help 2>/dev/null | grep -q -- '--progress'; then echo ".buildkit"; fi)
 DOCKER_ARGS?=--build-arg "VCS_REF=$(VCS_REF)"


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

The regbot image was not reproducible.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This sets `buildid` to an empty string in the binary.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```
make oci-image-regbot
regctl image digest ocidir://output/regbot:scratch
regctl image digest ocidir://output/regbot:scratch
```

The above digests should match:

```
regctl image digest ghcr.io/regclient/regbot:edge
regctl image digest ghcr.io/regclient/regbot:edge-alpine
```

<!-- Include steps that can be taken to verify the change -->

### Changelog text

<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
