### PR TITLE
Normalize filenames on tar read

### DIFF
--- a/types/blob/blob_test.go
+++ b/types/blob/blob_test.go
@@ -484,6 +484,11 @@ func TestReadFile(t *testing.T) {
 			content:  "1\n",
 		},
 		{
+			name:     "layer1 absolute",
+			filename: "/layer1.txt",
+			content:  "1\n",
+		},
+		{
 			name:      "layer2",
 			filename:  "layer2.txt",
 			expectErr: types.ErrFileDeleted,

--- a/types/blob/tar.go
+++ b/types/blob/tar.go
@@ -110,6 +110,11 @@ func (tr *tarReader) ReadFile(filename string) (*tar.Header, io.Reader, error) {
 	if strings.HasPrefix(filename, ".wh.") {
 		return nil, nil, fmt.Errorf(".wh. prefix is reserved for whiteout files")
 	}
+	// normalize filenames,
+	filename = filepath.Clean(filename)
+	if filename[0] == '/' {
+		filename = filename[1:]
+	}
 	// get reader
 	rdr, err := tr.GetTarReader()
 	if err != nil {
@@ -126,8 +131,12 @@ func (tr *tarReader) ReadFile(filename string) (*tar.Header, io.Reader, error) {
 			}
 			return nil, nil, err
 		}
+		thFile := filepath.Clean(th.Name)
+		if thFile[0] == '/' {
+			thFile = thFile[1:]
+		}
 		// found the target file
-		if th.Name == filename {
+		if thFile == filename {
 			return th, rdr, nil
 		}
 		// check/track whiteout file


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Trying to read a file from an image built by ko fails because of leading slashes in the filenames.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This normalizes the filename for both the file being searched and each tar entry.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```
regctl image get-file ghcr.io/sigstore/cosign/cosign:v1.13.1 /ko-app/cosign >cosign
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
