### PR TITLE
Fix regclient.WithRegOpts

### DIFF
--- a/regclient.go
+++ b/regclient.go
@@ -173,7 +173,7 @@ func WithLog(log *logrus.Logger) Opt {
 // WithRegOpts passes through opts to the reg scheme
 func WithRegOpts(opts ...reg.Opts) Opt {
 	return func(rc *RegClient) {
-		if len(rc.regOpts) == 0 {
+		if len(opts) == 0 {
 			return
 		}
 		rc.regOpts = append(rc.regOpts, opts...)

--- a/regclient_test.go
+++ b/regclient_test.go
@@ -1,0 +1,102 @@
+package regclient
+
+import (
+	"testing"
+
+	"github.com/regclient/regclient/scheme/reg"
+	"github.com/sirupsen/logrus"
+)
+
+func TestNew(t *testing.T) {
+	logPtr := logrus.New()
+	tt := []struct {
+		name   string
+		opts   []Opt
+		expect RegClient
+	}{
+		{
+			name:   "default",
+			opts:   []Opt{},
+			expect: RegClient{},
+		},
+		{
+			name: "regOpt",
+			opts: []Opt{
+				WithRegOpts(
+					reg.WithBlobLimit(1234),
+					reg.WithBlobSize(64, 128),
+				),
+			},
+			expect: RegClient{
+				regOpts: []reg.Opts{
+					reg.WithBlobLimit(1234),
+					reg.WithBlobSize(64, 128),
+				},
+			},
+		},
+		{
+			name: "regOpt separate",
+			opts: []Opt{
+				WithRegOpts(reg.WithBlobLimit(1234)),
+				WithRegOpts(reg.WithBlobSize(64, 128)),
+			},
+			expect: RegClient{
+				regOpts: []reg.Opts{
+					reg.WithBlobLimit(1234),
+					reg.WithBlobSize(64, 128),
+				},
+			},
+		},
+		{
+			name: "log",
+			opts: []Opt{
+				WithLog(logPtr),
+			},
+			expect: RegClient{
+				log: logPtr,
+			},
+		},
+		{
+			name: "userAgent",
+			opts: []Opt{
+				WithUserAgent("unit-test"),
+			},
+			expect: RegClient{
+				userAgent: "unit-test",
+			},
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			result := New(tc.opts...)
+			if tc.expect.hosts != nil {
+				if result.hosts == nil {
+					t.Errorf("host is nil")
+				} else {
+					for name := range tc.expect.hosts {
+						if _, ok := result.hosts[name]; !ok {
+							t.Errorf("host entry missing for %s", name)
+						}
+					}
+				}
+			}
+			if tc.expect.log != nil {
+				if result.log == nil {
+					t.Errorf("log is nil")
+				} else if result.log != tc.expect.log {
+					t.Errorf("log pointer mismatch")
+				}
+			}
+			if len(tc.expect.regOpts) > 0 {
+				if len(tc.expect.regOpts)+3 != len(result.regOpts) {
+					t.Errorf("regOpts length mismatch, expected %d, received %d", len(tc.expect.regOpts), len(result.regOpts))
+				}
+				// TODO: can content of each regOpt be compared?
+			}
+			if tc.expect.userAgent != "" && tc.expect.userAgent != result.userAgent {
+				t.Errorf("userAgent, expected %s, received %s", tc.expect.userAgent, result.userAgent)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Fixes #410
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

The input validation was done on the wrong variable resulting in WithRegOpts always returning without making changes.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

`regclient.WithRegOpts` should now work.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [x] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
