### PR TITLE
Add keyless signing for binary artifacts

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,8 +18,8 @@ jobs:
     permissions:
       # id-token is used by cosign's OIDC based signing
       # https://blog.chainguard.dev/zero-friction-keyless-signing-with-github-actions/
-      # TODO: make token conditional: "${{ github.event_name != 'pull_request' && github.repository_owner == 'regclient' && 'write' || 'none' }}"
       id-token: 'write'
+      contents: 'read'
 
     strategy:
       matrix:
@@ -111,13 +111,15 @@ jobs:
           org.opencontainers.image.revision=${{ github.sha }}
 
     - name: Install cosign
+      if: github.event_name != 'pull_request' && github.repository_owner == 'regclient'
       uses: sigstore/cosign-installer@main
     
     - name: Install syft
+      if: github.event_name != 'pull_request' && github.repository_owner == 'regclient'
       uses: anchore/sbom-action/download-syft@v0.13.1
       id: syft
       with:
-        syft-version: "v0.68.0"
+        syft-version: "v0.72.0"
     
     # Dogfooding, use regctl to modify regclient images to improve reproducibility
     - name: Install regctl

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,6 +21,12 @@ jobs:
     env:
       RELEASE_GO_VER: "1.20"
 
+    permissions:
+      # id-token is used by cosign's OIDC based signing
+      # https://blog.chainguard.dev/zero-friction-keyless-signing-with-github-actions/
+      id-token: 'write'
+      contents: 'read'
+
     steps:
     - name: "Set up Go ${{ matrix.gover }}"
       uses: actions/setup-go@v3
@@ -48,9 +54,54 @@ jobs:
       if: matrix.gover == env.RELEASE_GO_VER
       run: make lint
 
+    - name: Install syft
+      if: startsWith( github.ref, 'refs/tags/v' ) || github.ref == 'refs/heads/main'
+      uses: anchore/sbom-action/download-syft@v0.13.1
+      id: syft
+      with:
+        syft-version: "v0.72.0"
+
     - name: Build artifacts
       if: startsWith( github.ref, 'refs/tags/v' ) || github.ref == 'refs/heads/main'
       run: make artifacts
+
+    - name: Install cosign
+      if: ( startsWith( github.ref, 'refs/tags/v' ) || github.ref == 'refs/heads/main' ) && matrix.gover == env.RELEASE_GO_VER
+      uses: sigstore/cosign-installer@main
+
+    - name: Package artifacts
+      if: ( startsWith( github.ref, 'refs/tags/v' ) || github.ref == 'refs/heads/main' ) && matrix.gover == env.RELEASE_GO_VER
+      env:
+        # experimental support needed for GitHub OIDC signing
+        COSIGN_EXPERIMENTAL: "true"
+      run: |
+        cd artifacts
+        for artifact in \
+            regbot-darwin-amd64 \
+            regbot-darwin-arm64 \
+            regbot-linux-amd64 \
+            regbot-linux-arm64 \
+            regbot-linux-ppc64le \
+            regbot-linux-s390x \
+            regbot-windows-amd64.exe \
+            regctl-darwin-amd64 \
+            regctl-darwin-arm64 \
+            regctl-linux-amd64 \
+            regctl-linux-arm64 \
+            regctl-linux-ppc64le \
+            regctl-linux-s390x \
+            regctl-windows-amd64.exe \
+            regsync-darwin-amd64 \
+            regsync-darwin-arm64 \
+            regsync-linux-amd64 \
+            regsync-linux-arm64 \
+            regsync-linux-ppc64le \
+            regsync-linux-s390x \
+            regsync-windows-amd64.exe \
+          ; do
+          cosign sign-blob --output-signature "${artifact%.exe}.sig" --output-certificate "${artifact%.exe}.pem" "${artifact}"
+        done
+        tar -cvzf metadata.tgz *.sig *.pem *.json
 
     - name: Gather release details
       if: startsWith( github.ref, 'refs/tags/v' ) && github.repository_owner == 'regclient' && matrix.gover == env.RELEASE_GO_VER
