### PR TITLE
Allow registry to adjust blob chunk size

### DIFF
--- a/cmd/regbot/config.go
+++ b/cmd/regbot/config.go
@@ -21,12 +21,14 @@ type Config struct {
 
 // ConfigDefaults is uses for general options and defaults for ConfigScript entries
 type ConfigDefaults struct {
-	Interval       time.Duration `yaml:"interval" json:"interval"`
-	Schedule       string        `yaml:"schedule" json:"schedule"`
-	Parallel       int           `yaml:"parallel" json:"parallel"`
-	SkipDockerConf bool          `yaml:"skipDockerConfig" json:"skipDockerConfig"`
-	Timeout        time.Duration `yaml:"timeout" json:"timeout"`
-	UserAgent      string        `yaml:"userAgent" json:"userAgent"`
+	Interval time.Duration `yaml:"interval" json:"interval"`
+	Schedule string        `yaml:"schedule" json:"schedule"`
+	Parallel int           `yaml:"parallel" json:"parallel"`
+	Timeout  time.Duration `yaml:"timeout" json:"timeout"`
+	// general options
+	BlobLimit      int64  `yaml:"blobLimit" json:"blobLimit"`
+	SkipDockerConf bool   `yaml:"skipDockerConfig" json:"skipDockerConfig"`
+	UserAgent      string `yaml:"userAgent" json:"userAgent"`
 }
 
 // ConfigScript defines a source/target repository to sync
@@ -105,13 +107,6 @@ func configExpandTemplates(c *Config) error {
 		}
 		c.Creds[i].RegCert = val
 	}
-	// for i := range c.Scripts {
-	// 	val, err := template.String(c.Scripts[i].Script, nil)
-	// 	if err != nil {
-	// 		return err
-	// 	}
-	// 	c.Scripts[i].Script = val
-	// }
 	return nil
 }
 

