### PR TITLE
Disable pushing referrers to Hub in GHA

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -186,9 +186,15 @@ jobs:
       id: push
       run: |
         # loop over the tags
+        image_hub="${{ steps.prep.outputs.image_hub }}"
         for tag in $(echo ${{ steps.prep.outputs.tags }} | tr , ' '); do
           echo "Pushing ${tag}"
-          regctl image copy --referrers "ocidir://output/${{matrix.image}}:${{matrix.type}}" "${tag}"
+          # TODO: push referrers to Hub once this is fixed: https://github.com/docker/hub-feedback/issues/2307
+          if [ "$tag" != "${tag#$image_hub}" ]; then
+            regctl image copy "ocidir://output/${{matrix.image}}:${{matrix.type}}" "${tag}"
+          else
+            regctl image copy --referrers "ocidir://output/${{matrix.image}}:${{matrix.type}}" "${tag}"
+          fi
         done
 
     - name: Sign the container image


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Pushing manifests with a `subject` field to Hub is currently resulting in a 404. This removes any referrers from a push to Hub as a workaround for https://github.com/docker/hub-feedback/issues/2307.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This modifies the GHA to skip pushing referrers to Hub.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

CI will hopefully unbreak.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