@@ -103,48 +154,7 @@ jobs:
           ./artifacts/regsync-linux-ppc64le
           ./artifacts/regsync-linux-s390x
           ./artifacts/regsync-windows-amd64.exe
-          ./artifacts/regbot-darwin-amd64.cyclonedx.json
-          ./artifacts/regbot-darwin-arm64.cyclonedx.json
-          ./artifacts/regbot-linux-amd64.cyclonedx.json
-          ./artifacts/regbot-linux-arm64.cyclonedx.json
-          ./artifacts/regbot-linux-ppc64le.cyclonedx.json
-          ./artifacts/regbot-linux-s390x.cyclonedx.json
-          ./artifacts/regbot-windows-amd64.cyclonedx.json
-          ./artifacts/regctl-darwin-amd64.cyclonedx.json
-          ./artifacts/regctl-darwin-arm64.cyclonedx.json
-          ./artifacts/regctl-linux-amd64.cyclonedx.json
-          ./artifacts/regctl-linux-arm64.cyclonedx.json
-          ./artifacts/regctl-linux-ppc64le.cyclonedx.json
-          ./artifacts/regctl-linux-s390x.cyclonedx.json
-          ./artifacts/regctl-windows-amd64.cyclonedx.json
-          ./artifacts/regsync-darwin-amd64.cyclonedx.json
-          ./artifacts/regsync-darwin-arm64.cyclonedx.json
-          ./artifacts/regsync-linux-amd64.cyclonedx.json
-          ./artifacts/regsync-linux-arm64.cyclonedx.json
-          ./artifacts/regsync-linux-ppc64le.cyclonedx.json
-          ./artifacts/regsync-linux-s390x.cyclonedx.json
-          ./artifacts/regsync-windows-amd64.cyclonedx.json
-          ./artifacts/regbot-darwin-amd64.spdx.json
-          ./artifacts/regbot-darwin-arm64.spdx.json
-          ./artifacts/regbot-linux-amd64.spdx.json
-          ./artifacts/regbot-linux-arm64.spdx.json
-          ./artifacts/regbot-linux-ppc64le.spdx.json
-          ./artifacts/regbot-linux-s390x.spdx.json
-          ./artifacts/regbot-windows-amd64.spdx.json
-          ./artifacts/regctl-darwin-amd64.spdx.json
-          ./artifacts/regctl-darwin-arm64.spdx.json
-          ./artifacts/regctl-linux-amd64.spdx.json
-          ./artifacts/regctl-linux-arm64.spdx.json
-          ./artifacts/regctl-linux-ppc64le.spdx.json
-          ./artifacts/regctl-linux-s390x.spdx.json
-          ./artifacts/regctl-windows-amd64.spdx.json
-          ./artifacts/regsync-darwin-amd64.spdx.json
-          ./artifacts/regsync-darwin-arm64.spdx.json
-          ./artifacts/regsync-linux-amd64.spdx.json
-          ./artifacts/regsync-linux-arm64.spdx.json
-          ./artifacts/regsync-linux-ppc64le.spdx.json
-          ./artifacts/regsync-linux-s390x.spdx.json
-          ./artifacts/regsync-windows-amd64.spdx.json
+          ./artifacts/metadata.tgz
 
     - name: Save artifacts
       if: github.ref == 'refs/heads/main' && matrix.gover == env.RELEASE_GO_VER

--- a/.version-bump.lock
+++ b/.version-bump.lock
@@ -15,5 +15,7 @@
 {"name":"registry-digest-arg","key":"golang:1.19-alpine","version":"sha256:2381c1e5f8350a901597d633b2e517775eeac7a6682be39225a93b22cfd0f8bb"}
 {"name":"registry-digest-arg","key":"golang:1.20-alpine","version":"sha256:48f336ef8366b9d6246293e3047259d0f614ee167db1869bdbc343d6e09aed8a"}
 {"name":"registry-digest-match","key":"anchore/syft:v0.72.0","version":"sha256:f4735b4c31d4b9ad979eb650712cdcdb1156afe80c7d63653ac87439b379e468"}
