### PR TITLE
Fix handling of multiple separators in a reference

### DIFF
--- a/cmd/regctl/artifact_test.go
+++ b/cmd/regctl/artifact_test.go
@@ -38,7 +38,7 @@ func TestArtifactPut(t *testing.T) {
 		{
 			name:      "Invalid ref",
 			args:      []string{"artifact", "put", "invalid*ref"},
-			expectErr: fmt.Errorf("invalid reference \"%s\"", "invalid*ref"),
+			expectErr: types.ErrInvalidReference,
 		},
 		{
 			name: "Put artifact",
@@ -112,7 +112,7 @@ func TestArtifactTree(t *testing.T) {
 		{
 			name:      "Invalid ref",
 			args:      []string{"artifact", "tree", "invalid*ref"},
-			expectErr: fmt.Errorf("invalid reference \"%s\"", "invalid*ref"),
+			expectErr: types.ErrInvalidReference,
 		},
 		{
 			name:      "Missing manifest",

--- a/cmd/regctl/manifest_test.go
+++ b/cmd/regctl/manifest_test.go
@@ -25,7 +25,7 @@ func TestManifestHead(t *testing.T) {
 		{
 			name:      "Invalid ref",
 			args:      []string{"manifest", "head", "invalid*ref"},
-			expectErr: fmt.Errorf("invalid reference \"%s\"", "invalid*ref"),
+			expectErr: types.ErrInvalidReference,
 		},
 		{
 			name:      "Missing manifest",

--- a/cmd/regsync/regsync_test.go
+++ b/cmd/regsync/regsync_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"fmt"
 	"io/fs"
 	"testing"
 
@@ -296,7 +295,7 @@ func TestRegsyncOnce(t *testing.T) {
 				Type:   "image",
 			},
 			desired: []string{},
-			expErr:  fmt.Errorf(`invalid reference "InvalidTestmissing:v1:garbage"`),
+			expErr:  types.ErrInvalidReference,
 		},
 		{
 			name: "InvalidTargetImage",
@@ -306,7 +305,7 @@ func TestRegsyncOnce(t *testing.T) {
 				Type:   "image",
 			},
 			desired: []string{},
-			expErr:  fmt.Errorf(`invalid reference "InvalidTestmissing:v1:garbage"`),
+			expErr:  types.ErrInvalidReference,
 		},
 		{
 			name: "InvalidSourceRepository",
@@ -316,7 +315,7 @@ func TestRegsyncOnce(t *testing.T) {
 				Type:   "repository",
 			},
 			desired: []string{},
-			expErr:  fmt.Errorf(`invalid reference "InvalidTestmissing:v1:garbage"`),
+			expErr:  types.ErrInvalidReference,
 		},
 		{
 			name: "InvalidTargetRepository",
@@ -326,7 +325,7 @@ func TestRegsyncOnce(t *testing.T) {
 				Type:   "repository",
 			},
 			desired: []string{},
-			expErr:  fmt.Errorf(`invalid reference "InvalidTestmissing:v1:garbage"`),
+			expErr:  types.ErrInvalidReference,
 		},
 		{
 			name: "InvalidType",

--- a/types/error.go
+++ b/types/error.go
@@ -27,6 +27,8 @@ var (
 	ErrHTTPStatus = errors.New("unexpected http status code")
 	// ErrInvalidChallenge indicates an issue with the received challenge in the WWW-Authenticate header
 	ErrInvalidChallenge = errors.New("invalid challenge header")
+	// ErrInvalidReference indicates the reference to an image is has an invalid synax
+	ErrInvalidReference = errors.New("invalid reference")
 	// ErrManifestNotSet indicates the manifest is not set, it must be pulled with a ManifestGet first
 	ErrManifestNotSet = errors.New("manifest not set")
 	// ErrMissingAnnotation returned when a needed annotation is not found


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

A reference with multiple consecutive separators in a path component is invalid.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

The regex was adjusted to remove the `*` so that the separator cannot appear consecutively.

Unallowed:

- `example.com/path--part:tag`
- `example.com/path._part:tag`

Allowed:

- `example.com/path.and_part:tag`
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Invalid references return an invalid reference error without sending the request to the registry (where a 404 would typically be received).
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Fix: invalid references are detected before querying the registry
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
