### PR TITLE
Include a scratch layer in the fallback tag delete

### DIFF
--- a/scheme/reg/tag_test.go
+++ b/scheme/reg/tag_test.go
@@ -42,7 +42,6 @@ func TestTag(t *testing.T) {
 	delFallbackTag := "del-fallback"
 	delFallbackManifest := "digest for del-fallback"
 	delFallbackDigest := digest.FromString(delFallbackManifest)
-	fallbackConfigDigest := digest.FromString("digest for fallback config")
 	uuid1 := uuid.New()
 	ctx := context.Background()
 	rrs := []reqresp.ReqResp{
@@ -193,7 +192,7 @@ func TestTag(t *testing.T) {
 		},
 		{
 			ReqEntry: reqresp.ReqEntry{
-				Name:   "POST for fallback config",
+				Name:   "POST for fallback blob",
 				Method: "POST",
 				Path:   "/v2" + repoPath + "/blobs/uploads/",
 			},
@@ -207,8 +206,9 @@ func TestTag(t *testing.T) {
 			},
 		},
 		{
+			// accept any blob content since fallback content is unknown
 			ReqEntry: reqresp.ReqEntry{
-				Name:   "PUT for fallback config",
+				Name:   "PUT for fallback blob",
 				Method: "PUT",
 				Path:   "/v2" + repoPath + "/blobs/uploads/" + uuid1.String(),
 			},
@@ -216,7 +216,7 @@ func TestTag(t *testing.T) {
 				Status: http.StatusCreated,
 				Headers: http.Header{
 					"Content-Length": {"0"},
-					"Location":       {"/v2" + repoPath + "/blobs/" + fallbackConfigDigest.String()},
+					"Location":       {"/v2" + repoPath + "/blobs/" + uuid1.String()},
 				},
 			},
 		},

--- a/types/descriptor.go
+++ b/types/descriptor.go
@@ -44,6 +44,8 @@ type Descriptor struct {
 	ArtifactType string `json:"artifactType,omitempty"`
 }
 
+var ScratchData = []byte("{}")
+var ScratchDigest = digest.FromBytes(ScratchData)
 var emptyDigest = digest.FromBytes([]byte{})
 var mtToOCI map[string]string
 


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

This should solve #393.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

The temporary manifest used to purge a tag needs a layer for for some registries to allow it.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

`regctl tag rm` on certain registries.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Fix an issue on `regctl tag rm` to support registries that require a layer
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