+{"name":"registry-golang-latest","key":"golang-latest","version":"1.20"}
+{"name":"registry-golang-matrix","key":"golang-matrix","version":"[\"1.18\", \"1.19\", \"1.20\"]"}
 {"name":"registry-tag-arg-semver","key":"anchore/syft","version":"v0.72.0"}
 {"name":"registry-tag-match-semver","key":"anchore/syft","version":"v0.72.0"}

--- a/.version-bump.yml
+++ b/.version-bump.yml
@@ -2,6 +2,7 @@ files:
   "build/Dockerfile*":
     scans:
       - docker-arg-alpine
+      - docker-arg-go-tag
       - docker-arg-go
       - git-commit-ecr
       - git-commit-gcr
@@ -9,7 +10,10 @@ files:
       - git-commit-semver
   ".github/workflows/*.yml":
     scans:
+      - gha-golang-matrix
+      - gha-golang-release
       - gha-uses
+      - gha-syft-version
   "Makefile":
     scans:
       - makefile-staticcheck
@@ -24,6 +28,11 @@ scans:
     args:
       regexp: '^ARG ALPINE_VER=(?P<Tag>[a-z0-9\-\.]+)@(?P<Version>sha256:[0-9a-f]+)\s*$'
       image: "alpine"
+  docker-arg-go-tag:
+    type: "regexp"
+    source: "registry-golang-latest"
+    args:
+      regexp: '^ARG GO_VER=(?P<Version>[a-z0-9\-\.]+)-alpine@(?P<SHA>sha256:[0-9a-f]+)\s*$'
   docker-arg-go:
     type: "regexp"
     source: "registry-digest-arg"
@@ -63,6 +72,22 @@ scans:
     source: "gha-uses"
     args:
       regexp: '^\s+-?\s+uses: (?P<Repo>[^@]+)@(?P<Version>v\d+)\s*$'
+  gha-golang-matrix:
+    type: "regexp"
+    source: "registry-golang-matrix"
+    args:
+      regexp: '^\s*gover: (?P<Version>\[["0-9, \.]+\])\s*$'
+  gha-golang-release:
+    type: "regexp"
+    source: "registry-golang-latest"
+    args:
+      regexp: '^\s*RELEASE_GO_VER: "(?P<Version>[0-9\.]+)"\s*$'
+  gha-syft-version:
+    type: "regexp"
+    source: "registry-tag-arg-semver"
+    args:
+      regexp: '^\s*syft-version: "(?P<Version>v[0-9\.]+)"\s*$'
+      repo: "anchore/syft"
   makefile-staticcheck:
     type: "regexp"
     source: "git-tag-semver"
@@ -117,6 +142,27 @@ sources:
     key: "{{ .ScanMatch.Image }}:{{.ScanMatch.Tag}}"
     args:
       image: "{{ .ScanMatch.Image }}:{{.ScanMatch.Tag}}"
+  registry-golang-latest:
+    type: "registry"
+    key: "golang-latest"
+    args:
+      repo: "golang"
+      type: "tag"
+    filter:
+      expr: '^\d+\.\d+$'
+    sort:
+      method: "semver"
+  registry-golang-matrix:
+    type: "registry"
+    key: "golang-matrix"
+    args:
+      repo: "golang"
+      type: "tag"
+    filter:
+      expr: '^\d+\.\d+$'
+    sort:
+      method: "semver"
+    template: '["{{ index .VerMap ( index .VerList 2 ) }}", "{{ index .VerMap ( index .VerList 1 ) }}", "{{ index .VerMap ( index .VerList 0 ) }}"]'
   gha-uses:
     type: "git"
     key: "{{ .ScanMatch.Repo }}"


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Describe the change

This adds signing to the binary artifacts using cosign's keyless method.
This also added entries for Syft and Go in the version-bump config.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

`metadata.tgz` will be shipped with artifacts with a `.sig` and `.pem` that can be used with `cosign verify-blob`.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Binary artifacts are signed with cosign keyless signing.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
