### PR TITLE
Fix handling of non-tar layers

### DIFF
--- a/mod/mod_test.go
+++ b/mod/mod_test.go
@@ -147,6 +147,14 @@ func TestMod(t *testing.T) {
 			ref: "ocidir://testrepo:v1",
 		},
 		{
+			name: "Config Time Artifact",
+			opts: []Opts{
+				WithConfigTimestampMax(tTime),
+			},
+			ref:      "ocidir://testrepo:a1",
+			wantSame: true,
+		},
+		{
 			name: "Config Time Unchanged",
 			opts: []Opts{
 				WithConfigTimestampMax(time.Now()),
@@ -155,18 +163,26 @@ func TestMod(t *testing.T) {
 			wantSame: true,
 		},
 		{
-			name: "Expose port",
+			name: "Expose Port",
 			opts: []Opts{
 				WithExposeAdd("8080"),
 			},
 			ref: "ocidir://testrepo:v1",
 		},
 		{
-			name: "Expose port delete unchanged",
+			name: "Expose Port Delete Unchanged",
 			opts: []Opts{
 				WithExposeRm("8080"),
 			},
 			ref:      "ocidir://testrepo:v1",
+			wantSame: true,
+		},
+		{
+			name: "Expose Port Artifact",
+			opts: []Opts{
+				WithExposeAdd("8080"),
+			},
+			ref:      "ocidir://testrepo:a1",
 			wantSame: true,
 		},
 		{
@@ -198,6 +214,14 @@ func TestMod(t *testing.T) {
 				WithLayerTimestampMax(time.Now()),
 			},
 			ref:      "ocidir://testrepo:v1",
+			wantSame: true,
+		},
+		{
+			name: "Layer Timestamp Artifact",
+			opts: []Opts{
+				WithLayerTimestampMax(tTime),
+			},
+			ref:      "ocidir://testrepo:a1",
 			wantSame: true,
 		},
 		{
@@ -391,4 +415,17 @@ func TestMod(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestInList(t *testing.T) {
+	t.Run("match", func(t *testing.T) {
+		if !inListStr(types.MediaTypeDocker2LayerGzip, mtWLTar) {
+			t.Errorf("did not find docker layer in tar whitelist")
+		}
+	})
+	t.Run("mismatch", func(t *testing.T) {
+		if inListStr(types.MediaTypeDocker2LayerGzip, mtWLConfig) {
+			t.Errorf("found docker layer in config whitelist")
+		}
+	})
 }


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Docker's buildkit attestations are attached within the index, but are artifacts rather than images with layers. This breaks the `regctl image mod` command, which also breaks CI.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Image mod now checks for supported layer and config media types before processing.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Perform a `regctl image mod` on an index that contains docker's buildkit attestations with a timestamp change to the layer contents.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Fix `regctl image mod` for non-tar layers and non-image configs.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
