### PR TITLE
Adding platform option to artifact commands

### DIFF
--- a/scheme/ocidir/referrer.go
+++ b/scheme/ocidir/referrer.go
@@ -9,6 +9,7 @@ import (
 	"github.com/regclient/regclient/types"
 	"github.com/regclient/regclient/types/manifest"
 	v1 "github.com/regclient/regclient/types/oci/v1"
+	"github.com/regclient/regclient/types/platform"
 	"github.com/regclient/regclient/types/ref"
 	"github.com/regclient/regclient/types/referrer"
 )
@@ -22,6 +23,26 @@ func (o *OCIDir) ReferrerList(ctx context.Context, r ref.Ref, opts ...scheme.Ref
 	rl := referrer.ReferrerList{
 		Subject: r,
 		Tags:    []string{},
+	}
+	// select a platform from a manifest list
+	if config.Platform != "" {
+		m, err := o.ManifestGet(ctx, r)
+		if err != nil {
+			return rl, err
+		}
+		if m.IsList() {
+			plat, err := platform.Parse(config.Platform)
+			if err != nil {
+				return rl, err
+			}
+			d, err := manifest.GetPlatformDesc(m, &plat)
+			if err != nil {
+				return rl, err
+			}
+			r.Digest = d.Digest.String()
+		} else {
+			r.Digest = m.GetDescriptor().Digest.String()
+		}
 	}
 	// if ref is a tag, run a head request for the digest
 	if r.Digest == "" {

--- a/scheme/ocidir/referrer_test.go
+++ b/scheme/ocidir/referrer_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/regclient/regclient/types"
 	"github.com/regclient/regclient/types/manifest"
 	v1 "github.com/regclient/regclient/types/oci/v1"
+	"github.com/regclient/regclient/types/platform"
 	"github.com/regclient/regclient/types/ref"
 	"github.com/sirupsen/logrus"
 )
@@ -39,6 +40,7 @@ func TestReferrer(t *testing.T) {
 	tagName := "v3"
 	aType := "application/example.sbom"
 	bType := "application/example.sig"
+	cType := "application/example.attestation"
 	extraAnnot := "org.opencontainers.artifact.sbom.format"
 	extraValueA := "json"
 	extraValueB := "yaml"
@@ -60,6 +62,17 @@ func TestReferrer(t *testing.T) {
 		extraAnnot: extraValueA,
 	}
 	mDesc := m.GetDescriptor()
+	pAMDStr := "linux/amd64"
+	pAMD, err := platform.Parse(pAMDStr)
+	if err != nil {
+		t.Errorf("failed to parse platform: %v", err)
+		return
+	}
+	mAMDDesc, err := manifest.GetPlatformDesc(m, &pAMD)
+	if err != nil {
+		t.Errorf("failed to get AMD descriptor: %v", err)
+		return
+	}
 	artifactA := v1.Manifest{
 		Versioned: v1.ManifestSchemaVersion,
 		MediaType: types.MediaTypeOCI1Manifest,
@@ -112,6 +125,23 @@ func TestReferrer(t *testing.T) {
 		t.Errorf("failed extracting raw body from artifact: %v", err)
 		return
 	}
+	artifactC := v1.ArtifactManifest{
+		MediaType:    types.MediaTypeOCI1Artifact,
+		ArtifactType: cType,
+		Blobs: []types.Descriptor{
+			{
+				MediaType: types.MediaTypeOCI1LayerGzip,
+				Size:      8,
+				Digest:    digest2,
+			},
+		},
+		Subject: mAMDDesc,
+	}
+	artifactCM, err := manifest.New(manifest.WithOrig(artifactC))
+	if err != nil {
+		t.Errorf("failed creating artifact manifest: %v", err)
+		return
+	}
 
 	// list empty
 	t.Run("List empty", func(t *testing.T) {
@@ -127,7 +157,7 @@ func TestReferrer(t *testing.T) {
 		}
 	})
 
-	// attach to v1 image
+	// attach to image
 	t.Run("Put", func(t *testing.T) {
 		r := mRef
 		r.Tag = ""
@@ -144,6 +174,12 @@ func TestReferrer(t *testing.T) {
 		}
 		r.Digest = artifactBM.GetDescriptor().Digest.String()
 		err = o.ManifestPut(ctx, r, artifactBM, scheme.WithManifestChild())
+		if err != nil {
+			t.Errorf("Failed running ManifestPut on Artifact: %v", err)
+			return
+		}
+		r.Digest = artifactCM.GetDescriptor().Digest.String()
+		err = o.ManifestPut(ctx, r, artifactCM, scheme.WithManifestChild())
 		if err != nil {
 			t.Errorf("Failed running ManifestPut on Artifact: %v", err)
 			return
@@ -233,6 +269,23 @@ func TestReferrer(t *testing.T) {
 		}
 		if len(rl.Descriptors) > 0 {
 			t.Errorf("unexpected descriptors")
+			return
+		}
+	})
+	// list platform=linux/amd64
+	t.Run("List Annotation for Platform", func(t *testing.T) {
+		r, err := ref.New(repo + ":" + tagName)
+		if err != nil {
+			t.Errorf("Failed creating getRef: %v", err)
+			return
+		}
+		rl, err := o.ReferrerList(ctx, r, scheme.WithReferrerPlatform(pAMDStr))
+		if err != nil {
+			t.Errorf("Failed running ReferrerList: %v", err)
+			return
+		}
+		if len(rl.Descriptors) != 1 {
+			t.Errorf("descriptor list length, expected 1, received %d", len(rl.Descriptors))
 			return
 		}
 	})

--- a/scheme/reg/referrer.go
+++ b/scheme/reg/referrer.go
@@ -13,6 +13,7 @@ import (
 	"github.com/regclient/regclient/types"
 	"github.com/regclient/regclient/types/manifest"
 	v1 "github.com/regclient/regclient/types/oci/v1"
+	"github.com/regclient/regclient/types/platform"
 	"github.com/regclient/regclient/types/ref"
 	"github.com/regclient/regclient/types/referrer"
 )
@@ -26,6 +27,30 @@ func (reg *Reg) ReferrerList(ctx context.Context, r ref.Ref, opts ...scheme.Refe
 	rl := referrer.ReferrerList{
 		Subject: r,
 		Tags:    []string{},
+	}
+	// select a platform from a manifest list
+	if config.Platform != "" {
+		m, err := reg.ManifestHead(ctx, r)
+		if err != nil {
+			return rl, err
+		}
+		if m.IsList() {
+			m, err = reg.ManifestGet(ctx, r)
+			if err != nil {
+				return rl, err
+			}
+			plat, err := platform.Parse(config.Platform)
+			if err != nil {
+				return rl, err
+			}
+			d, err := manifest.GetPlatformDesc(m, &plat)
+			if err != nil {
+				return rl, err
+			}
+			r.Digest = d.Digest.String()
+		} else {
+			r.Digest = m.GetDescriptor().Digest.String()
+		}
 	}
 	// if ref is a tag, run a head request for the digest
 	if r.Digest == "" {

--- a/scheme/scheme.go
+++ b/scheme/scheme.go
@@ -96,6 +96,7 @@ func WithManifest(m manifest.Manifest) ManifestOpts {
 type ReferrerConfig struct {
 	FilterArtifactType string
 	FilterAnnotation   map[string]string
+	Platform           string
 }
 
 // ReferrerOpts is used to set options on referrer APIs
@@ -118,6 +119,13 @@ func WithReferrerAnnotations(annotations map[string]string) ReferrerOpts {
 				config.FilterAnnotation[k] = v
 			}
 		}
+	}
+}
+
+// WithReferrerPlatform gets referrers for a single platform from a multi-platform manifest
+func WithReferrerPlatform(platform string) ReferrerOpts {
+	return func(config *ReferrerConfig) {
+		config.Platform = platform
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Describe the change

This adds a platform option to the referrers list API, and platform options to the `regctl artifact` commands.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```
$ regctl artifact list ghcr.io/regclient/regctl:edge --platform local
Subject:                                     ghcr.io/regclient/regctl:edge
                                             
Referrers:                                   
                                             
  Name:                                      ghcr.io/regclient/regctl@sha256:5ff1e4b783ebc265fdf307b2b6acf16209f0d56eff66775a46996f3925e1030c
  Digest:                                    sha256:5ff1e4b783ebc265fdf307b2b6acf16209f0d56eff66775a46996f3925e1030c
  MediaType:                                 application/vnd.oci.image.manifest.v1+json
  ArtifactType:                              application/vnd.oci.image.config.v1+json
  Annotations:                               
    vnd.docker.reference.type:               attestation-manifest
                                             
  Name:                                      ghcr.io/regclient/regctl@sha256:a6367946236e7365af6f2d2c63c2a49a60bc356cd674075c5c1c8d75ec837fee
  Digest:                                    sha256:a6367946236e7365af6f2d2c63c2a49a60bc356cd674075c5c1c8d75ec837fee
  MediaType:                                 application/vnd.oci.image.manifest.v1+json
  ArtifactType:                              application/vnd.cyclonedx+json
  Annotations:                               
    org.opencontainers.artifact.description: CycloneDX JSON SBOM
    org.opencontainers.artifact.created:     2023-02-05T22:12:47Z
                                             
  Name:                                      ghcr.io/regclient/regctl@sha256:e24f230c183737c52fa97949c061d14d4dab2500a67cb8e78f24ea236877f1bc
  Digest:                                    sha256:e24f230c183737c52fa97949c061d14d4dab2500a67cb8e78f24ea236877f1bc
  MediaType:                                 application/vnd.oci.image.manifest.v1+json
  ArtifactType:                              application/spdx+json
  Annotations:                               
    org.opencontainers.artifact.created:     2023-02-05T22:12:47Z
    org.opencontainers.artifact.description: SPDX JSON SBOM

$ regctl artifact get --subject ghcr.io/regclient/regctl:edge --platform linux/amd64 --filter-artifact-type application/vnd.cyclonedx+json | head
{
  "bomFormat": "CycloneDX",
  "specVersion": "1.4",
  "serialNumber": "urn:uuid:1f566275-1c4c-4582-85e7-77472f59827f",
  "version": 1,
  "metadata": {
    "timestamp": "2023-02-05T22:12:48Z",
    "tools": [
      {
        "vendor": "anchore",
```

<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Adding platform option to `regctl artifact` commands
- Adding platform option to the `ReferrerList` API
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [x] Tests have been added or not applicable
- [x] Documentation has been added, updated, or not applicable
- [x] Changes have been rebased to main
- [x] Multiple commits to the same code have been squashed
