### PR TITLE
Blob put for ocidir uses tmp file

### DIFF
--- a/internal/rwfs/rwfs.go
+++ b/internal/rwfs/rwfs.go
@@ -131,7 +131,7 @@ func CreateTemp(rwfs RWFS, dir, pattern string) (RWFile, error) {
 	if i >= 0 {
 		prefix, suffix = pattern[:i], pattern[i+1:]
 	}
-	prefix = filepath.Join(dir, prefix)
+	prefix = filepath.Clean(dir) + string(filepath.Separator) + prefix
 	try := 0
 	for {
 		rnd := strconv.FormatUint(rand.Uint64(), 10)


### PR DESCRIPTION
This removes the in memory digest calculation.

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Pushing a blob to an ocidir without a digest uses a memory buffer.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Since there was already a tmpfile being used for safely writing blobs, this was also used for blobs that did not have a predefined digest.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

No user visible changes other than less memory usage in some scenarios.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
