### PR TITLE
Normalize filenames on tar import

### DIFF
--- a/image_test.go
+++ b/image_test.go
@@ -1,8 +1,10 @@
 package regclient
 
 import (
+	"archive/tar"
 	"context"
 	"errors"
+	"io"
 	"testing"
 
 	"github.com/regclient/regclient/internal/rwfs"
@@ -122,5 +124,86 @@ func TestImageCheckBase(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestExportImport(t *testing.T) {
+	ctx := context.Background()
+	// copy testdata images into memory
+	fsOS := rwfs.OSNew("")
+	fsMem := rwfs.MemNew()
+	err := rwfs.CopyRecursive(fsOS, "testdata", fsMem, ".")
+	if err != nil {
+		t.Errorf("failed to setup memfs copy: %v", err)
+		return
+	}
+	// create regclient
+	rc := New(WithFS(fsMem))
+	rIn, err := ref.New("ocidir://testrepo:v1")
+	if err != nil {
+		t.Errorf("failed to parse ref: %v", err)
+	}
+	rOut, err := ref.New("ocidir://testout:v1")
+	if err != nil {
+		t.Errorf("failed to parse ref: %v", err)
+	}
+
+	// export repo to tar
+	fileOut, err := fsMem.Create("test.tar")
+	if err != nil {
+		t.Errorf("failed to create output tar: %v", err)
+	}
+	err = rc.ImageExport(ctx, rIn, fileOut)
+	fileOut.Close()
+	if err != nil {
+		t.Errorf("failed to export: %v", err)
+	}
+
+	// modify tar for tests
+	fileR, err := fsMem.Open("test.tar")
+	if err != nil {
+		t.Errorf("failed to open tar: %v", err)
+	}
+	fileW, err := fsMem.Create("test2.tar")
+	if err != nil {
+		t.Errorf("failed to create tar: %v", err)
+	}
+	tr := tar.NewReader(fileR)
+	tw := tar.NewWriter(fileW)
+	for {
+		th, err := tr.Next()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			t.Errorf("failed to read tar header: %v", err)
+		}
+		th.Name = "./" + th.Name
+		err = tw.WriteHeader(th)
+		if err != nil {
+			t.Errorf("failed to write tar header: %v", err)
+		}
+		if th.Size > 0 {
+			_, err = io.Copy(tw, tr)
+			if err != nil {
+				t.Errorf("failed to copy tar file contents %s: %v", th.Name, err)
+			}
+		}
+	}
+	fileR.Close()
+	fileW.Close()
+
+	// import tar to repo
+	fileIn, err := fsMem.Open("test2.tar")
+	if err != nil {
+		t.Errorf("failed to open tar: %v", err)
+	}
+	fileInSeeker, ok := fileIn.(io.ReadSeeker)
+	if !ok {
+		t.Fatalf("could not convert fileIn to io.ReadSeeker, type %T", fileIn)
+	}
+	err = rc.ImageImport(ctx, rOut, fileInSeeker)
+	if err != nil {
+		t.Errorf("failed to export: %v", err)
 	}
 }

--- a/internal/rwfs/mem.go
+++ b/internal/rwfs/mem.go
@@ -365,6 +365,20 @@ func (mfp *MemFileFP) Read(b []byte) (int, error) {
 	return lc, nil
 }
 
+func (mfp *MemFileFP) Seek(offset int64, whence int) (int64, error) {
+	switch whence {
+	case io.SeekStart:
+		mfp.cur = whence
+	case io.SeekEnd:
+		mfp.cur = int(int64(len(mfp.f.b)) + offset)
+	case io.SeekCurrent:
+		mfp.cur += int(offset)
+	default:
+		return -1, fmt.Errorf("unknown whence value: %d", whence)
+	}
+	return int64(mfp.cur), nil
+}
+
 func (mfp *MemFileFP) Stat() (fs.FileInfo, error) {
 	fi := NewFI(mfp.name, int64(len(mfp.f.b)), time.Time{}, 0)
 	return fi, nil


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue
Fixes #354
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This runs filenames from tar through filepath.Clean to normalize the input.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

1. create an OCI image tarball with `regctl image export $image $file`
2. extract the tar into a directory with `tar -xvf $file -C $dir`
3. re-archive the tar: `tar -cf $file -C $dir .`
4. run `regctl image import $image $file`

<!-- Include steps that can be taken to verify the change -->

### Changelog text

Fix issue importing images created with `tar`.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [x] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
