### PR TITLE
Make artifactType optional

### DIFF
--- a/cmd/regctl/artifact.go
+++ b/cmd/regctl/artifact.go
@@ -469,7 +469,7 @@ func runArtifactPut(cmd *cobra.Command, args []string) error {
 		// all other mis-matches are invalid
 		return fmt.Errorf("one artifact media-type must be set for each artifact file")
 	}
-	if artifactOpts.artifactType == "" {
+	if artifactOpts.artifactType == "" && hasConfig {
 		artifactOpts.artifactType = defaultMTConfig
 	}
 

--- a/types/oci/v1/artifact.go
+++ b/types/oci/v1/artifact.go
@@ -10,7 +10,7 @@ type ArtifactManifest struct {
 	MediaType string `json:"mediaType"`
 
 	// ArtifactType is the media type of the artifact this schema refers to.
-	ArtifactType string `json:"artifactType"`
+	ArtifactType string `json:"artifactType,omitempty"`
 
 	// Blobs is a collection of blobs referenced by this manifest.
 	Blobs []types.Descriptor `json:"blobs,omitempty"`


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Fixes #326 
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

`artifactType` is optional for the artifact media type.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Pushing an artifact media type no longer includes an `artifactType` by default.

```
$ echo test | regctl artifact put \
  --media-type application/vnd.oci.artifact.manifest.v1+json \
  ocidir://test:artifact1

$ echo test | regctl artifact put \
  --artifact-type application/example.test.text \
  --media-type application/vnd.oci.artifact.manifest.v1+json \
  ocidir://test:artifact2

$ echo test | regctl artifact put \
  --artifact-type application/example.test.text \
  --media-type application/vnd.oci.image.manifest.v1+json \
  ocidir://test:artifact3

$ regctl manifest get ocidir://test:artifact1 --format '{{jsonPretty .}}'
{
  "mediaType": "application/vnd.oci.artifact.manifest.v1+json",
  "blobs": [
    {
      "mediaType": "application/octet-stream",
      "size": 5,
      "digest": "sha256:f2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2"
    }
  ]
}

$ regctl manifest get ocidir://test:artifact2 --format '{{jsonPretty .}}'
{
  "mediaType": "application/vnd.oci.artifact.manifest.v1+json",
  "artifactType": "application/example.test.text",
  "blobs": [
    {
      "mediaType": "application/octet-stream",
      "size": 5,
      "digest": "sha256:f2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2"
    }
  ]
}

$ regctl manifest get ocidir://test:artifact3 --format '{{jsonPretty .}}'
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.oci.image.manifest.v1+json",
  "config": {
    "mediaType": "application/example.test.text",
    "size": 2,
    "digest": "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"
  },
  "layers": [
    {
      "mediaType": "application/octet-stream",
      "size": 5,
      "digest": "sha256:f2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2"
    }
  ]
}
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Make `artifactType` field optional for artifact manifests
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
