### PR TITLE
regsync handle repo list exceeding catalog limit

### DIFF
--- a/cmd/regsync/root.go
+++ b/cmd/regsync/root.go
@@ -380,100 +380,111 @@ func (s ConfigSync) process(ctx context.Context, action string) error {
 	var retErr error
 	switch s.Type {
 	case "registry":
-		sRepos, err := rc.RepoList(ctx, s.Source)
-		if err != nil {
-			log.WithFields(logrus.Fields{
-				"source": s.Source,
-				"error":  err,
-			}).Error("Failed to list source repositories")
-			return err
-		}
-		sRepoList, err := sRepos.GetRepos()
-		if err != nil {
-			log.WithFields(logrus.Fields{
-				"source": s.Source,
-				"error":  err,
-			}).Error("Failed to list source repositories")
-			return err
-		}
-		for _, repo := range sRepoList {
-			sRepoRef, err := ref.New(fmt.Sprintf("%s/%s", s.Source, repo))
+		last := ""
+		for {
+			repoOpts := []scheme.RepoOpts{}
+			if last != "" {
+				repoOpts = append(repoOpts, scheme.WithRepoLast(last))
+			}
+			sRepos, err := rc.RepoList(ctx, s.Source, repoOpts...)
 			if err != nil {
 				log.WithFields(logrus.Fields{
 					"source": s.Source,
-					"repo":   repo,
 					"error":  err,
-				}).Error("Failed to define source reference")
+				}).Error("Failed to list source repositories")
 				return err
 			}
-			sTags, err := rc.TagList(ctx, sRepoRef)
+			sRepoList, err := sRepos.GetRepos()
 			if err != nil {
 				log.WithFields(logrus.Fields{
-					"source": sRepoRef.CommonName(),
+					"source": s.Source,
 					"error":  err,
-				}).Error("Failed getting source tags")
-				retErr = err
-				continue
-			}
-			sTagsList, err := sTags.GetTags()
-			if err != nil {
-				log.WithFields(logrus.Fields{
-					"source": sRepoRef.CommonName(),
-					"error":  err,
-				}).Error("Failed getting source tags")
-				retErr = err
-				continue
-			}
-			sTagList, err := s.filterTags(sTagsList)
-			if err != nil {
-				log.WithFields(logrus.Fields{
-					"source": sRepoRef.CommonName(),
-					"allow":  s.Tags.Allow,
-					"deny":   s.Tags.Deny,
-					"error":  err,
-				}).Error("Failed processing tag filters")
-				retErr = err
-				continue
-			}
-			if len(sTagList) == 0 {
-				log.WithFields(logrus.Fields{
-					"source":    sRepoRef.CommonName(),
-					"allow":     s.Tags.Allow,
-					"deny":      s.Tags.Deny,
-					"available": sTagsList,
-				}).Info("No matching tags found")
-				retErr = err
-				continue
-			}
-			tRepoRef, err := ref.New(fmt.Sprintf("%s/%s", s.Target, repo))
-			if err != nil {
-				log.WithFields(logrus.Fields{
-					"target": s.Target,
-					"repo":   repo,
-					"error":  err,
-				}).Error("Failed parsing target")
+				}).Error("Failed to list source repositories")
 				return err
 			}
-			for _, tag := range sTagList {
-				sRef := sRepoRef
-				sRef.Tag = tag
-				tRef := tRepoRef
-				tRef.Tag = tag
-				err = s.processRef(ctx, sRef, tRef, action)
+			if len(sRepoList) == 0 || last == sRepoList[len(sRepoList)-1] {
+				break
+			}
+			last = sRepoList[len(sRepoList)-1]
+			for _, repo := range sRepoList {
+				sRepoRef, err := ref.New(fmt.Sprintf("%s/%s", s.Source, repo))
 				if err != nil {
 					log.WithFields(logrus.Fields{
-						"target": tRef.CommonName(),
-						"source": sRef.CommonName(),
+						"source": s.Source,
+						"repo":   repo,
 						"error":  err,
-					}).Error("Failed to sync")
-					retErr = err
+					}).Error("Failed to define source reference")
+					return err
 				}
-				err = rc.Close(ctx, tRef)
+				sTags, err := rc.TagList(ctx, sRepoRef)
 				if err != nil {
 					log.WithFields(logrus.Fields{
-						"ref":   tRef.CommonName(),
-						"error": err,
-					}).Error("Error closing ref")
+						"source": sRepoRef.CommonName(),
+						"error":  err,
+					}).Error("Failed getting source tags")
+					retErr = err
+					continue
+				}
+				sTagsList, err := sTags.GetTags()
+				if err != nil {
+					log.WithFields(logrus.Fields{
+						"source": sRepoRef.CommonName(),
+						"error":  err,
+					}).Error("Failed getting source tags")
+					retErr = err
+					continue
+				}
+				sTagList, err := s.filterTags(sTagsList)
+				if err != nil {
+					log.WithFields(logrus.Fields{
+						"source": sRepoRef.CommonName(),
+						"allow":  s.Tags.Allow,
+						"deny":   s.Tags.Deny,
+						"error":  err,
+					}).Error("Failed processing tag filters")
+					retErr = err
+					continue
+				}
+				if len(sTagList) == 0 {
+					log.WithFields(logrus.Fields{
+						"source":    sRepoRef.CommonName(),
+						"allow":     s.Tags.Allow,
+						"deny":      s.Tags.Deny,
+						"available": sTagsList,
+					}).Info("No matching tags found")
+					retErr = err
+					continue
+				}
+				tRepoRef, err := ref.New(fmt.Sprintf("%s/%s", s.Target, repo))
+				if err != nil {
+					log.WithFields(logrus.Fields{
+						"target": s.Target,
+						"repo":   repo,
+						"error":  err,
+					}).Error("Failed parsing target")
+					return err
+				}
+				for _, tag := range sTagList {
+					sRef := sRepoRef
+					sRef.Tag = tag
+					tRef := tRepoRef
+					tRef.Tag = tag
+					err = s.processRef(ctx, sRef, tRef, action)
+					if err != nil {
+						log.WithFields(logrus.Fields{
+							"target": tRef.CommonName(),
+							"source": sRef.CommonName(),
+							"error":  err,
+						}).Error("Failed to sync")
+						retErr = err
+					}
+					err = rc.Close(ctx, tRef)
+					if err != nil {
+						log.WithFields(logrus.Fields{
+							"ref":   tRef.CommonName(),
+							"error": err,
+						}).Error("Error closing ref")
+					}
 				}
 			}
 		}


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Fixes #404.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

The regsync for an entire registry did not handle the scenario when the catalog API paginated the responses. This now loops through the paginated responses when syncing a registry.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Use regsync on a registry with more repositories than the default catalog API response and verify all repos gets synced.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Fix regsync handling of the paginated repo listing when syncing registries
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [ ] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
