### PR TITLE
Pin version of staticcheck and syft

### DIFF
--- a/.version-bump.lock
+++ b/.version-bump.lock
@@ -10,6 +10,10 @@
 {"name":"git-commit","key":"https://github.com/awslabs/amazon-ecr-credential-helper.git:main","version":"feb497de7dbcd593de0ef828a114dbb6cab6d6f5"}
 {"name":"git-commit","key":"https://github.com/grafi-tt/lunajson.git:master","version":"e6063d37de97dfdfe2749e24de949472bfad0945"}
 {"name":"git-commit","key":"https://github.com/kikito/semver.lua.git:master","version":"af495adc857d51fd1507a112be18523828a1da0d"}
+{"name":"git-tag-semver","key":"github.com/dominikh/go-tools","version":"v0.4.2"}
 {"name":"registry-digest-arg","key":"alpine:3","version":"sha256:69665d02cb32192e52e07644d76bc6f25abeb5410edc1c7a81a10ba3f0efb90a"}
 {"name":"registry-digest-arg","key":"golang:1.19-alpine","version":"sha256:2381c1e5f8350a901597d633b2e517775eeac7a6682be39225a93b22cfd0f8bb"}
 {"name":"registry-digest-arg","key":"golang:1.20-alpine","version":"sha256:48f336ef8366b9d6246293e3047259d0f614ee167db1869bdbc343d6e09aed8a"}
+{"name":"registry-digest-match","key":"anchore/syft:v0.72.0","version":"sha256:f4735b4c31d4b9ad979eb650712cdcdb1156afe80c7d63653ac87439b379e468"}
+{"name":"registry-tag-arg-semver","key":"anchore/syft","version":"v0.72.0"}
+{"name":"registry-tag-match-semver","key":"anchore/syft","version":"v0.72.0"}

--- a/.version-bump.yml
+++ b/.version-bump.yml
@@ -10,6 +10,12 @@ files:
   ".github/workflows/*.yml":
     scans:
       - gha-uses
+  "Makefile":
+    scans:
+      - makefile-staticcheck
+      - makefile-syft-version
+      - makefile-syft-version2
+      - makefile-syft-digest
 
 scans:
   docker-arg-alpine:
@@ -57,13 +63,60 @@ scans:
     source: "gha-uses"
     args:
       regexp: '^\s+-?\s+uses: (?P<Repo>[^@]+)@(?P<Version>v\d+)\s*$'
+  makefile-staticcheck:
+    type: "regexp"
+    source: "git-tag-semver"
+    args:
+      regexp: '^STATICCHECK_VER\?=(?P<Version>v[0-9\.]+)\s*$'
+      repo: "github.com/dominikh/go-tools"
+  makefile-syft-version:
+    type: "regexp"
+    source: "registry-tag-arg-semver"
+    args:
+      regexp: '^SYFT_VERSION\?=(?P<Version>v[0-9\.]+)\s*$'
+      repo: "anchore/syft"
+  makefile-syft-version2:
+    type: "regexp"
+    source: "registry-tag-match-semver"
+    args:
+      regexp: '^SYFT_CONTAINER\?=(?P<Repo>[^:]*):(?P<Version>v[0-9\.]+)@(?P<Digest>sha256:[0-9a-f]+)\s*$'
+  makefile-syft-digest:
+    type: "regexp"
+    source: "registry-digest-match"
+    args:
+      regexp: '^SYFT_CONTAINER\?=(?P<Image>[^:]*):(?P<Tag>v[0-9\.]+)@(?P<Version>sha256:[0-9a-f]+)\s*$'
 
 sources:
+  registry-tag-arg-semver:
+    type: "registry"
+    key: "{{ .ScanArgs.repo }}"
+    args:
+      type: "tag"
+      repo: "{{ .ScanArgs.repo }}"
+    filter:
+      expr: '^v[0-9]+\.[0-9]+\.[0-9]+$'
+    sort:
+      method: "semver"
+  registry-tag-match-semver:
+    type: "registry"
+    key: "{{ .ScanMatch.Repo }}"
+    args:
+      type: "tag"
+      repo: "{{ .ScanMatch.Repo }}"
+    filter:
+      expr: '^v[0-9]+\.[0-9]+\.[0-9]+$'
+    sort:
+      method: "semver"
   registry-digest-arg:
     type: "registry"
     key: "{{ .ScanArgs.image }}:{{.ScanMatch.Tag}}"
     args:
       image: "{{ .ScanArgs.image }}:{{.ScanMatch.Tag}}"
+  registry-digest-match:
+    type: "registry"
+    key: "{{ .ScanMatch.Image }}:{{.ScanMatch.Tag}}"
+    args:
+      image: "{{ .ScanMatch.Image }}:{{.ScanMatch.Tag}}"
   gha-uses:
     type: "git"
     key: "{{ .ScanMatch.Repo }}"
@@ -72,6 +125,8 @@ sources:
       url: "https://github.com/{{ .ScanMatch.Repo }}.git"
     filter:
       expr: '^v\d+$'
+    sort:
+      method: "semver"
   git-commit:
     type: "git"
     key: "{{ .ScanArgs.repo }}:{{ .ScanArgs.ref }}"
@@ -80,3 +135,13 @@ sources:
       url: "{{ .ScanArgs.repo }}"
     filter:
       expr: '^{{ .ScanArgs.ref }}$'
+  git-tag-semver:
+    type: "git"
+    key: "{{ .ScanArgs.repo }}"
+    args:
+      type: "tag"
+      url: "https://{{ .ScanArgs.repo }}.git"
+    filter:
+      expr: '^v[0-9]+\.[0-9]+\.[0-9]+$'
+    sort:
+      method: "semver"


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Staticcheck will break old versions of Go in new releases.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Pin the version of staticcheck so that Go and staticcheck are upgraded together. This also pins the version of Syft.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```
make lint
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Pin the version of staticcheck.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
