### PR TITLE
Adding image mod to-docker

### DIFF
--- a/cmd/regctl/image.go
+++ b/cmd/regctl/image.go
@@ -465,6 +465,20 @@ func init() {
 			return nil
 		},
 	}, "time-max", "", `max timestamp for both the config and layers`)
+	flagDocker := imageModCmd.Flags().VarPF(&modFlagFunc{
+		t: "bool",
+		f: func(val string) error {
+			b, err := strconv.ParseBool(val)
+			if err != nil {
+				return fmt.Errorf("unable to parse value %s: %w", val, err)
+			}
+			if b {
+				imageOpts.modOpts = append(imageOpts.modOpts, mod.WithManifestToDocker())
+			}
+			return nil
+		},
+	}, "to-docker", "", `convert to Docker schema2 media types`)
+	flagDocker.NoOptDefVal = "true"
 	flagOCI := imageModCmd.Flags().VarPF(&modFlagFunc{
 		t: "bool",
 		f: func(val string) error {

--- a/mod/mod_test.go
+++ b/mod/mod_test.go
@@ -97,6 +97,14 @@ func TestMod(t *testing.T) {
 			wantSame: true,
 		},
 		{
+			name: "To Docker",
+			opts: []Opts{
+				WithManifestToDocker(),
+			},
+			ref:      "ocidir://testrepo:v1",
+			wantSame: false,
+		},
+		{
 			name: "To OCI Referrers",
 			opts: []Opts{
 				WithManifestToOCIReferrers(),


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This adds a flag `regctl image mod --to-docker` to convert manifests from OCI to Docker schema2 types. This is used to support old installs of the Docker engine.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```
regctl image copy ubuntu $tgt
regctl image mod $tgt --to-docker --replace
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Adding `regctl image mod --to-docker` to convert manifests from OCI to Docker schema2
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
