### PR TITLE
Quote email addresses for linting

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -61,8 +61,8 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-git@bmitch.net, or via DM on twitter (@sudo_bmitch) or slack (I'm found on the
-Docker, CNCF, and OCI slacks).
+<git@bmitch.net> or slack (I'm found on the CNCF, Docker, OCI, and OpenSSF
+slacks).
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Reporting security issues
 
-Please send security issues to git@bmitch.net.
+Please send security issues to <git@bmitch.net> or report them directly in GitHub at <https://github.com/regclient/regclient/security/advisories/new>.
 
 ## Reporting other issues
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,3 @@
 # Reporting security issues
 
-Please send security issues to git@bmitch.net.
+Please send security issues to <git@bmitch.net> or report them directly in GitHub at <https://github.com/regclient/regclient/security/advisories/new>.


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Linting now requires email addresses to be quoted.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Email addresses in markdown files are now quoted. Contact details for CoC and security were also updated.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

GHA linting checks should pass.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
