### PR TITLE
Add SBOMs to artifacts and images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -80,9 +80,6 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
 
-    - name: Install cosign
-      uses: sigstore/cosign-installer@main
-    
     - name: Login to DockerHub
       if: github.repository_owner == 'regclient'
       uses: docker/login-action@v2 
@@ -98,7 +95,7 @@ jobs:
         username: ${{ secrets.GHCR_USERNAME }}
         password: ${{ secrets.GHCR_TOKEN }}
 
-    - name: Build and push
+    - name: Build
       uses: docker/build-push-action@v3
       id: build
       with:
@@ -113,6 +110,15 @@ jobs:
           org.opencontainers.image.version=${{ steps.prep.outputs.version }}
           org.opencontainers.image.revision=${{ github.sha }}
 
+    - name: Install cosign
+      uses: sigstore/cosign-installer@main
+    
+    - name: Install syft
+      uses: anchore/sbom-action/download-syft@v0.13.1
+      id: syft
+      with:
+        syft-version: "v0.68.0"
+    
     # Dogfooding, use regctl to modify regclient images to improve reproducibility
     - name: Install regctl
       uses: regclient/actions/regctl-installer@main
@@ -135,6 +141,7 @@ jobs:
         local_tag="ocidir://output/${{matrix.image}}:${{matrix.type}}"
         echo "Loading ${local_tag} from output/${{matrix.image}}-${{matrix.type}}.tar"
         regctl image import "${local_tag}" "output/${{matrix.image}}-${{matrix.type}}.tar"
+        echo "Modifying image for reproducibility"
         regctl image mod "${local_tag}" --replace \
           --to-oci-referrers \
           --time-max "${vcs_date}" \
@@ -146,12 +153,43 @@ jobs:
             --annotation "oci.opencontainers.image.base.name=${base_name}" \
             --annotation "oci.opencontainers.image.base.digest=${base_digest}"
         fi
+        echo "digest=$(regctl image digest ${local_tag})" >>$GITHUB_OUTPUT
+
+    - name: Attach SBOMs
+      if: github.event_name != 'pull_request' && github.repository_owner == 'regclient'
+      id: sbom
+      run: |
+        now_date="$(date +%Y-%m-%dT%H:%M:%SZ --utc)"
+        for digest in $(regctl manifest get ocidir://output/${{matrix.image}}:${{matrix.type}} \
+                        --format '{{range .Manifests}}{{printf "%s\n" .Digest}}{{end}}'); do
+          echo "Attaching SBOMs for ${{matrix.image}}@${digest}"
+          regctl image copy ocidir://output/${{matrix.image}}@${digest} ocidir://output/${{matrix.image}}-sbom
+          ${{steps.syft.outputs.cmd}} packages -q "oci-dir:output/${{matrix.image}}-sbom" \
+              --name "docker:docker.io/regclient/${{matrix.image}}@${digest}" -o cyclonedx-json \
+            | regctl artifact put --subject "ocidir://output/${{matrix.image}}@${digest}" \
+                --artifact-type application/vnd.cyclonedx+json \
+                -m application/vnd.cyclonedx+json \
+                --annotation "org.opencontainers.artifact.created=${now_date}" \
+                --annotation "org.opencontainers.artifact.description=CycloneDX JSON SBOM"
+          ${{steps.syft.outputs.cmd}} packages -q "oci-dir:output/${{matrix.image}}-sbom" \
+              --name "docker:docker.io/regclient/${{matrix.image}}@${digest}" -o spdx-json \
+            | regctl artifact put --subject "ocidir://output/${{matrix.image}}@${digest}" \
+                --artifact-type application/spdx+json \
+                -m application/spdx+json \
+                --annotation "org.opencontainers.artifact.created=${now_date}" \
+                --annotation "org.opencontainers.artifact.description=SPDX JSON SBOM"
+          rm -r output/${{matrix.image}}-sbom
+        done
+
+    - name: Push
+      if: github.event_name != 'pull_request' && github.repository_owner == 'regclient'
+      id: push
+      run: |
         # loop over the tags
         for tag in $(echo ${{ steps.prep.outputs.tags }} | tr , ' '); do
