### PR TITLE
Fallback from head to get when digest is missing

### DIFF
--- a/cmd/regctl/artifact.go
+++ b/cmd/regctl/artifact.go
@@ -390,7 +390,7 @@ func runArtifactGet(cmd *cobra.Command, args []string) error {
 			return err
 		}
 		defer rdr.Close()
-		io.Copy(os.Stdout, rdr)
+		io.Copy(cmd.OutOrStdout(), rdr)
 	}
 
 	return nil
@@ -440,7 +440,7 @@ func runArtifactList(cmd *cobra.Command, args []string) error {
 	case "rawHeaders", "raw-headers", "headers":
 		artifactOpts.formatList = "{{ range $key,$vals := .Manifest.RawHeaders}}{{range $val := $vals}}{{printf \"%s: %s\\n\" $key $val }}{{end}}{{end}}"
 	}
-	return template.Writer(os.Stdout, artifactOpts.formatList, rl)
+	return template.Writer(cmd.OutOrStdout(), artifactOpts.formatList, rl)
 }
 
 func runArtifactPut(cmd *cobra.Command, args []string) error {
@@ -518,7 +518,7 @@ func runArtifactPut(cmd *cobra.Command, args []string) error {
 
 	var subjectDesc *types.Descriptor
 	if !rSubject.IsZero() {
-		smh, err := rc.ManifestHead(ctx, rSubject)
+		smh, err := rc.ManifestHead(ctx, rSubject, regclient.WithManifestRequireDigest())
 		if err != nil {
 			return fmt.Errorf("unable to find subject manifest: %w", err)
 		}
@@ -711,7 +711,7 @@ func runArtifactPut(cmd *cobra.Command, args []string) error {
 	if artifactOpts.byDigest && artifactOpts.formatPut == "" {
 		artifactOpts.formatPut = "{{ printf \"%s\\n\" .Manifest.GetDescriptor.Digest }}"
 	}
-	return template.Writer(os.Stdout, artifactOpts.formatPut, result)
+	return template.Writer(cmd.OutOrStdout(), artifactOpts.formatPut, result)
 }
 
 func runArtifactTree(cmd *cobra.Command, args []string) error {

--- a/cmd/regctl/index.go
+++ b/cmd/regctl/index.go
@@ -350,7 +350,7 @@ func indexBuildDescList(ctx context.Context, rc *regclient.RegClient, r ref.Ref)
 		if err != nil {
 			return nil, err
 		}
-		mCopy, err := rc.ManifestHead(ctx, srcRef)
+		mCopy, err := rc.ManifestHead(ctx, srcRef, regclient.WithManifestRequireDigest())
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/regctl/manifest_test.go
+++ b/cmd/regctl/manifest_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/regclient/regclient/types"
+)
+
+func TestManifestHead(t *testing.T) {
+	tt := []struct {
+		name        string
+		args        []string
+		expectErr   error
+		expectOut   string
+		outContains bool
+	}{
+		{
+			name:      "Missing arg",
+			args:      []string{"manifest", "head"},
+			expectErr: fmt.Errorf("accepts 1 arg(s), received 0"),
+		},
+		{
+			name:      "Invalid ref",
+			args:      []string{"manifest", "head", "invalid*ref"},
+			expectErr: fmt.Errorf("invalid reference \"%s\"", "invalid*ref"),
+		},
+		{
+			name:      "Missing manifest",
+			args:      []string{"manifest", "head", "ocidir://../../testdata/testrepo:missing"},
+			expectErr: types.ErrNotFound,
+		},
+		{
+			name:        "Digest",
+			args:        []string{"manifest", "head", "ocidir://../../testdata/testrepo:v1"},
+			expectOut:   "sha256:",
+			outContains: true,
+		},
+		{
+			name:        "Platform amd64",
+			args:        []string{"manifest", "head", "ocidir://../../testdata/testrepo:v1", "--platform", "linux/amd64"},
+			expectOut:   "sha256:",
+			outContains: true,
+		},
+		{
+			name:      "Platform unknown",
+			args:      []string{"manifest", "head", "ocidir://../../testdata/testrepo:v1", "--platform", "linux/unknown"},
+			expectErr: ErrNotFound,
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := cobraTest(t, tc.args...)
+			if tc.expectErr != nil {
+				if err == nil {
+					t.Errorf("did not receive expected error: %v", tc.expectErr)
+				} else if !errors.Is(err, tc.expectErr) && err.Error() != tc.expectErr.Error() {
+					t.Errorf("unexpected error, received %v, expected %v", err, tc.expectErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("returned unexpected error: %v", err)
+				return
+			}
+			if (!tc.outContains && out != tc.expectOut) || (tc.outContains && !strings.Contains(out, tc.expectOut)) {
+				t.Errorf("unexpected output, expected %s, received %s", tc.expectOut, out)
+			}
+		})
+	}
+
+}

--- a/cmd/regsync/root.go
+++ b/cmd/regsync/root.go
@@ -574,7 +574,7 @@ func (s ConfigSync) process(ctx context.Context, action string) error {
 
 // process a sync step
 func (s ConfigSync) processRef(ctx context.Context, src, tgt ref.Ref, action string) error {
-	mSrc, err := rc.ManifestHead(ctx, src)
+	mSrc, err := rc.ManifestHead(ctx, src, regclient.WithManifestRequireDigest())
 	if err != nil && errors.Is(err, types.ErrUnsupportedAPI) {
 		mSrc, err = rc.ManifestGet(ctx, src)
 	}
@@ -585,7 +585,7 @@ func (s ConfigSync) processRef(ctx context.Context, src, tgt ref.Ref, action str
 		}).Error("Failed to lookup source manifest")
 		return err
 	}
-	mTgt, err := rc.ManifestHead(ctx, tgt)
+	mTgt, err := rc.ManifestHead(ctx, tgt, regclient.WithManifestRequireDigest())
 	tgtExists := (err == nil)
 	tgtMatches := false
 	if err == nil && manifest.GetDigest(mSrc).String() == manifest.GetDigest(mTgt).String() {

--- a/image.go
+++ b/image.go
@@ -200,7 +200,7 @@ func (rc *RegClient) ImageCheckBase(ctx context.Context, r ref.Ref, opts ...Imag
 
 	// if the digest is available, check if that matches the base name
 	if opt.checkBaseDigest != "" {
-		baseMH, err := rc.ManifestHead(ctx, baseR)
+		baseMH, err := rc.ManifestHead(ctx, baseR, WithManifestRequireDigest())
 		if err != nil {
 			return err
 		}
@@ -398,7 +398,7 @@ func (rc *RegClient) imageCopyOpt(ctx context.Context, refSrc ref.Ref, refTgt re
 		opt.forceRecursive = true
 	}
 	// check if source and destination already match
-	mdh, errD := rc.ManifestHead(ctx, refTgt)
+	mdh, errD := rc.ManifestHead(ctx, refTgt, WithManifestRequireDigest())
 	if opt.forceRecursive {
 		// copy forced, unable to run below skips
 	} else if errD == nil && refTgt.Digest != "" && digest.Digest(refTgt.Digest) == mdh.GetDescriptor().Digest {
@@ -408,7 +408,7 @@ func (rc *RegClient) imageCopyOpt(ctx context.Context, refSrc ref.Ref, refTgt re
 		}).Info("Copy not needed, target already up to date")
 		return nil
 	} else if errD == nil && refTgt.Digest == "" {
-		msh, errS := rc.ManifestHead(ctx, refSrc)
+		msh, errS := rc.ManifestHead(ctx, refSrc, WithManifestRequireDigest())
 		if errS == nil && msh.GetDescriptor().Digest == mdh.GetDescriptor().Digest {
 			rc.log.WithFields(logrus.Fields{
 				"source": refSrc.Reference,


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Some registries are missing the docker digest header.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This triggers a fallback to a GET request on those registries.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```
regctl image digest registry.redhat.io/rhel8/buildah:8.7
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Fallback to GET when HEAD request is missing digest header
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
