### PR TITLE
Fix support for docker credsStore

### DIFF
--- a/config/credhelper.go
+++ b/config/credhelper.go
@@ -70,4 +70,25 @@ func (ch *credHelper) get(host *Host) error {
 	return nil
 }
 
-// store and list methods not implemented
+func (ch *credHelper) list() ([]Host, error) {
+	credList := map[string]string{}
+	outB, err := ch.run("list", bytes.NewReader([]byte{}))
+	if err != nil {
+		outS := strings.TrimSpace(string(outB))
+		return nil, fmt.Errorf("error getting credential list, output: %s, error: %v", outS, err)
+	}
+	err = json.NewDecoder(bytes.NewReader(outB)).Decode(&credList)
+	if err != nil {
+		return nil, fmt.Errorf("error reading credential list: %w", err)
+	}
+	hostList := []Host{}
+	for host, user := range credList {
+		h := HostNewName(host)
+		h.User = user
+		h.CredHelper = ch.prog
+		hostList = append(hostList, *h)
+	}
+	return hostList, nil
+}
+
+// store method not implemented

--- a/config/docker.go
+++ b/config/docker.go
@@ -91,6 +91,14 @@ func dockerParse(cf *conffile.File) ([]Host, error) {
 		}
 		hosts = append(hosts, *h)
 	}
+	// add credStore entries
+	if dc.CredentialsStore != "" {
+		ch := newCredHelper(dockerHelperPre+dc.CredentialsStore, map[string]string{})
+		csHosts, err := ch.list()
+		if err == nil {
+			hosts = append(hosts, csHosts...)
+		}
+	}
 	return hosts, nil
 }
 
@@ -98,8 +106,6 @@ func dockerAuthToHost(name string, conf dockerConfig, auth dockerAuthConfig) (Ho
 	helper := ""
 	if conf.CredentialHelpers != nil && conf.CredentialHelpers[name] != "" {
 		helper = dockerHelperPre + conf.CredentialHelpers[name]
-	} else if conf.CredentialsStore != "" {
-		helper = dockerHelperPre + conf.CredentialsStore
 	}
 	// parse base64 auth into user/pass
 	if auth.Auth != "" {

--- a/config/testdata/config.json
+++ b/config/testdata/config.json
@@ -11,5 +11,6 @@
     "testhost.example.com": "test",
     "https://index.docker.io/v1/": "test",
     "http://http.example.com/": "test"
-  }
+  },
+  "credsStore": "teststore"
 }

--- a/config/testdata/docker-credential-test
+++ b/config/testdata/docker-credential-test
@@ -1,5 +1,12 @@
 #!/bin/sh
 
+list='{
+  "https://index.docker.io/v1/": "hubuser",
+  "http://http.example.com/": "hello",
+  "testhost.example.com": "hello",
+  "testtoken.example.com": "<token>"
+}'
+
 registry_hub='
 { "ServerURL": "https://index.docker.io/v1/",
   "Username": "hubuser",
@@ -45,6 +52,9 @@ if [ "$1" = "get" ]; then
       exit 0
       ;;
   esac
+elif [ "$1" = "list" ]; then
+  echo "${list}"
+  exit 0
 fi
 # unhandled request
 exit 1

--- a/config/testdata/docker-credential-teststore
+++ b/config/testdata/docker-credential-teststore
@@ -1,0 +1,49 @@
+#!/bin/sh
+
+list='{
+  "http://storehttp.example.com/": "hello",
+  "storehost.example.com": "hello",
+  "storetoken.example.com": "<token>"
+}'
+
+registry_http='
+{ "ServerURL": "http://storehttp.example.com/",
+  "Username": "hello",
+  "Secret": "universe"
+}
+'
+registry_testhost='
+{ "ServerURL": "storehost.example.com",
+  "Username": "hello",
+  "Secret": "world"
+}
+'
+registry_testtoken='
+{ "ServerURL": "storetoken.example.com",
+  "Username": "<token>",
+  "Secret": "deadbeefcafe"
+}
+'
+
+if [ "$1" = "get" ]; then
+  read hostname
+  case "$hostname" in
+    http://storehttp.example.com/)
+      echo "${registry_http}"
+      exit 0
+      ;;
+    storehost.example.com)
+      echo "${registry_testhost}"
+      exit 0
+      ;;
+    storetoken.example.com)
+      echo "${registry_testtoken}"
+      exit 0
+      ;;
+  esac
+elif [ "$1" = "list" ]; then
+  echo "${list}"
+  exit 0
+fi
+# unhandled request
+exit 1


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Fixes #403. The handling of docker's credStore assumed there would be empty auths entries, rather than fetching the list from the credential helper.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This makes a best effort to get the list from the helper. Error handling and logging of issues is minimal to avoid a bad `docker/config.json` breaking the regclient commands.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Running binaries on Docker Desktop should detect docker logins.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Fix handling of docker registry logins with credStore
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
