### PR TITLE
Switch regbot from semaphore to throttle

### DIFF
--- a/cmd/regbot/regbot_test.go
+++ b/cmd/regbot/regbot_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/regclient/regclient"
 	"github.com/regclient/regclient/internal/rwfs"
+	"github.com/regclient/regclient/internal/throttle"
 	"github.com/regclient/regclient/types/ref"
-	"golang.org/x/sync/semaphore"
 )
 
 func TestRegbot(t *testing.T) {
@@ -24,7 +24,7 @@ func TestRegbot(t *testing.T) {
 		return
 	}
 	// setup various globals normally done by loadConf
-	sem = semaphore.NewWeighted(1)
+	throttleC = throttle.New(1)
 	rc = regclient.New(regclient.WithFS(fsMem))
 	var confBytes = `
   version: 1

--- a/cmd/regbot/sandbox/image.go
+++ b/cmd/regbot/sandbox/image.go
@@ -76,9 +76,9 @@ func (s *Sandbox) configGet(ls *lua.LState) int {
 		ls.RaiseError("Context error: %v", err)
 	}
 	m := s.checkManifest(ls, 1, false, false)
-	if s.sem != nil {
-		s.sem.Acquire(s.ctx, 1)
-		defer s.sem.Release(1)
+	if s.throttleC != nil {
+		s.throttleC.Acquire(s.ctx)
+		defer s.throttleC.Release(s.ctx)
 	}
 	s.log.WithFields(logrus.Fields{
 		"script": s.name,
@@ -198,9 +198,9 @@ func (s *Sandbox) imageCopy(ls *lua.LState) int {
 			opts = append(opts, regclient.ImageWithPlatforms(lOpts.Platforms))
 		}
 	}
-	if s.sem != nil {
-		s.sem.Acquire(s.ctx, 1)
-		defer s.sem.Release(1)
+	if s.throttleC != nil {
+		s.throttleC.Acquire(s.ctx)
+		defer s.throttleC.Release(s.ctx)
 	}
 	s.log.WithFields(logrus.Fields{
 		"script":          s.name,
@@ -232,9 +232,9 @@ func (s *Sandbox) imageExportTar(ls *lua.LState) int {
 	}
 	src := s.checkReference(ls, 1)
 	file := ls.CheckString(2)
-	if s.sem != nil {
-		s.sem.Acquire(s.ctx, 1)
-		defer s.sem.Release(1)
+	if s.throttleC != nil {
+		s.throttleC.Acquire(s.ctx)
+		defer s.throttleC.Release(s.ctx)
 	}
 	fh, err := os.Create(file)
 	if err != nil {
@@ -254,9 +254,9 @@ func (s *Sandbox) imageImportTar(ls *lua.LState) int {
 	}
 	tgt := s.checkReference(ls, 1)
 	file := ls.CheckString(2)
-	if s.sem != nil {
-		s.sem.Acquire(s.ctx, 1)
-		defer s.sem.Release(1)
+	if s.throttleC != nil {
+		s.throttleC.Acquire(s.ctx)
+		defer s.throttleC.Release(s.ctx)
 	}
 	rs, err := os.Open(file)
 	if err != nil {

--- a/cmd/regbot/sandbox/sandbox.go
+++ b/cmd/regbot/sandbox/sandbox.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/regclient/regclient"
 	"github.com/regclient/regclient/cmd/regbot/internal/go2lua"
+	"github.com/regclient/regclient/internal/throttle"
 	"github.com/sirupsen/logrus"
 	lua "github.com/yuin/gopher-lua"
-	"golang.org/x/sync/semaphore"
 )
 
 const (
@@ -23,13 +23,13 @@ const (
 
 // Sandbox defines a lua sandbox
 type Sandbox struct {
-	name   string
-	ctx    context.Context
-	log    *logrus.Logger
-	ls     *lua.LState
-	rc     *regclient.RegClient
-	sem    *semaphore.Weighted
-	dryRun bool
+	name      string
+	ctx       context.Context
+	log       *logrus.Logger
+	ls        *lua.LState
+	rc        *regclient.RegClient
+	throttleC *throttle.Throttle
+	dryRun    bool
 }
 
 // LuaMod defines a mod to add to Lua's sandbox
@@ -111,10 +111,10 @@ func WithRegClient(rc *regclient.RegClient) Opt {
 	}
 }
 
-// WithSemaphore defines a semaphore to limit various actions
-func WithSemaphore(sem *semaphore.Weighted) Opt {
+// WithThrottle defines a semaphore to limit various actions
+func WithThrottle(t *throttle.Throttle) Opt {
 	return func(s *Sandbox) {
-		s.sem = sem
+		s.throttleC = t
 	}
 }
 


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Semaphore isn't needed for a basic throttle.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This removes an external dependency. The semaphore was excessive for this use case, a buffered channel (the throttle) is good enough.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

No user visible change.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
