### PR TITLE
Deprecate redundant regclient options

### DIFF
--- a/blob_test.go
+++ b/blob_test.go
@@ -172,7 +172,7 @@ func TestBlobGet(t *testing.T) {
 	delayInit, _ := time.ParseDuration("0.05s")
 	delayMax, _ := time.ParseDuration("0.10s")
 	rc := New(
-		WithConfigHosts(rcHosts),
+		WithConfigHost(rcHosts...),
 		WithLog(log),
 		WithRetryDelay(delayInit, delayMax),
 	)
@@ -666,7 +666,7 @@ func TestBlobPut(t *testing.T) {
 	delayInit, _ := time.ParseDuration("0.05s")
 	delayMax, _ := time.ParseDuration("0.10s")
 	rc := New(
-		WithConfigHosts(rcHosts),
+		WithConfigHost(rcHosts...),
 		WithLog(log),
 		WithRetryDelay(delayInit, delayMax),
 	)
@@ -1123,7 +1123,7 @@ func TestBlobCopy(t *testing.T) {
 	delayInit, _ := time.ParseDuration("0.05s")
 	delayMax, _ := time.ParseDuration("0.10s")
 	rc := New(
-		WithConfigHosts(rcHosts),
+		WithConfigHost(rcHosts...),
 		WithLog(log),
 		WithRetryDelay(delayInit, delayMax),
 	)

--- a/cmd/regbot/root.go
+++ b/cmd/regbot/root.go
@@ -12,6 +12,7 @@ import (
 	"github.com/regclient/regclient/config"
 	"github.com/regclient/regclient/internal/version"
 	"github.com/regclient/regclient/pkg/template"
+	"github.com/regclient/regclient/scheme/reg"
 	"github.com/robfig/cron/v3"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -248,7 +249,7 @@ func loadConf() error {
 		regclient.WithLog(log),
 	}
 	if conf.Defaults.BlobLimit != 0 {
-		rcOpts = append(rcOpts, regclient.WithBlobLimit(conf.Defaults.BlobLimit))
+		rcOpts = append(rcOpts, regclient.WithRegOpts(reg.WithBlobLimit(conf.Defaults.BlobLimit)))
 	}
 	if !conf.Defaults.SkipDockerConf {
 		rcOpts = append(rcOpts, regclient.WithDockerCreds(), regclient.WithDockerCerts())
@@ -273,7 +274,7 @@ func loadConf() error {
 		rcHosts = append(rcHosts, host)
 	}
 	if len(rcHosts) > 0 {
-		rcOpts = append(rcOpts, regclient.WithConfigHosts(rcHosts))
+		rcOpts = append(rcOpts, regclient.WithConfigHost(rcHosts...))
 	}
 	rc = regclient.New(rcOpts...)
 	return nil

--- a/cmd/regctl/root.go
+++ b/cmd/regctl/root.go
@@ -7,6 +7,7 @@ import (
 	"github.com/regclient/regclient/config"
 	"github.com/regclient/regclient/internal/version"
 	"github.com/regclient/regclient/pkg/template"
+	"github.com/regclient/regclient/scheme/reg"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -110,7 +111,7 @@ func newRegClient() *regclient.RegClient {
 		}
 	}
 	if conf.BlobLimit != 0 {
-		rcOpts = append(rcOpts, regclient.WithBlobLimit(conf.BlobLimit))
+		rcOpts = append(rcOpts, regclient.WithRegOpts(reg.WithBlobLimit(conf.BlobLimit)))
 	}
 	if conf.IncDockerCred == nil || *conf.IncDockerCred {
 		rcOpts = append(rcOpts, regclient.WithDockerCreds())
@@ -125,7 +126,7 @@ func newRegClient() *regclient.RegClient {
 		rcHosts = append(rcHosts, *host)
 	}
 	if len(rcHosts) > 0 {
-		rcOpts = append(rcOpts, regclient.WithConfigHosts(rcHosts))
+		rcOpts = append(rcOpts, regclient.WithConfigHost(rcHosts...))
 	}
 
 	return regclient.New(rcOpts...)

--- a/cmd/regsync/root.go
+++ b/cmd/regsync/root.go
@@ -22,6 +22,7 @@ import (
 	"github.com/regclient/regclient/internal/version"
 	"github.com/regclient/regclient/pkg/template"
 	"github.com/regclient/regclient/scheme"
+	"github.com/regclient/regclient/scheme/reg"
 	"github.com/regclient/regclient/types"
 	"github.com/regclient/regclient/types/manifest"
 	"github.com/regclient/regclient/types/platform"
@@ -344,7 +345,7 @@ func loadConf() error {
 		regclient.WithLog(log),
 	}
 	if conf.Defaults.BlobLimit != 0 {
-		rcOpts = append(rcOpts, regclient.WithBlobLimit(conf.Defaults.BlobLimit))
+		rcOpts = append(rcOpts, regclient.WithRegOpts(reg.WithBlobLimit(conf.Defaults.BlobLimit)))
 	}
 	if !conf.Defaults.SkipDockerConf {
 		rcOpts = append(rcOpts, regclient.WithDockerCreds(), regclient.WithDockerCerts())
@@ -369,7 +370,7 @@ func loadConf() error {
 		rcHosts = append(rcHosts, host)
 	}
 	if len(rcHosts) > 0 {
-		rcOpts = append(rcOpts, regclient.WithConfigHosts(rcHosts))
+		rcOpts = append(rcOpts, regclient.WithConfigHost(rcHosts...))
 	}
 	rc = regclient.New(rcOpts...)
 	return nil

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -205,7 +205,7 @@ func TestManifest(t *testing.T) {
 	delayInit, _ := time.ParseDuration("0.05s")
 	delayMax, _ := time.ParseDuration("0.10s")
 	rc := New(
-		WithConfigHosts(rcHosts),
+		WithConfigHost(rcHosts...),
 		WithLog(log),
 		WithRetryDelay(delayInit, delayMax),
 	)

--- a/regclient.go
+++ b/regclient.go
@@ -96,17 +96,44 @@ func New(opts ...Opt) *RegClient {
 }
 
 // WithBlobLimit sets the max size for chunked blob uploads which get stored in memory
+//
+// Deprecated: replace with WithRegOpts(reg.WithBlobLimit(limit))
 func WithBlobLimit(limit int64) Opt {
 	return func(rc *RegClient) {
 		rc.regOpts = append(rc.regOpts, reg.WithBlobLimit(limit))
 	}
 }
 
+// WithBlobSize overrides default blob sizes
+//
+// Deprecated: replace with WithRegOpts(reg.WithBlobSize(chunk, max))
+func WithBlobSize(chunk, max int64) Opt {
+	return func(rc *RegClient) {
+		rc.regOpts = append(rc.regOpts, reg.WithBlobSize(chunk, max))
+	}
+}
+
 // WithCertDir adds a path of certificates to trust similar to Docker's /etc/docker/certs.d
+//
+// Deprecated: replace with WithRegOpts(reg.WithCertDirs(path))
 func WithCertDir(path ...string) Opt {
 	return func(rc *RegClient) {
 		rc.regOpts = append(rc.regOpts, reg.WithCertDirs(path))
 	}
+}
+
+// WithConfigHost adds a list of config host settings
+func WithConfigHost(configHost ...config.Host) Opt {
+	return func(rc *RegClient) {
+		rc.hostLoad("host", configHost)
+	}
+}
+
+// WithConfigHosts adds a list of config host settings
+//
+// Deprecated: replace with WithConfigHost
+func WithConfigHosts(configHosts []config.Host) Opt {
+	return WithConfigHost(configHosts...)
 }
 
 // WithDockerCerts adds certificates trusted by docker in /etc/docker/certs.d
@@ -129,25 +156,6 @@ func WithDockerCreds() Opt {
 	}
 }
 
-// WithConfigHosts adds a list of config host settings
-func WithConfigHosts(configHosts []config.Host) Opt {
-	return func(rc *RegClient) {
-		rc.hostLoad("host", configHosts)
-	}
-}
-
-// WithConfigHost adds config host settings
-func WithConfigHost(configHost config.Host) Opt {
-	return WithConfigHosts([]config.Host{configHost})
-}
-
-// WithBlobSize overrides default blob sizes
-func WithBlobSize(chunk, max int64) Opt {
-	return func(rc *RegClient) {
-		rc.regOpts = append(rc.regOpts, reg.WithBlobSize(chunk, max))
-	}
-}
-
 // WithFS overrides the backing filesystem (used by ocidir)
 func WithFS(fs rwfs.RWFS) Opt {
 	return func(rc *RegClient) {
@@ -162,7 +170,19 @@ func WithLog(log *logrus.Logger) Opt {
 	}
 }
 
+// WithRegOpts passes through opts to the reg scheme
+func WithRegOpts(opts ...reg.Opts) Opt {
+	return func(rc *RegClient) {
+		if len(rc.regOpts) == 0 {
+			return
+		}
+		rc.regOpts = append(rc.regOpts, opts...)
+	}
+}
+
 // WithRetryDelay specifies the time permitted for retry delays
+//
+// Deprecated: replace with WithRegOpts(reg.WithDelay(delayInit, delayMax))
 func WithRetryDelay(delayInit, delayMax time.Duration) Opt {
 	return func(rc *RegClient) {
 		rc.regOpts = append(rc.regOpts, reg.WithDelay(delayInit, delayMax))
@@ -170,6 +190,8 @@ func WithRetryDelay(delayInit, delayMax time.Duration) Opt {
 }
 
 // WithRetryLimit specifies the number of retries for non-fatal errors
+//
+// Deprecated: replace with WithRegOpts(reg.WithRetryLimit(retryLimit))
 func WithRetryLimit(retryLimit int) Opt {
 	return func(rc *RegClient) {
 		rc.regOpts = append(rc.regOpts, reg.WithRetryLimit(retryLimit))
@@ -180,16 +202,6 @@ func WithRetryLimit(retryLimit int) Opt {
 func WithUserAgent(ua string) Opt {
 	return func(rc *RegClient) {
 		rc.userAgent = ua
-	}
-}
-
-// WithRegOpts passes through reg.Opts to the reg client
-func WithRegOpts(opts ...reg.Opts) Opt {
-	return func(rc *RegClient) {
-		if rc.regOpts == nil {
-			rc.regOpts = []reg.Opts{}
-		}
-		rc.regOpts = append(rc.regOpts, opts...)
 	}
 }
 

--- a/regclient/regclient.go
+++ b/regclient/regclient.go
@@ -1,6 +1,8 @@
 //go:build !nolegacy
 // +build !nolegacy
 
+//lint:file-ignore SA1019 Ignore deprecations since this entire package is deprecated
+
 // Package regclient is a legacy package, this has been moved to the top level regclient package
 package regclient
 


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

With the addition of the WithRegOpts option, several other options can be deprecated.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Linting will trigger issues when deprecated methods are used.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Deprecated: `regclient.WithConfigHosts` is replaced by a variadic on `regclient.WithConfigHost`
- Deprecated: `regclient.WithBlobLimit`, `regcleint.WithBlobSize`, `regclient.WithCertDir`, `regclient.WithRetryDelay`, and `regclient.WithRetryLimit` are replaced by `regclient.WithRegOpts`
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
