### PR TITLE
Only change config media type from known values

### DIFF
--- a/mod/manifest.go
+++ b/mod/manifest.go
@@ -229,7 +229,7 @@ func WithManifestToDocker() Opts {
 				if dm.m.GetDescriptor().MediaType != types.MediaTypeDocker2Manifest {
 					changed = true
 				}
-				if ociM.Config.MediaType != types.MediaTypeDocker2ImageConfig {
+				if ociM.Config.MediaType == types.MediaTypeOCI1ImageConfig {
 					ociM.Config.MediaType = types.MediaTypeDocker2ImageConfig
 					changed = true
 				}
@@ -293,7 +293,7 @@ func WithManifestToOCI() Opts {
 				if dm.m.GetDescriptor().MediaType != types.MediaTypeOCI1Manifest {
 					changed = true
 				}
-				if ociM.Config.MediaType != types.MediaTypeOCI1ImageConfig {
+				if ociM.Config.MediaType == types.MediaTypeDocker2ImageConfig {
 					ociM.Config.MediaType = types.MediaTypeOCI1ImageConfig
 					changed = true
 				}


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Changing the config mediaType blindly can break artifacts.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This checks the config mediaType for a known good value before changing it.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Converting an artifact with a custom config mediaType should not change the value.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Image mod only convert `config.mediaType` between known values
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [ ] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
