### PR TITLE
Fix referrer handling of auth response

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -322,7 +322,7 @@ func ParseAuthHeaders(ahl []string) ([]Challenge, error) {
 	for _, ah := range ahl {
 		c, err := ParseAuthHeader(ah)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse challenge header: %s", ah)
+			return nil, fmt.Errorf("failed to parse challenge header: %s, %w", ah, err)
 		}
 		cl = append(cl, c...)
 	}

--- a/internal/auth/error.go
+++ b/internal/auth/error.go
@@ -1,22 +1,24 @@
 package auth
 
-import "errors"
+import (
+	"github.com/regclient/regclient/types"
+)
 
 var (
 	// ErrEmptyChallenge indicates an issue with the received challenge in the WWW-Authenticate header
-	ErrEmptyChallenge = errors.New("empty challenge header")
+	ErrEmptyChallenge = types.ErrEmptyChallenge
 	// ErrInvalidChallenge indicates an issue with the received challenge in the WWW-Authenticate header
-	ErrInvalidChallenge = errors.New("invalid challenge header")
+	ErrInvalidChallenge = types.ErrInvalidChallenge
 	// ErrNoNewChallenge indicates a challenge update did not result in any change
-	ErrNoNewChallenge = errors.New("no new challenge")
+	ErrNoNewChallenge = types.ErrNoNewChallenge
 	// ErrNotFound indicates no credentials found for basic auth
-	ErrNotFound = errors.New("no credentials available for basic auth")
+	ErrNotFound = types.ErrNotFound
 	// ErrNotImplemented returned when method has not been implemented yet
-	ErrNotImplemented = errors.New("not implemented")
+	ErrNotImplemented = types.ErrNotImplemented
 	// ErrParseFailure indicates the WWW-Authenticate header could not be parsed
-	ErrParseFailure = errors.New("parse failure")
+	ErrParseFailure = types.ErrParsingFailed
 	// ErrUnauthorized request was not authorized
-	ErrUnauthorized = errors.New("unauthorized")
+	ErrUnauthorized = types.ErrHTTPUnauthorized
 	// ErrUnsupported indicates the request was unsupported
-	ErrUnsupported = errors.New("unsupported")
+	ErrUnsupported = types.ErrUnsupported
 )


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Fixes #384
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Harbor responds with an unauthorized rather than not found to the referrer API. This ignores those errors.
It also removes the `_oci/artifacts` API fallback from referrer the development work, and cleans up auth error handling.

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Actions against a Harbor registry that call the referrers API won't trigger backoffs or output warnings.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Improve handling of the referrers API with Harbor
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
