### PR TITLE
regbot: add limit and last options to repo.ls

### DIFF
--- a/cmd/regbot/internal/go2lua/import.go
+++ b/cmd/regbot/internal/go2lua/import.go
@@ -20,7 +20,7 @@ func Import(ls *lua.LState, lv lua.LValue, v, orig interface{}) (err error) {
 	// orig may not be a pointer or empty interface, dereference v until the two values match
 	rV := reflect.ValueOf(v)
 	rOrig := reflect.ValueOf(orig)
-	for rV.IsValid() && rV.Type() != rOrig.Type() &&
+	for rV.IsValid() && rOrig.IsValid() && rV.Type() != rOrig.Type() &&
 		(rV.Type().Kind() == reflect.Interface || rV.Type().Kind() == reflect.Ptr) {
 		rV = rV.Elem()
 	}
@@ -74,7 +74,7 @@ func importReflect(ls *lua.LState, lv lua.LValue, v, orig reflect.Value) error {
 		}
 		return nil
 	case reflect.Slice:
-		// Slice follows the same pattern as array, except the slice is firsted created with the desired size.
+		// Slice follows the same pattern as array, except the slice is first created with the desired size.
 		if lvi, ok := lv.(*lua.LTable); ok {
 			newV := reflect.MakeSlice(v.Type(), lvi.Len(), lvi.Len())
 			for i := 0; i < newV.Len(); i++ {

--- a/cmd/regbot/sandbox/repo.go
+++ b/cmd/regbot/sandbox/repo.go
@@ -1,6 +1,10 @@
 package sandbox
 
 import (
+	"fmt"
+
+	"github.com/regclient/regclient/cmd/regbot/internal/go2lua"
+	"github.com/regclient/regclient/scheme"
 	"github.com/sirupsen/logrus"
 	lua "github.com/yuin/gopher-lua"
 )
@@ -17,6 +21,11 @@ func setupRepo(s *Sandbox) {
 	)
 }
 
+type repoLsOpts struct {
+	Limit int    `json:"limit"`
+	Last  string `json:"last"`
+}
+
 func (s *Sandbox) repoLs(ls *lua.LState) int {
 	hostLV := ls.Get(1)
 	hostLVS, ok := hostLV.(lua.LString)
@@ -24,11 +33,27 @@ func (s *Sandbox) repoLs(ls *lua.LState) int {
 		ls.ArgError(1, "Expected registry name (host and optional port)")
 	}
 	host := hostLVS.String()
+	opts := repoLsOpts{}
+	optsArgs := []scheme.RepoOpts{}
+	if ls.GetTop() > 1 {
+		tab := ls.CheckTable(2)
+		err := go2lua.Import(ls, tab, &opts, nil)
+		if err != nil {
+			ls.ArgError(2, fmt.Sprintf("Failed to parse options: %v", err))
+		}
+		if opts.Limit > 0 {
+			optsArgs = append(optsArgs, scheme.WithRepoLimit(opts.Limit))
+		}
+		if opts.Last != "" {
+			optsArgs = append(optsArgs, scheme.WithRepoLast(opts.Last))
+		}
+	}
 	s.log.WithFields(logrus.Fields{
 		"script": s.name,
 		"host":   host,
+		"opts":   opts,
 	}).Debug("Listing repositories")
-	repoList, err := s.rc.RepoList(s.ctx, host)
+	repoList, err := s.rc.RepoList(s.ctx, host, optsArgs...)
 	if err != nil {
 		ls.RaiseError("Failed retrieving repo list: %v", err)
 	}

--- a/docs/regbot.md
+++ b/docs/regbot.md
@@ -191,9 +191,14 @@ The following additional functions are available:
 - `<ref>:tag`:
   Get or set the tag on a reference.
   This is useful when iterating over tags within a repository.
-- `repo.ls <host:port>`:
+- `repo.ls <host:port> [opts]`:
   List the repositories on a registry server.
   This depends on the registry supporting the API call.
+  Opts is a table that can have the following values set:
+  - `limit`: number of results to return
+  - `last`: last received repo, next batch of results will start after this
+
+  e.g. `list = repo.ls("example.com", {limit = 500})`
 - `tag.ls <repo>`:
   Returns an array of tags found within a repository.
 - `tag.delete <ref>`:


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Fixes #329 
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Adds options to `repo.ls` that takes a table with `limit` and `last`.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Example config yaml:

```yml
version: 1
creds:
  - registry: localhost:5000
    tls: disabled
scripts:
  - name: repo ls opts
    script: |
      reg = "localhost:5000"
      list = repo.ls(reg, {limit = 10, last = "library/busybox"})
      for k, i in ipairs(list) do
        log(k .. ": " .. i)
      end
```

<!-- Include steps that can be taken to verify the change -->

### Changelog text

regbot: adding options to `repo.ls` to support paginated responses
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

Testing for regbot uses ocidir where paginated `repo.ls` doesn't apply. These changes have been manually tested and will eventually be rolled into an e2e test suite.
<!-- Mark the following with an [X] to verify they are included -->

- [ ] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
