### PR TITLE
Ignore anonymous blob mounts failures

### DIFF
--- a/scheme/reg/blob.go
+++ b/scheme/reg/blob.go
@@ -302,8 +302,10 @@ func (reg *Reg) blobMount(ctx context.Context, rTgt ref.Ref, d types.Descriptor,
 	// build/send request
 	query := url.Values{}
 	query.Set("mount", d.Digest.String())
+	ignoreErr := true // ignore errors from anonymous blob mount attempts
 	if rSrc.Registry == rTgt.Registry && rSrc.Repository != "" {
 		query.Set("from", rSrc.Repository)
+		ignoreErr = false
 	}
 
 	req := &reghttp.Req{
@@ -315,6 +317,7 @@ func (reg *Reg) blobMount(ctx context.Context, rTgt ref.Ref, d types.Descriptor,
 				Repository: rTgt.Repository,
 				Path:       "blobs/uploads/",
 				Query:      query,
+				IgnoreErr:  ignoreErr,
 			},
 		},
 	}


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Fixes #398
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Some registries fail on an anonymous blob mount instead of defaulting to a 202 response. This ignores those errors instead of triggering the backoff code. The errors are already ignored at higher levels since a failure to run the blob mount is followed by the slower blob upload.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Pushing images and deleting tags on certain versions of quay.io will stop triggering backoffs.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Ignore anonymous blob mount failures
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [ ] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
