### PR TITLE
Fix parsing of media types

### DIFF
--- a/scheme/reg/manifest.go
+++ b/scheme/reg/manifest.go
@@ -92,6 +92,7 @@ func (reg *Reg) ManifestGet(ctx context.Context, r ref.Ref) (manifest.Manifest, 
 			types.MediaTypeDocker2ManifestList,
 			types.MediaTypeOCI1Manifest,
 			types.MediaTypeOCI1ManifestList,
+			types.MediaTypeOCI1Artifact,
 		},
 	}
 	req := &reghttp.Req{
@@ -148,6 +149,7 @@ func (reg *Reg) ManifestHead(ctx context.Context, r ref.Ref) (manifest.Manifest,
 			types.MediaTypeDocker2ManifestList,
 			types.MediaTypeOCI1Manifest,
 			types.MediaTypeOCI1ManifestList,
+			types.MediaTypeOCI1Artifact,
 		},
 	}
 	req := &reghttp.Req{

--- a/scheme/reg/referrer.go
+++ b/scheme/reg/referrer.go
@@ -16,6 +16,7 @@ import (
 	"github.com/regclient/regclient/types/platform"
 	"github.com/regclient/regclient/types/ref"
 	"github.com/regclient/regclient/types/referrer"
+	"github.com/sirupsen/logrus"
 )
 
 // ReferrerList returns a list of referrers to a given reference
@@ -85,6 +86,10 @@ func (reg *Reg) referrerListAPI(ctx context.Context, r ref.Ref, config scheme.Re
 	for {
 		rlAdd, respNext, err := reg.referrerListAPIReq(ctx, r, config, link)
 		if err != nil {
+			reg.log.WithFields(logrus.Fields{
+				"err": err,
+				"ref": r.CommonName(),
+			}).Debug("referrers API failed")
 			return rl, err
 		}
 		if rl.Manifest == nil {

--- a/scheme/reg/repo.go
+++ b/scheme/reg/repo.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/regclient/regclient/internal/reghttp"
 	"github.com/regclient/regclient/scheme"
+	"github.com/regclient/regclient/types"
 	"github.com/regclient/regclient/types/repo"
 	"github.com/sirupsen/logrus"
 )
@@ -63,7 +64,7 @@ func (reg *Reg) RepoList(ctx context.Context, hostname string, opts ...scheme.Re
 		}).Warn("Failed to read repo list")
 		return nil, fmt.Errorf("failed to read repo list for %s: %w", hostname, err)
 	}
-	mt := resp.HTTPResponse().Header.Get("Content-Type")
+	mt := types.MediaTypeBase(resp.HTTPResponse().Header.Get("Content-Type"))
 	rl, err := repo.New(
 		repo.WithMT(mt),
 		repo.WithRaw(respBody),

--- a/types/blob/reader.go
+++ b/types/blob/reader.go
@@ -10,6 +10,7 @@ import (
 	_ "crypto/sha512"
 
 	"github.com/opencontainers/go-digest"
+	"github.com/regclient/regclient/types"
 )
 
 // Reader is an unprocessed Blob with an available ReadCloser for reading the Blob
@@ -47,7 +48,7 @@ func NewReader(opts ...Opts) Reader {
 	if bc.header != nil {
 		// extract fields from header if descriptor not passed
 		if bc.desc.MediaType == "" {
-			bc.desc.MediaType = bc.header.Get("Content-Type")
+			bc.desc.MediaType = types.MediaTypeBase(bc.header.Get("Content-Type"))
 		}
 		if bc.desc.Size == 0 {
 			cl, _ := strconv.Atoi(bc.header.Get("Content-Length"))

--- a/types/manifest/manifest.go
+++ b/types/manifest/manifest.go
@@ -106,7 +106,7 @@ func New(opts ...Opts) (Manifest, error) {
 	// extract fields from header where available
 	if mc.header != nil {
 		if c.desc.MediaType == "" {
-			c.desc.MediaType = mc.header.Get("Content-Type")
+			c.desc.MediaType = types.MediaTypeBase(mc.header.Get("Content-Type"))
 		}
 		if c.desc.Size == 0 {
 			cl, _ := strconv.Atoi(mc.header.Get("Content-Length"))

--- a/types/mediatype.go
+++ b/types/mediatype.go
@@ -1,5 +1,7 @@
 package types
 
+import "strings"
+
 const (
 	// MediaTypeDocker1Manifest deprecated media type for docker schema1 manifests
 	MediaTypeDocker1Manifest = "application/vnd.docker.distribution.manifest.v1+json"
@@ -40,3 +42,9 @@ const (
 	// MediaTypeBuildkitCacheConfig is used by buildkit cache images
 	MediaTypeBuildkitCacheConfig = "application/vnd.buildkit.cacheconfig.v0"
 )
+
+// MediaTypeBase cleans the Content-Type header to return only the lower case base media type
+func MediaTypeBase(orig string) string {
+	base, _, _ := strings.Cut(orig, ";")
+	return strings.TrimSpace(strings.ToLower(base))
+}

--- a/types/mediatype_test.go
+++ b/types/mediatype_test.go
@@ -1,0 +1,32 @@
+package types
+
+import "testing"
+
+func TestMediaTypeBase(t *testing.T) {
+	tt := []struct {
+		name   string
+		orig   string
+		expect string
+	}{
+		{
+			name:   "OCI Index",
+			orig:   MediaTypeOCI1ManifestList,
+			expect: MediaTypeOCI1ManifestList,
+		},
+		{
+			name:   "OCI Index with charset",
+			orig:   "application/vnd.oci.image.index.v1+json; charset=utf-8",
+			expect: MediaTypeOCI1ManifestList,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			result := MediaTypeBase(tc.orig)
+			if tc.expect != result {
+				t.Errorf("invalid result: expected \"%s\", received \"%s\"", tc.expect, result)
+			}
+		})
+	}
+
+}

--- a/types/tag/taglist.go
+++ b/types/tag/taglist.go
@@ -78,7 +78,7 @@ func New(opts ...Opts) (*List, error) {
 		tl.Tags = conf.tags
 	}
 	if len(conf.raw) > 0 {
-		mt := strings.Split(conf.mt, ";")[0] // "application/json; charset=utf-8" -> "application/json"
+		mt := types.MediaTypeBase(conf.mt)
 		switch mt {
 		case "application/json", "text/plain":
 			err := json.Unmarshal(conf.raw, &tl)


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Fixes #417
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

The content-type headers from some registries contain optional parameters, and can be in upper case. This normalizes the result to only the base value in lower case.
It also updates the manifest get request to accept the OCI artifact manifest. Support for this should still be considered experimental until released by OCI.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Notation signed content on ACR should be accessible with `regctl artifact list` and `regctl manifest get`.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Fix handling of content-type headers.
- Accept manifests with OCI artifact media type (experimental).
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