--- a/cmd/regbot/root.go
+++ b/cmd/regbot/root.go
@@ -247,6 +247,12 @@ func loadConf() error {
 	rcOpts := []regclient.Opt{
 		regclient.WithLog(log),
 	}
+	if conf.Defaults.BlobLimit != 0 {
+		rcOpts = append(rcOpts, regclient.WithBlobLimit(conf.Defaults.BlobLimit))
+	}
+	if !conf.Defaults.SkipDockerConf {
+		rcOpts = append(rcOpts, regclient.WithDockerCreds(), regclient.WithDockerCerts())
+	}
 	if conf.Defaults.UserAgent != "" {
 		rcOpts = append(rcOpts, regclient.WithUserAgent(conf.Defaults.UserAgent))
 	} else {
@@ -256,9 +262,6 @@ func loadConf() error {
 		} else {
 			rcOpts = append(rcOpts, regclient.WithUserAgent(UserAgent+" ("+info.VCSRef+")"))
 		}
-	}
-	if !conf.Defaults.SkipDockerConf {
-		rcOpts = append(rcOpts, regclient.WithDockerCreds(), regclient.WithDockerCerts())
 	}
 	rcHosts := []config.Host{}
 	for _, host := range conf.Creds {

--- a/cmd/regctl/config_test.go
+++ b/cmd/regctl/config_test.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestConfig(t *testing.T) {
+	// set a temp dir for storing configs
+	tempDir := t.TempDir()
+	origEnv, set := os.LookupEnv(ConfigEnv)
+	if set {
+		defer os.Setenv(ConfigEnv, origEnv)
+	}
+	os.Setenv(ConfigEnv, filepath.Join(tempDir, "config.json"))
+
+	// test empty config
+	out, err := cobraTest(t, "config", "get", "--format", "{{ json . }}")
+	if err != nil {
+		t.Errorf("failed to run config get: %v", err)
+	}
+	if out != `{"hosts":{}}` {
+		t.Errorf("unexpected output from empty config, expected: %s, received: %s", `{"hosts":{}}`, out)
+	}
+
+	// set options
+	testLimit := "420000000"
+	out, err = cobraTest(t, "config", "set", "--blob-limit", testLimit)
+	if err != nil {
+		t.Errorf("failed to set blob-limit: %v", err)
+	}
+	if out != "" {
+		t.Errorf("unexpected output from set: %s", out)
+	}
+	out, err = cobraTest(t, "config", "set", "--docker-cert=false")
+	if err != nil {
+		t.Errorf("failed to set docker-cert: %v", err)
+	}
+	if out != "" {
+		t.Errorf("unexpected output from set: %s", out)
+	}
+	out, err = cobraTest(t, "config", "set", "--docker-cred=false")
+	if err != nil {
+		t.Errorf("failed to set docker-cred: %v", err)
+	}
+	if out != "" {
+		t.Errorf("unexpected output from set: %s", out)
+	}
+
+	// get changes
+	out, err = cobraTest(t, "config", "get", "--format", "{{ .BlobLimit }}")
+	if err != nil {
+		t.Errorf("failed to run config get on blob-limit: %v", err)
+	}
+	if out != testLimit {
+		t.Errorf("unexpected output for blob-limit, expected: %s, received: %s", testLimit, out)
+	}
+	out, err = cobraTest(t, "config", "get", "--format", "{{ .IncDockerCert }}")
+	if err != nil {
+		t.Errorf("failed to run config get on docker-cert: %v", err)
+	}
+	if out != "false" {
+		t.Errorf("unexpected output for docker-cert, expected: false, received: %s", out)
+	}
+	out, err = cobraTest(t, "config", "get", "--format", "{{ .IncDockerCred }}")
+	if err != nil {
+		t.Errorf("failed to run config get on docker-cred: %v", err)
+	}
+	if out != "false" {
+		t.Errorf("unexpected output for docker-cred, expected: false, received: %s", out)
+	}
+
+	// reset back to zero values
+	out, err = cobraTest(t, "config", "set", "--blob-limit", "0")
+	if err != nil {
+		t.Errorf("failed to set blob-limit: %v", err)
+	}
+	if out != "" {
+		t.Errorf("unexpected output from set: %s", out)
+	}
+	out, err = cobraTest(t, "config", "set", "--docker-cert")
+	if err != nil {
+		t.Errorf("failed to set docker-cert: %v", err)
+	}
+	if out != "" {
+		t.Errorf("unexpected output from set: %s", out)
+	}
+	out, err = cobraTest(t, "config", "set", "--docker-cred")
+	if err != nil {
+		t.Errorf("failed to set docker-cred: %v", err)
+	}
+	if out != "" {
+		t.Errorf("unexpected output from set: %s", out)
+	}
+
+	// verify config is empty
+	out, err = cobraTest(t, "config", "get", "--format", "{{ json . }}")
+	if err != nil {
+		t.Errorf("failed to run config get: %v", err)
+	}
+	if out != `{"hosts":{}}` {
+		t.Errorf("unexpected output from empty config, expected: %s, received: %s", `{"hosts":{}}`, out)
+	}
+
+}

--- a/cmd/regctl/root.go
+++ b/cmd/regctl/root.go
@@ -109,6 +109,9 @@ func newRegClient() *regclient.RegClient {
 			rcOpts = append(rcOpts, regclient.WithUserAgent(UserAgent+" ("+info.VCSRef+")"))
 		}
 	}
+	if conf.BlobLimit != 0 {
+		rcOpts = append(rcOpts, regclient.WithBlobLimit(conf.BlobLimit))
+	}
 	if conf.IncDockerCred == nil || *conf.IncDockerCred {
 		rcOpts = append(rcOpts, regclient.WithDockerCreds())
 	}

--- a/cmd/regsync/config.go
+++ b/cmd/regsync/config.go
@@ -46,9 +46,11 @@ type ConfigDefaults struct {
 	ForceRecursive  *bool                  `yaml:"forceRecursive" json:"forceRecursive"`
 	IncludeExternal *bool                  `yaml:"includeExternal" json:"includeExternal"`
 	MediaTypes      []string               `yaml:"mediaTypes" json:"mediaTypes"`
-	SkipDockerConf  bool                   `yaml:"skipDockerConfig" json:"skipDockerConfig"`
 	Hooks           ConfigHooks            `yaml:"hooks" json:"hooks"`
-	UserAgent       string                 `yaml:"userAgent" json:"userAgent"`
+	// general options
+	BlobLimit      int64  `yaml:"blobLimit" json:"blobLimit"`
+	SkipDockerConf bool   `yaml:"skipDockerConfig" json:"skipDockerConfig"`
+	UserAgent      string `yaml:"userAgent" json:"userAgent"`
 }
 
 // ConfigRateLimit is for rate limit settings

--- a/cmd/regsync/root.go
+++ b/cmd/regsync/root.go
@@ -343,6 +343,12 @@ func loadConf() error {
 	rcOpts := []regclient.Opt{
 		regclient.WithLog(log),
 	}
+	if conf.Defaults.BlobLimit != 0 {
+		rcOpts = append(rcOpts, regclient.WithBlobLimit(conf.Defaults.BlobLimit))
+	}
+	if !conf.Defaults.SkipDockerConf {
+		rcOpts = append(rcOpts, regclient.WithDockerCreds(), regclient.WithDockerCerts())
+	}
 	if conf.Defaults.UserAgent != "" {
 		rcOpts = append(rcOpts, regclient.WithUserAgent(conf.Defaults.UserAgent))
 	} else {
@@ -352,9 +358,6 @@ func loadConf() error {
 		} else {
 			rcOpts = append(rcOpts, regclient.WithUserAgent(UserAgent+" ("+info.VCSRef+")"))
 		}
-	}
-	if !conf.Defaults.SkipDockerConf {
-		rcOpts = append(rcOpts, regclient.WithDockerCreds(), regclient.WithDockerCerts())
 	}
 	rcHosts := []config.Host{}
 	for _, host := range conf.Creds {

--- a/regclient.go
+++ b/regclient.go
@@ -95,6 +95,13 @@ func New(opts ...Opt) *RegClient {
 	return &rc
 }
 
+// WithBlobLimit sets the max size for chunked blob uploads which get stored in memory
+func WithBlobLimit(limit int64) Opt {
+	return func(rc *RegClient) {
+		rc.regOpts = append(rc.regOpts, reg.WithBlobLimit(limit))
+	}
+}
+
 // WithCertDir adds a path of certificates to trust similar to Docker's /etc/docker/certs.d
 func WithCertDir(path ...string) Opt {
 	return func(rc *RegClient) {

--- a/regclient/regclient.go
+++ b/regclient/regclient.go
@@ -9,14 +9,13 @@ import (
 	"github.com/regclient/regclient/config"
 	"github.com/regclient/regclient/internal/reghttp"
 	"github.com/regclient/regclient/scheme"
-	"github.com/regclient/regclient/scheme/reg"
 	"github.com/regclient/regclient/types/repo"
 	"github.com/regclient/regclient/types/tag"
 )
 
 const (
-	DefaultBlobChunk   = reg.DefaultBlobChunk
-	DefaultBlobMax     = reg.DefaultBlobMax
+	DefaultBlobChunk   = 1024 * 1024
+	DefaultBlobMax     = -1
 	DefaultRetryLimit  = reghttp.DefaultRetryLimit
 	DefaultUserAgent   = rcTop.DefaultUserAgent
 	DockerCertDir      = rcTop.DockerCertDir

--- a/scheme/reg/blob.go
+++ b/scheme/reg/blob.go
@@ -253,6 +253,30 @@ func (reg *Reg) blobGetUploadURL(ctx context.Context, r ref.Ref) (*url.URL, erro
 		return nil, fmt.Errorf("failed to send blob post, ref %s: %w", r.CommonName(), reghttp.HTTPError(resp.HTTPResponse().StatusCode))
 	}
 
+	// if min size header received, check/adjust host settings
+	minSizeStr := resp.HTTPResponse().Header.Get(blobChunkMinHeader)
+	if minSizeStr != "" {
+		minSize, err := strconv.ParseInt(minSizeStr, 10, 64)
+		if err != nil {
+			reg.log.WithFields(logrus.Fields{
+				"size": minSizeStr,
+				"err":  err,
+			}).Warn("Failed to parse chunk size header")
+		} else {
+			host := reg.hostGet(r.Registry)
+			if (host.BlobChunk > 0 && minSize > host.BlobChunk) || (host.BlobChunk <= 0 && minSize > reg.blobChunkSize) {
+				if minSize > reg.blobChunkLimit {
+					host.BlobChunk = reg.blobChunkLimit
+				} else {
+					host.BlobChunk = minSize
+				}
+				reg.log.WithFields(logrus.Fields{
+					"size": host.BlobChunk,
+					"host": host.Name,
+				}).Debug("Registry requested min chunk size")
+			}
+		}
+	}
 	// Extract the location into a new putURL based on whether it's relative, fqdn with a scheme, or without a scheme.
 	location := resp.HTTPResponse().Header.Get("Location")
 	if location == "" {
@@ -299,6 +323,31 @@ func (reg *Reg) blobMount(ctx context.Context, rTgt ref.Ref, d types.Descriptor,
 		return nil, "", fmt.Errorf("failed to mount blob, digest %s, ref %s: %w", d.Digest.String(), rTgt.CommonName(), err)
 	}
 	defer resp.Close()
+
+	// if min size header received, check/adjust host settings
+	minSizeStr := resp.HTTPResponse().Header.Get(blobChunkMinHeader)
+	if minSizeStr != "" {
+		minSize, err := strconv.ParseInt(minSizeStr, 10, 64)
+		if err != nil {
+			reg.log.WithFields(logrus.Fields{
+				"size": minSizeStr,
+				"err":  err,
+			}).Warn("Failed to parse chunk size header")
+		} else {
+			host := reg.hostGet(rTgt.Registry)
+			if (host.BlobChunk > 0 && minSize > host.BlobChunk) || (host.BlobChunk <= 0 && minSize > reg.blobChunkSize) {
+				if minSize > reg.blobChunkLimit {
+					host.BlobChunk = reg.blobChunkLimit
+				} else {
+					host.BlobChunk = minSize
+				}
+				reg.log.WithFields(logrus.Fields{
+					"size": host.BlobChunk,
+					"host": host.Name,
+				}).Debug("Registry requested min chunk size")
+			}
+		}
+	}
 	// 201 indicates the blob mount succeeded
 	if resp.HTTPResponse().StatusCode == 201 {
 		return nil, "", nil


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This adds support for the `OCI-Chunk-Min-Length` header defined in https://github.com/opencontainers/distribution-spec/pull/391

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Performing a chunked upload to a registry that uses this header, with a small chunk size, will automatically adjust as long as the chunk size doesn't exceed the limit.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Support `OCI-Chunk-Min-Length` header
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
