### PR TITLE
Switch from semaphore to throttle in regsync

### DIFF
--- a/cmd/regbot/root.go
+++ b/cmd/regbot/root.go
@@ -224,15 +224,15 @@ func loadConf() error {
 	} else {
 		return ErrMissingInput
 	}
-	// use a semaphore to control parallelism
-	concurrent := int64(conf.Defaults.Parallel)
+	// use a throttle to control parallelism
+	concurrent := conf.Defaults.Parallel
 	if concurrent <= 0 {
 		concurrent = 1
 	}
 	log.WithFields(logrus.Fields{
 		"concurrent": concurrent,
 	}).Debug("Configuring parallel settings")
-	throttleC = throttle.New(int(concurrent))
+	throttleC = throttle.New(concurrent)
 	// set the regclient, loading docker creds unless disabled, and inject logins from config file
 	rcOpts := []regclient.Opt{
 		regclient.WithLog(log),

--- a/cmd/regbot/sandbox/sandbox.go
+++ b/cmd/regbot/sandbox/sandbox.go
@@ -111,7 +111,7 @@ func WithRegClient(rc *regclient.RegClient) Opt {
 	}
 }
 
-// WithThrottle defines a semaphore to limit various actions
+// WithThrottle is used to limit various actions
 func WithThrottle(t *throttle.Throttle) Opt {
 	return func(s *Sandbox) {
 		s.throttleC = t

--- a/cmd/regsync/regsync_test.go
+++ b/cmd/regsync/regsync_test.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/regclient/regclient"
 	"github.com/regclient/regclient/internal/rwfs"
+	"github.com/regclient/regclient/internal/throttle"
 	"github.com/regclient/regclient/types"
 	"github.com/regclient/regclient/types/ref"
-	"golang.org/x/sync/semaphore"
 )
 
 func TestRegsyncOnce(t *testing.T) {
@@ -27,7 +27,7 @@ func TestRegsyncOnce(t *testing.T) {
 	}
 	// setup various globals normally done by loadConf
 	rc = regclient.New(regclient.WithFS(fsMem))
-	sem = semaphore.NewWeighted(1)
+	throttleC = throttle.New(1)
 	var confBytes = `
   version: 1
   defaults:

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.3.0
 	github.com/yuin/gopher-lua v0.0.0-20210529063254-f4c35e4016d9
-	golang.org/x/sync v0.1.0
 	golang.org/x/sys v0.7.0
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -470,8 +470,6 @@ golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
-golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

The semaphore wasn't needed for controlling concurrency.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Switch to using a buffered channel in the throttle for concurrency.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

No user visible changes.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
