### PR TITLE
Use OCI referrers in the docker image build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -136,6 +136,7 @@ jobs:
         echo "Loading ${local_tag} from output/${{matrix.image}}-${{matrix.type}}.tar"
         regctl image import "${local_tag}" "output/${{matrix.image}}-${{matrix.type}}.tar"
         regctl image mod "${local_tag}" --replace \
+          --to-oci-referrers \
           --time-max "${vcs_date}" \
           --annotation "oci.opencontainers.image.created=${vcs_date}" \
           --annotation "oci.opencontainers.image.source=${{ steps.prep.outputs.repo_url }}" \
@@ -148,7 +149,7 @@ jobs:
         # loop over the tags
         for tag in $(echo ${{ steps.prep.outputs.tags }} | tr , ' '); do
           echo "Updating ${tag}"
-          regctl image copy "${local_tag}" "${tag}"
+          regctl image copy --referrers "${local_tag}" "${tag}"
         done
         echo "digest=$(regctl image digest ${local_tag})" >>$GITHUB_OUTPUT
 

--- a/build/oci-image.sh
+++ b/build/oci-image.sh
@@ -82,6 +82,7 @@ regctl image import "ocidir://output/${image}:${release}" "output/${image}-${rel
 echo "Modding image"
 regctl image mod \
   "ocidir://output/${image}:${release}" --replace \
+  --to-oci-referrers \
   --time-max "${vcs_date}" \
   --annotation "oci.opencontainers.image.created=${vcs_date}" \
   --annotation "oci.opencontainers.image.source=${vcs_repo}" \


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Image builds aren't reproducible.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Converts docker provenance to OCI referrers in GHA builds.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Digests should match GHA using `make oci-image`
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Fix reproducible builds with docker provenance.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
