### PR TITLE
Check if manifest is set

### DIFF
--- a/types/error.go
+++ b/types/error.go
@@ -27,6 +27,8 @@ var (
 	ErrHTTPStatus = errors.New("unexpected http status code")
 	// ErrInvalidChallenge indicates an issue with the received challenge in the WWW-Authenticate header
 	ErrInvalidChallenge = errors.New("invalid challenge header")
+	// ErrManifestNotSet indicates the manifest is not set, it must be pulled with a ManifestGet first
+	ErrManifestNotSet = errors.New("manifest not set")
 	// ErrMissingAnnotation returned when a needed annotation is not found
 	ErrMissingAnnotation = errors.New("annotation is missing")
 	// ErrMissingDigest returned when image reference does not include a digest

--- a/types/manifest/common.go
+++ b/types/manifest/common.go
@@ -73,7 +73,7 @@ func (m *common) IsSet() bool {
 // RawBody returns the raw body from the manifest if available.
 func (m *common) RawBody() ([]byte, error) {
 	if len(m.rawBody) == 0 {
-		return m.rawBody, types.ErrUnavailable
+		return m.rawBody, types.ErrManifestNotSet
 	}
 	return m.rawBody, nil
 }

--- a/types/manifest/manifest.go
+++ b/types/manifest/manifest.go
@@ -15,7 +15,6 @@ import (
 	_ "crypto/sha512"
 
 	digest "github.com/opencontainers/go-digest"
-	"github.com/regclient/regclient/internal/wraperr"
 	"github.com/regclient/regclient/types"
 	"github.com/regclient/regclient/types/docker/schema1"
 	"github.com/regclient/regclient/types/docker/schema2"
@@ -540,7 +539,7 @@ func verifyMT(expected, received string) error {
 
 func getPlatformDesc(p *platform.Platform, dl []types.Descriptor) (*types.Descriptor, error) {
 	if p == nil {
-		return nil, wraperr.New(fmt.Errorf("invalid input, platform is nil"), types.ErrNotFound)
+		return nil, fmt.Errorf("invalid input, platform is nil%.0w", types.ErrNotFound)
 	}
 	for _, d := range dl {
 		if d.Platform != nil && platform.Match(*p, *d.Platform) {
@@ -553,7 +552,7 @@ func getPlatformDesc(p *platform.Platform, dl []types.Descriptor) (*types.Descri
 			return &d, nil
 		}
 	}
-	return nil, wraperr.New(fmt.Errorf("platform not found: %s", *p), types.ErrNotFound)
+	return nil, fmt.Errorf("platform not found: %s%.0w", *p, types.ErrNotFound)
 }
 
 func getPlatformList(dl []types.Descriptor) ([]*platform.Platform, error) {

--- a/types/manifest/manifest_test.go
+++ b/types/manifest/manifest_test.go
@@ -356,6 +356,7 @@ func TestNew(t *testing.T) {
 		wantR       ref.Ref
 		wantDesc    types.Descriptor
 		wantE       error
+		isSet       bool
 		testAnnot   bool
 		hasAnnot    bool
 		testPlat    string
@@ -380,6 +381,7 @@ func TestNew(t *testing.T) {
 				Digest:    digestDockerSchema2,
 			},
 			wantE:       nil,
+			isSet:       true,
 			testAnnot:   true,
 			testSubject: true,
 			hasAnnot:    true,
@@ -402,6 +404,7 @@ func TestNew(t *testing.T) {
 			testAnnot:   true,
 			testSubject: true,
 			wantE:       nil,
+			isSet:       true,
 			hasAnnot:    true,
 		},
 		{
@@ -415,6 +418,7 @@ func TestNew(t *testing.T) {
 				}),
 			},
 			wantE:       nil,
+			isSet:       true,
 			testAnnot:   true,
 			testSubject: true,
 			hasAnnot:    true,
@@ -432,6 +436,7 @@ func TestNew(t *testing.T) {
 				WithRaw(rawDockerSchema2List),
 			},
 			wantE:       nil,
+			isSet:       true,
 			testAnnot:   true,
 			testSubject: true,
 			hasAnnot:    true,
@@ -453,13 +458,14 @@ func TestNew(t *testing.T) {
 				}),
 			},
 			wantE:       nil,
+			isSet:       true,
 			testAnnot:   true,
 			testSubject: true,
 			hasAnnot:    true,
 			hasSubject:  true,
 		},
 		{
-			name: "Header Request",
+			name: "Header Request Docker 2 Manifest",
 			opts: []Opts{
 				WithRef(r),
 				WithHeader(http.Header{
@@ -476,12 +482,132 @@ func TestNew(t *testing.T) {
 			wantE: nil,
 		},
 		{
+			name: "Header Request Docker 1 Manifest",
+			opts: []Opts{
+				WithRef(r),
+				WithHeader(http.Header{
+					"Content-Type":          []string{types.MediaTypeDocker1Manifest},
+					"Content-Length":        []string{fmt.Sprintf("%d", len(rawDockerSchema2))},
+					"Docker-Content-Digest": []string{digestDockerSchema2.String()},
+				}),
+			},
+			wantDesc: types.Descriptor{
+				MediaType: types.MediaTypeDocker1Manifest,
+				Size:      int64(len(rawDockerSchema2)),
+				Digest:    digestDockerSchema2,
+			},
+			wantE: nil,
+		},
+		{
+			name: "Header Request Docker 1 Manifest Signed",
+			opts: []Opts{
+				WithRef(r),
+				WithHeader(http.Header{
+					"Content-Type":          []string{types.MediaTypeDocker1ManifestSigned},
+					"Content-Length":        []string{fmt.Sprintf("%d", len(rawDockerSchema2))},
+					"Docker-Content-Digest": []string{digestDockerSchema2.String()},
+				}),
+			},
+			wantDesc: types.Descriptor{
+				MediaType: types.MediaTypeDocker1ManifestSigned,
+				Size:      int64(len(rawDockerSchema2)),
+				Digest:    digestDockerSchema2,
+			},
+			wantE: nil,
+		},
+		{
+			name: "Header Request Docker 2 Manifest",
+			opts: []Opts{
+				WithRef(r),
+				WithHeader(http.Header{
+					"Content-Type":          []string{types.MediaTypeDocker2Manifest},
+					"Content-Length":        []string{fmt.Sprintf("%d", len(rawDockerSchema2))},
+					"Docker-Content-Digest": []string{digestDockerSchema2.String()},
+				}),
+			},
+			wantDesc: types.Descriptor{
+				MediaType: types.MediaTypeDocker2Manifest,
+				Size:      int64(len(rawDockerSchema2)),
+				Digest:    digestDockerSchema2,
+			},
+			wantE: nil,
+		},
+		{
+			name: "Header Request Docker 2 Manifest List",
+			opts: []Opts{
+				WithRef(r),
+				WithHeader(http.Header{
+					"Content-Type":          []string{types.MediaTypeDocker2ManifestList},
+					"Content-Length":        []string{fmt.Sprintf("%d", len(rawDockerSchema2))},
+					"Docker-Content-Digest": []string{digestDockerSchema2.String()},
+				}),
+			},
+			wantDesc: types.Descriptor{
+				MediaType: types.MediaTypeDocker2ManifestList,
+				Size:      int64(len(rawDockerSchema2)),
+				Digest:    digestDockerSchema2,
+			},
+			wantE: nil,
+		},
+		{
+			name: "Header Request OCI Manifest",
+			opts: []Opts{
+				WithRef(r),
+				WithHeader(http.Header{
+					"Content-Type":          []string{types.MediaTypeOCI1Manifest},
+					"Content-Length":        []string{fmt.Sprintf("%d", len(rawDockerSchema2))},
+					"Docker-Content-Digest": []string{digestDockerSchema2.String()},
+				}),
+			},
+			wantDesc: types.Descriptor{
+				MediaType: types.MediaTypeOCI1Manifest,
+				Size:      int64(len(rawDockerSchema2)),
+				Digest:    digestDockerSchema2,
+			},
+			wantE: nil,
+		},
+		{
+			name: "Header Request OCI Manifest List",
+			opts: []Opts{
+				WithRef(r),
+				WithHeader(http.Header{
+					"Content-Type":          []string{types.MediaTypeOCI1ManifestList},
+					"Content-Length":        []string{fmt.Sprintf("%d", len(rawDockerSchema2))},
+					"Docker-Content-Digest": []string{digestDockerSchema2.String()},
+				}),
+			},
+			wantDesc: types.Descriptor{
+				MediaType: types.MediaTypeOCI1ManifestList,
+				Size:      int64(len(rawDockerSchema2)),
+				Digest:    digestDockerSchema2,
+			},
+			wantE: nil,
+		},
+		{
+			name: "Header Request OCI Artifact",
+			opts: []Opts{
+				WithRef(r),
+				WithHeader(http.Header{
+					"Content-Type":          []string{types.MediaTypeOCI1Artifact},
+					"Content-Length":        []string{fmt.Sprintf("%d", len(rawDockerSchema2))},
+					"Docker-Content-Digest": []string{digestDockerSchema2.String()},
+				}),
+			},
+			wantDesc: types.Descriptor{
+				MediaType: types.MediaTypeOCI1Artifact,
+				Size:      int64(len(rawDockerSchema2)),
+				Digest:    digestDockerSchema2,
+			},
+			wantE: nil,
+		},
+		{
 			name: "Docker Schema 1 Signed",
 			opts: []Opts{
 				WithRef(r),
 				WithRaw(rawDockerSchema1Signed),
 			},
 			wantE:       nil,
+			isSet:       true,
 			testAnnot:   true,
 			testSubject: true,
 		},
@@ -496,6 +622,7 @@ func TestNew(t *testing.T) {
 				}),
 			},
 			wantE: nil,
+			isSet: true,
 		},
 		{
 			name: "Invalid Http Digest",
@@ -519,6 +646,7 @@ func TestNew(t *testing.T) {
 				}),
 			},
 			wantE: nil,
+			isSet: true,
 		},
 		{
 			name: "Ambiguous OCI Index",
@@ -530,6 +658,7 @@ func TestNew(t *testing.T) {
 				}),
 			},
 			wantE: nil,
+			isSet: true,
 		},
 		{
 			name: "Invalid OCI Index",
@@ -585,6 +714,7 @@ func TestNew(t *testing.T) {
 				WithOrig(manifestDockerSchema2),
 			},
 			wantE:       nil,
+			isSet:       true,
 			testAnnot:   true,
 			testSubject: true,
 			hasAnnot:    true,
@@ -595,6 +725,7 @@ func TestNew(t *testing.T) {
 				WithOrig(manifestOCIArtifact),
 			},
 			wantE:       nil,
+			isSet:       true,
 			testAnnot:   true,
 			testSubject: true,
 			hasAnnot:    true,
@@ -606,6 +737,7 @@ func TestNew(t *testing.T) {
 				WithOrig(manifestDockerSchema1Signed),
 			},
 			wantE: nil,
+			isSet: true,
 		},
 		{
 			name: "Invalid Media Type",
@@ -641,14 +773,16 @@ func TestNew(t *testing.T) {
 				t.Errorf("failed running New: %v", err)
 				return
 			}
-			mp, ok := m.(interface{ MarshalPretty() ([]byte, error) })
-			if ok {
+			// MarshalPretty succeeds even if manifest is not set (it shows available metadata)
+			if mp, ok := m.(interface{ MarshalPretty() ([]byte, error) }); ok {
 				pretty, err := mp.MarshalPretty()
 				if err != nil {
-					t.Errorf("marshal pretty: %v", err)
+					t.Errorf("failed to MarshalPretty: %v", err)
 				} else {
 					t.Logf("marshal pretty:\n%s", string(pretty))
 				}
+			} else {
+				t.Errorf("MarshalPretty not available")
 			}
 			if tt.wantR.Scheme != "" && m.GetRef().CommonName() != tt.wantR.CommonName() {
 				t.Errorf("ref mismatch, expected %s, received %s", tt.wantR.CommonName(), m.GetRef().CommonName())
@@ -658,6 +792,75 @@ func TestNew(t *testing.T) {
 			}
 			if tt.wantDesc.MediaType != "" && GetMediaType(m) != tt.wantDesc.MediaType {
 				t.Errorf("media type mismatch, expected %s, received %s", tt.wantDesc.MediaType, GetMediaType(m))
+			}
+			if !tt.isSet {
+				// test methods on unset manifest
+				if m.IsSet() {
+					t.Errorf("manifest reports it is set")
+				}
+				if _, err := m.RawBody(); !errors.Is(err, types.ErrManifestNotSet) && !errors.Is(err, types.ErrUnsupportedMediaType) {
+					t.Errorf("RawBody did not return ManifestNotSet: %v", err)
+				}
+				if _, err := m.MarshalJSON(); !errors.Is(err, types.ErrManifestNotSet) && !errors.Is(err, types.ErrUnsupportedMediaType) {
+					t.Errorf("MarshalJSON did not return ManifestNotSet: %v", err)
+				}
+				if ma, ok := m.(Annotator); ok {
+					if _, err := ma.GetAnnotations(); !errors.Is(err, types.ErrManifestNotSet) && !errors.Is(err, types.ErrUnsupportedMediaType) {
+						t.Errorf("GetAnnotations did not return ManifestNotSet: %v", err)
+					}
+				}
+				if mi, ok := m.(Indexer); ok {
+					if _, err := mi.GetManifestList(); !errors.Is(err, types.ErrManifestNotSet) && !errors.Is(err, types.ErrUnsupportedMediaType) {
+						t.Errorf("GetManifestList did not return ManifestNotSet: %v", err)
+					}
+				}
+				if mi, ok := m.(Imager); ok {
+					if _, err := mi.GetConfig(); !errors.Is(err, types.ErrManifestNotSet) && !errors.Is(err, types.ErrUnsupportedMediaType) {
+						t.Errorf("GetConfig did not return ManifestNotSet: %v", err)
+					}
+					if _, err := mi.GetLayers(); !errors.Is(err, types.ErrManifestNotSet) && !errors.Is(err, types.ErrUnsupportedMediaType) {
+						t.Errorf("GetLayers did not return ManifestNotSet: %v", err)
+					}
+				}
+				if ms, ok := m.(Subjecter); ok {
+					if _, err := ms.GetSubject(); !errors.Is(err, types.ErrManifestNotSet) && !errors.Is(err, types.ErrUnsupportedMediaType) {
+						t.Errorf("GetSubject did not return ManifestNotSet: %v", err)
+					}
+				}
+			} else {
+				// test methods on set manifest
+				if !m.IsSet() {
+					t.Errorf("manifest reports it is not set")
+				}
+				if _, err := m.RawBody(); errors.Is(err, types.ErrManifestNotSet) {
+					t.Errorf("RawBody returned ManifestNotSet: %v", err)
+				}
+				if _, err := m.MarshalJSON(); errors.Is(err, types.ErrManifestNotSet) {
+					t.Errorf("MarshalJSON returned ManifestNotSet: %v", err)
+				}
+				if ma, ok := m.(Annotator); ok {
+					if _, err := ma.GetAnnotations(); errors.Is(err, types.ErrManifestNotSet) {
+						t.Errorf("GetAnnotations returned ManifestNotSet: %v", err)
+					}
+				}
+				if mi, ok := m.(Indexer); ok {
+					if _, err := mi.GetManifestList(); errors.Is(err, types.ErrManifestNotSet) {
+						t.Errorf("GetManifestList returned ManifestNotSet: %v", err)
+					}
+				}
+				if mi, ok := m.(Imager); ok {
+					if _, err := mi.GetConfig(); errors.Is(err, types.ErrManifestNotSet) {
+						t.Errorf("GetConfig returned ManifestNotSet: %v", err)
+					}
+					if _, err := mi.GetLayers(); errors.Is(err, types.ErrManifestNotSet) {
+						t.Errorf("GetLayers returned ManifestNotSet: %v", err)
+					}
+				}
+				if ms, ok := m.(Subjecter); ok {
+					if _, err := ms.GetSubject(); errors.Is(err, types.ErrManifestNotSet) {
+						t.Errorf("GetSubject returned ManifestNotSet: %v", err)
+					}
+				}
 			}
 			if tt.testAnnot {
 				mr, ok := m.(Annotator)

--- a/types/manifest/oci1.go
+++ b/types/manifest/oci1.go
@@ -13,7 +13,6 @@ import (
 
 	digest "github.com/opencontainers/go-digest"
 	"github.com/regclient/regclient/internal/units"
-	"github.com/regclient/regclient/internal/wraperr"
 	"github.com/regclient/regclient/types"
 	v1 "github.com/regclient/regclient/types/oci/v1"
 	"github.com/regclient/regclient/types/platform"
@@ -41,58 +40,73 @@ type oci1Artifact struct {
 
 func (m *oci1Manifest) GetAnnotations() (map[string]string, error) {
 	if !m.manifSet {
-		return nil, fmt.Errorf("manifest is not set")
+		return nil, types.ErrManifestNotSet
 	}
 	return m.Annotations, nil
 }
 func (m *oci1Manifest) GetConfig() (types.Descriptor, error) {
+	if !m.manifSet {
+		return types.Descriptor{}, types.ErrManifestNotSet
+	}
 	return m.Config, nil
 }
 func (m *oci1Manifest) GetConfigDigest() (digest.Digest, error) {
+	if !m.manifSet {
+		return digest.Digest(""), types.ErrManifestNotSet
+	}
 	return m.Config.Digest, nil
 }
 func (m *oci1Index) GetAnnotations() (map[string]string, error) {
 	if !m.manifSet {
-		return nil, fmt.Errorf("manifest is not set")
+		return nil, types.ErrManifestNotSet
 	}
 	return m.Annotations, nil
 }
 func (m *oci1Index) GetConfig() (types.Descriptor, error) {
-	return types.Descriptor{}, wraperr.New(fmt.Errorf("config digest not available for media type %s", m.desc.MediaType), types.ErrUnsupportedMediaType)
+	return types.Descriptor{}, fmt.Errorf("config digest not available for media type %s%.0w", m.desc.MediaType, types.ErrUnsupportedMediaType)
 }
 func (m *oci1Index) GetConfigDigest() (digest.Digest, error) {
-	return "", wraperr.New(fmt.Errorf("config digest not available for media type %s", m.desc.MediaType), types.ErrUnsupportedMediaType)
+	return "", fmt.Errorf("config digest not available for media type %s%.0w", m.desc.MediaType, types.ErrUnsupportedMediaType)
 }
 func (m *oci1Artifact) GetAnnotations() (map[string]string, error) {
 	if !m.manifSet {
-		return nil, fmt.Errorf("manifest is not set")
+		return nil, types.ErrManifestNotSet
 	}
 	return m.Annotations, nil
 }
 func (m *oci1Artifact) GetConfig() (types.Descriptor, error) {
-	return types.Descriptor{}, wraperr.New(fmt.Errorf("config digest not available for media type %s", m.desc.MediaType), types.ErrUnsupportedMediaType)
+	return types.Descriptor{}, fmt.Errorf("config digest not available for media type %s%.0w", m.desc.MediaType, types.ErrUnsupportedMediaType)
 }
 func (m *oci1Artifact) GetConfigDigest() (digest.Digest, error) {
-	return "", wraperr.New(fmt.Errorf("config digest not available for media type %s", m.desc.MediaType), types.ErrUnsupportedMediaType)
+	return "", fmt.Errorf("config digest not available for media type %s%.0w", m.desc.MediaType, types.ErrUnsupportedMediaType)
 }
 
 func (m *oci1Manifest) GetManifestList() ([]types.Descriptor, error) {
-	return []types.Descriptor{}, wraperr.New(fmt.Errorf("platform descriptor list not available for media type %s", m.desc.MediaType), types.ErrUnsupportedMediaType)
+	return []types.Descriptor{}, fmt.Errorf("platform descriptor list not available for media type %s%.0w", m.desc.MediaType, types.ErrUnsupportedMediaType)
 }
 func (m *oci1Index) GetManifestList() ([]types.Descriptor, error) {
+	if !m.manifSet {
+		return nil, types.ErrManifestNotSet
+	}
 	return m.Manifests, nil
 }
 func (m *oci1Artifact) GetManifestList() ([]types.Descriptor, error) {
-	return []types.Descriptor{}, wraperr.New(fmt.Errorf("platform descriptor list not available for media type %s", m.desc.MediaType), types.ErrUnsupportedMediaType)
+	return []types.Descriptor{}, fmt.Errorf("platform descriptor list not available for media type %s%.0w", m.desc.MediaType, types.ErrUnsupportedMediaType)
 }
 
 func (m *oci1Manifest) GetLayers() ([]types.Descriptor, error) {
+	if !m.manifSet {
+		return nil, types.ErrManifestNotSet
+	}
 	return m.Layers, nil
 }
 func (m *oci1Index) GetLayers() ([]types.Descriptor, error) {
-	return []types.Descriptor{}, wraperr.New(fmt.Errorf("layers are not available for media type %s", m.desc.MediaType), types.ErrUnsupportedMediaType)
+	return []types.Descriptor{}, fmt.Errorf("layers are not available for media type %s%.0w", m.desc.MediaType, types.ErrUnsupportedMediaType)
 }
 func (m *oci1Artifact) GetLayers() ([]types.Descriptor, error) {
+	if !m.manifSet {
+		return nil, types.ErrManifestNotSet
+	}
 	return m.Blobs, nil
 }
 
@@ -107,7 +121,7 @@ func (m *oci1Artifact) GetOrig() interface{} {
 }
 
 func (m *oci1Manifest) GetPlatformDesc(p *platform.Platform) (*types.Descriptor, error) {
-	return nil, wraperr.New(fmt.Errorf("platform lookup not available for media type %s", m.desc.MediaType), types.ErrUnsupportedMediaType)
+	return nil, fmt.Errorf("platform lookup not available for media type %s%.0w", m.desc.MediaType, types.ErrUnsupportedMediaType)
 }
 func (m *oci1Index) GetPlatformDesc(p *platform.Platform) (*types.Descriptor, error) {
 	dl, err := m.GetManifestList()
@@ -117,11 +131,11 @@ func (m *oci1Index) GetPlatformDesc(p *platform.Platform) (*types.Descriptor, er
 	return getPlatformDesc(p, dl)
 }
 func (m *oci1Artifact) GetPlatformDesc(p *platform.Platform) (*types.Descriptor, error) {
-	return nil, wraperr.New(fmt.Errorf("platform lookup not available for media type %s", m.desc.MediaType), types.ErrUnsupportedMediaType)
+	return nil, fmt.Errorf("platform lookup not available for media type %s%.0w", m.desc.MediaType, types.ErrUnsupportedMediaType)
 }
 
 func (m *oci1Manifest) GetPlatformList() ([]*platform.Platform, error) {
-	return nil, wraperr.New(fmt.Errorf("platform list not available for media type %s", m.desc.MediaType), types.ErrUnsupportedMediaType)
+	return nil, fmt.Errorf("platform list not available for media type %s%.0w", m.desc.MediaType, types.ErrUnsupportedMediaType)
 }
 func (m *oci1Index) GetPlatformList() ([]*platform.Platform, error) {
 	dl, err := m.GetManifestList()
@@ -131,12 +145,12 @@ func (m *oci1Index) GetPlatformList() ([]*platform.Platform, error) {
 	return getPlatformList(dl)
 }
 func (m *oci1Artifact) GetPlatformList() ([]*platform.Platform, error) {
-	return nil, wraperr.New(fmt.Errorf("platform list not available for media type %s", m.desc.MediaType), types.ErrUnsupportedMediaType)
+	return nil, fmt.Errorf("platform list not available for media type %s%.0w", m.desc.MediaType, types.ErrUnsupportedMediaType)
 }
 
 func (m *oci1Manifest) MarshalJSON() ([]byte, error) {
 	if !m.manifSet {
-		return []byte{}, wraperr.New(fmt.Errorf("Manifest unavailable, perform a ManifestGet first"), types.ErrUnavailable)
+		return []byte{}, types.ErrManifestNotSet
 	}
 
 	if len(m.rawBody) > 0 {
@@ -147,7 +161,7 @@ func (m *oci1Manifest) MarshalJSON() ([]byte, error) {
 }
 func (m *oci1Manifest) GetSubject() (*types.Descriptor, error) {
 	if !m.manifSet {
-		return nil, wraperr.New(fmt.Errorf("Manifest unavailable, perform a ManifestGet first"), types.ErrUnavailable)
+		return nil, types.ErrManifestNotSet
 	}
 	// TODO: remove fall back support for refers in a future release
 	if m.Manifest.Subject == nil && m.Manifest.Refers != nil {
@@ -157,7 +171,7 @@ func (m *oci1Manifest) GetSubject() (*types.Descriptor, error) {
 }
 func (m *oci1Artifact) GetSubject() (*types.Descriptor, error) {
 	if !m.manifSet {
-		return nil, wraperr.New(fmt.Errorf("Manifest unavailable, perform a ManifestGet first"), types.ErrUnavailable)
+		return nil, types.ErrManifestNotSet
 	}
 	// TODO: remove fall back support for refers in a future release
 	if m.ArtifactManifest.Subject == nil && m.ArtifactManifest.Refers != nil {
@@ -168,7 +182,7 @@ func (m *oci1Artifact) GetSubject() (*types.Descriptor, error) {
 
 func (m *oci1Index) MarshalJSON() ([]byte, error) {
 	if !m.manifSet {
-		return []byte{}, wraperr.New(fmt.Errorf("Manifest unavailable, perform a ManifestGet first"), types.ErrUnavailable)
+		return []byte{}, types.ErrManifestNotSet
 	}
 
 	if len(m.rawBody) > 0 {
@@ -179,7 +193,7 @@ func (m *oci1Index) MarshalJSON() ([]byte, error) {
 }
 func (m *oci1Artifact) MarshalJSON() ([]byte, error) {
 	if !m.manifSet {
-		return []byte{}, wraperr.New(fmt.Errorf("Manifest unavailable, perform a ManifestGet first"), types.ErrUnavailable)
+		return []byte{}, types.ErrManifestNotSet
 	}
 
 	if len(m.rawBody) > 0 {
@@ -334,7 +348,7 @@ func (m *oci1Artifact) MarshalPretty() ([]byte, error) {
 
 func (m *oci1Manifest) SetAnnotation(key, val string) error {
 	if !m.manifSet {
-		return fmt.Errorf("manifest is not set")
+		return types.ErrManifestNotSet
 	}
 	if m.Annotations == nil {
 		m.Annotations = map[string]string{}
@@ -344,7 +358,7 @@ func (m *oci1Manifest) SetAnnotation(key, val string) error {
 }
 func (m *oci1Index) SetAnnotation(key, val string) error {
 	if !m.manifSet {
-		return fmt.Errorf("manifest is not set")
+		return types.ErrManifestNotSet
 	}
 	if m.Annotations == nil {
 		m.Annotations = map[string]string{}
@@ -354,7 +368,7 @@ func (m *oci1Index) SetAnnotation(key, val string) error {
 }
 func (m *oci1Artifact) SetAnnotation(key, val string) error {
 	if !m.manifSet {
-		return fmt.Errorf("manifest is not set")
+		return types.ErrManifestNotSet
 	}
 	if m.Annotations == nil {
 		m.Annotations = map[string]string{}
@@ -364,12 +378,12 @@ func (m *oci1Artifact) SetAnnotation(key, val string) error {
 }
 
 func (m *oci1Artifact) SetConfig(d types.Descriptor) error {
-	return wraperr.New(fmt.Errorf("set config not available for media type %s", m.desc.MediaType), types.ErrUnsupportedMediaType)
+	return fmt.Errorf("set config not available for media type %s%.0w", m.desc.MediaType, types.ErrUnsupportedMediaType)
 }
 
 func (m *oci1Manifest) SetConfig(d types.Descriptor) error {
 	if !m.manifSet {
-		return fmt.Errorf("manifest is not set")
+		return types.ErrManifestNotSet
 	}
 	m.Config = d
 	return m.updateDesc()
@@ -377,7 +391,7 @@ func (m *oci1Manifest) SetConfig(d types.Descriptor) error {
 
 func (m *oci1Artifact) SetLayers(dl []types.Descriptor) error {
 	if !m.manifSet {
-		return fmt.Errorf("manifest is not set")
+		return types.ErrManifestNotSet
 	}
 	m.Blobs = dl
 	return m.updateDesc()
@@ -385,7 +399,7 @@ func (m *oci1Artifact) SetLayers(dl []types.Descriptor) error {
 
 func (m *oci1Manifest) SetLayers(dl []types.Descriptor) error {
 	if !m.manifSet {
-		return fmt.Errorf("manifest is not set")
+		return types.ErrManifestNotSet
 	}
 	m.Layers = dl
 	return m.updateDesc()
@@ -393,7 +407,7 @@ func (m *oci1Manifest) SetLayers(dl []types.Descriptor) error {
 
 func (m *oci1Index) SetManifestList(dl []types.Descriptor) error {
 	if !m.manifSet {
-		return fmt.Errorf("manifest is not set")
+		return types.ErrManifestNotSet
 	}
 	m.Manifests = dl
 	return m.updateDesc()
@@ -431,14 +445,14 @@ func (m *oci1Index) SetOrig(origIn interface{}) error {
 
 func (m *oci1Artifact) SetSubject(d *types.Descriptor) error {
 	if !m.manifSet {
-		return wraperr.New(fmt.Errorf("Manifest unavailable, perform a ManifestGet first"), types.ErrUnavailable)
+		return types.ErrManifestNotSet
 	}
 	m.ArtifactManifest.Subject = d
 	return m.updateDesc()
 }
 func (m *oci1Manifest) SetSubject(d *types.Descriptor) error {
 	if !m.manifSet {
-		return wraperr.New(fmt.Errorf("Manifest unavailable, perform a ManifestGet first"), types.ErrUnavailable)
+		return types.ErrManifestNotSet
 	}
 	m.Manifest.Subject = d
 	return m.updateDesc()


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Various methods would falsely succeed when a manifest is defined only with a HEAD request.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Check if the manifest "isSet" before attempting to return content.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

`ManifestHead` + `Get*` methods will fail with an `ErrManifestNotSet`
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Fix error handling on manifests created by `ManifestHead`
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