-          echo "Updating ${tag}"
-          regctl image copy --referrers "${local_tag}" "${tag}"
+          echo "Pushing ${tag}"
+          regctl image copy --referrers "ocidir://output/${{matrix.image}}:${{matrix.type}}" "${tag}"
         done
-        echo "digest=$(regctl image digest ${local_tag})" >>$GITHUB_OUTPUT
 
     - name: Sign the container image
       if: github.event_name != 'pull_request' && github.repository_owner == 'regclient'

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -102,6 +102,48 @@ jobs:
           ./artifacts/regsync-linux-ppc64le
           ./artifacts/regsync-linux-s390x
           ./artifacts/regsync-windows-amd64.exe
+          ./artifacts/regbot-darwin-amd64.cyclonedx.json
+          ./artifacts/regbot-darwin-arm64.cyclonedx.json
+          ./artifacts/regbot-linux-amd64.cyclonedx.json
+          ./artifacts/regbot-linux-arm64.cyclonedx.json
+          ./artifacts/regbot-linux-ppc64le.cyclonedx.json
+          ./artifacts/regbot-linux-s390x.cyclonedx.json
+          ./artifacts/regbot-windows-amd64.cyclonedx.json
+          ./artifacts/regctl-darwin-amd64.cyclonedx.json
+          ./artifacts/regctl-darwin-arm64.cyclonedx.json
+          ./artifacts/regctl-linux-amd64.cyclonedx.json
+          ./artifacts/regctl-linux-arm64.cyclonedx.json
+          ./artifacts/regctl-linux-ppc64le.cyclonedx.json
+          ./artifacts/regctl-linux-s390x.cyclonedx.json
+          ./artifacts/regctl-windows-amd64.cyclonedx.json
+          ./artifacts/regsync-darwin-amd64.cyclonedx.json
+          ./artifacts/regsync-darwin-arm64.cyclonedx.json
+          ./artifacts/regsync-linux-amd64.cyclonedx.json
+          ./artifacts/regsync-linux-arm64.cyclonedx.json
+          ./artifacts/regsync-linux-ppc64le.cyclonedx.json
+          ./artifacts/regsync-linux-s390x.cyclonedx.json
+          ./artifacts/regsync-windows-amd64.cyclonedx.json
+          ./artifacts/regbot-darwin-amd64.spdx.json
+          ./artifacts/regbot-darwin-arm64.spdx.json
+          ./artifacts/regbot-linux-amd64.spdx.json
+          ./artifacts/regbot-linux-arm64.spdx.json
+          ./artifacts/regbot-linux-ppc64le.spdx.json
+          ./artifacts/regbot-linux-s390x.spdx.json
+          ./artifacts/regbot-windows-amd64.spdx.json
+          ./artifacts/regctl-darwin-amd64.spdx.json
+          ./artifacts/regctl-darwin-arm64.spdx.json
+          ./artifacts/regctl-linux-amd64.spdx.json
+          ./artifacts/regctl-linux-arm64.spdx.json
+          ./artifacts/regctl-linux-ppc64le.spdx.json
+          ./artifacts/regctl-linux-s390x.spdx.json
+          ./artifacts/regctl-windows-amd64.spdx.json
+          ./artifacts/regsync-darwin-amd64.spdx.json
+          ./artifacts/regsync-darwin-arm64.spdx.json
+          ./artifacts/regsync-linux-amd64.spdx.json
+          ./artifacts/regsync-linux-arm64.spdx.json
+          ./artifacts/regsync-linux-ppc64le.spdx.json
+          ./artifacts/regsync-linux-s390x.spdx.json
+          ./artifacts/regsync-windows-amd64.spdx.json
 
     - name: Save artifacts
       if: github.ref == 'refs/heads/main' && matrix.gover == env.RELEASE_GO_VER


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This adds the creation of SBOMs to the artifacts and images. Both CycloneDX and SPDX formats are generated in JSON.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```
make artifacts
```

and with images:

```
regctl artifact list  ocidir://output/regctl@$(regctl image digest --platform local ocidir://output/regctl:scratch)
regctl artifact get --subject ocidir://output/regctl@$(regctl image digest --platform local ocidir://output/regctl:scratch) \
  --filter-artifact-type application/spdx+json
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Add SBOMs to artifacts to images
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
