### PR TITLE
Avoid a race condition when updating referrers

### DIFF
--- a/scheme/reg/reg.go
+++ b/scheme/reg/reg.go
@@ -33,7 +33,8 @@ type Reg struct {
 	blobChunkSize  int64
 	blobChunkLimit int64
 	blobMaxPut     int64
-	mu             sync.Mutex
+	muHost         sync.Mutex
+	muRefTag       sync.Mutex
 }
 
 // Opts provides options to access registries
@@ -76,8 +77,8 @@ func (reg *Reg) Throttle(r ref.Ref, put bool) []*throttle.Throttle {
 }
 
 func (reg *Reg) hostGet(hostname string) *config.Host {
-	reg.mu.Lock()
-	defer reg.mu.Unlock()
+	reg.muHost.Lock()
+	defer reg.muHost.Unlock()
 	if _, ok := reg.hosts[hostname]; !ok {
 		reg.hosts[hostname] = config.HostNewName(hostname)
 	}


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Copying an image with referrers may encounter a race condition updating the fallback tag.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This locks the update of the fallback tag to avoid internal race conditions. External race conditions are still possible.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Copying an image with referrers should have all the referrers in an artifact list of the destination.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Avoid an internal race condition when managing the referrers fallback tag.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
