### PR TITLE
Artifact manifest is experimental

### DIFF
--- a/cmd/regctl/artifact.go
+++ b/cmd/regctl/artifact.go
@@ -35,7 +35,6 @@ const (
 
 var manifestKnownTypes = []string{
 	types.MediaTypeOCI1Manifest,
-	types.MediaTypeOCI1Artifact,
 }
 var artifactFileKnownTypes = []string{
 	"application/octet-stream",
@@ -132,10 +131,11 @@ func init() {
 	artifactListCmd.Flags().StringVarP(&artifactOpts.formatList, "format", "", "{{printPretty .}}", "Format output with go template syntax")
 	artifactListCmd.Flags().StringVarP(&artifactOpts.platform, "platform", "p", "", "Specify platform (e.g. linux/amd64 or local)")
 
-	artifactPutCmd.Flags().StringVarP(&artifactOpts.artifactMT, "media-type", "", types.MediaTypeOCI1Manifest, "Manifest media-type")
+	artifactPutCmd.Flags().StringVarP(&artifactOpts.artifactMT, "media-type", "", types.MediaTypeOCI1Manifest, "EXPERIMENTAL: Manifest media-type")
 	artifactPutCmd.RegisterFlagCompletionFunc("media-type", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return manifestKnownTypes, cobra.ShellCompDirectiveNoFileComp
 	})
+	artifactPutCmd.Flags().MarkHidden("media-type")
 	artifactPutCmd.Flags().StringVarP(&artifactOpts.artifactType, "artifact-type", "", "", "Artifact type or config mediaType")
 	artifactPutCmd.RegisterFlagCompletionFunc("artifact-type", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return configKnownTypes, cobra.ShellCompDirectiveNoFileComp
@@ -452,6 +452,7 @@ func runArtifactPut(cmd *cobra.Command, args []string) error {
 
 	switch artifactOpts.artifactMT {
 	case types.MediaTypeOCI1Artifact:
+		log.Warnf("changing media-type is experimental and non-portable")
 		hasConfig = false
 	case "", types.MediaTypeOCI1Manifest:
 		hasConfig = true

--- a/types/manifest/oci1.go
+++ b/types/manifest/oci1.go
@@ -33,6 +33,8 @@ type oci1Index struct {
 	common
 	v1.Index
 }
+
+// oci1Artifact is EXPERIMENTAL
 type oci1Artifact struct {
 	common
 	v1.ArtifactManifest

--- a/types/mediatype.go
+++ b/types/mediatype.go
@@ -11,7 +11,7 @@ const (
 	MediaTypeDocker2ManifestList = "application/vnd.docker.distribution.manifest.list.v2+json"
 	// MediaTypeDocker2ImageConfig is for the configuration json object media type
 	MediaTypeDocker2ImageConfig = "application/vnd.docker.container.image.v1+json"
-	// MediaTypeOCI1Artifact OCI v1 artifact media type
+	// MediaTypeOCI1Artifact EXPERIMENTAL OCI v1 artifact media type
 	MediaTypeOCI1Artifact = "application/vnd.oci.artifact.manifest.v1+json"
 	// MediaTypeOCI1Manifest OCI v1 manifest media type
 	MediaTypeOCI1Manifest = "application/vnd.oci.image.manifest.v1+json"

--- a/types/oci/v1/artifact.go
+++ b/types/oci/v1/artifact.go
@@ -4,7 +4,7 @@ import (
 	"github.com/regclient/regclient/types"
 )
 
-// ArtifactManifest defines an OCI Artifact
+// ArtifactManifest EXPERIMENTAL defines an OCI Artifact
 type ArtifactManifest struct {
 	// MediaType is the media type of the object this schema refers to.
 	MediaType string `json:"mediaType"`


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

OCI is delaying the release of the artifact manifest and it may change in the future.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This marks the artifact manifest as experimental and hides flags that exposed it.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```
$ regctl artifact put --help
... does not show --media-type ...

$ echo test | regctl artifact put --media-type application/vnd.oci.artifact.manifest.v1+json --artifact-type application/vnd.example.test localhost:5000/artifact:test-oci-artifact
WARN[0000] changing media-type is experimental and non-portable
failed to put manifest localhost:5000/artifact:test-oci-artifact: request failed: unexpected http status code: Bad Request [http 400]: {"errors":[{"code":"MANIFEST_INVALID","message":"manifest invalid","detail":{}}]}
```

The warning was added to indicate the flag is unsupported, and the failure is expected on registries that do not support the artifact manifest.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Artifact manifest is experimental
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
