### PR TITLE
Add stat interface to rwfs

### DIFF
--- a/internal/rwfs/os.go
+++ b/internal/rwfs/os.go
@@ -139,6 +139,16 @@ func (o *OSFS) Rename(oldName, newName string) error {
 	return os.Rename(oldFile, newFile)
 }
 
+// Stat returns a FileInfo describing the named file.
+func (o *OSFS) Stat(name string) (fs.FileInfo, error) {
+	full, err := o.join("stat", name)
+	if err != nil {
+		return nil, err
+	}
+	return os.Stat(full)
+}
+
+// Sub returns an FS corresponding to the subtree rooted at dir.
 func (o *OSFS) Sub(name string) (*OSFS, error) {
 	if name == "." {
 		return o, nil

--- a/internal/rwfs/rwfs.go
+++ b/internal/rwfs/rwfs.go
@@ -192,6 +192,12 @@ func MkdirAll(rwfs RWFS, name string, perm fs.FileMode) error {
 
 // Stat returns the FileInfo for a specified file
 func Stat(rfs fs.FS, name string) (fs.FileInfo, error) {
+	sInt, ok := rfs.(interface {
+		Stat(name string) (fs.FileInfo, error)
+	})
+	if ok {
+		return sInt.Stat(name)
+	}
 	fh, err := rfs.Open(name)
 	if err != nil {
 		return nil, err

--- a/internal/rwfs/rwfs_test.go
+++ b/internal/rwfs/rwfs_test.go
@@ -595,6 +595,27 @@ func testRWFS(t *testing.T, rwfs RWFS) {
 		}
 	})
 
+	t.Run("StatFile", func(t *testing.T) {
+		fi, err := Stat(rwfs, exNestedFile)
+		if err != nil {
+			t.Errorf("failed to stat file: %v", err)
+			return
+		}
+		if fi.IsDir() {
+			t.Errorf("file stat indicates it is a directory")
+		}
+	})
+	t.Run("StatDir", func(t *testing.T) {
+		fi, err := Stat(rwfs, exNestedDir)
+		if err != nil {
+			t.Errorf("failed to stat directory: %v", err)
+			return
+		}
+		if !fi.IsDir() {
+			t.Errorf("directory stat indicates it is not a directory")
+		}
+	})
+
 	t.Run("remove", func(t *testing.T) {
 		err := rwfs.Remove(".")
 		if err == nil {


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Describe the change

This adds a Stat implementations to os and mem in rwfs.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

No user visible changes.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
