### PR TITLE
Pinning markdown lint version

### DIFF
--- a/.version-bump.yml
+++ b/.version-bump.yml
@@ -18,6 +18,7 @@ files:
       - gha-cosign-version
   "Makefile":
     scans:
+      - makefile-markdown-lint
       - makefile-staticcheck
       - makefile-syft-version
       - makefile-syft-version2
@@ -101,6 +102,12 @@ scans:
     args:
       regexp: '^\s*cosign-release: "(?P<Version>v[0-9\.]+)"\s*$'
       repo: "github.com/sigstore/cosign"
+  makefile-markdown-lint:
+    type: "regexp"
+    source: "registry-tag-arg-semver"
+    args:
+      regexp: '^MARKDOWN_LINT_VER\?=(?P<Version>v[0-9\.]+)\s*$'
+      repo: "ghcr.io/igorshubovych/markdownlint-cli"
   makefile-staticcheck:
     type: "regexp"
     source: "git-tag-semver"

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ ifeq "$(strip $(VER_BUMP))" ''
 		-u "$(shell id -u):$(shell id -g)" \
 		$(VER_BUMP_CONTAINER)
 endif
+MARKDOWN_LINT_VER?=v0.34.0
 SYFT?=$(shell command -v syft 2>/dev/null)
 SYFT_CMD_VER:=$(shell [ -x "$(SYFT)" ] && echo "v$$($(SYFT) version | awk '/^Version: / {print $$2}')" || echo "0")
 SYFT_VERSION?=v0.77.0
@@ -58,7 +59,7 @@ lint-go: $(GOPATH)/bin/staticcheck .FORCE ## Run linting for Go
 	$(GOPATH)/bin/staticcheck -checks all ./...
 
 lint-md: .FORCE ## Run linting for markdown
-	docker run --rm -v "$(PWD):/workdir:ro" ghcr.io/igorshubovych/markdownlint-cli:latest \
+	docker run --rm -v "$(PWD):/workdir:ro" ghcr.io/igorshubovych/markdownlint-cli:$(MARKDOWN_LINT_VER) \
 	  --ignore vendor .
 
 vulncheck-go: $(GOPATH)/bin/govulncheck .FORCE ## Run vulnerability scan for Go


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Markdown lint was not pinned, resulting in stale images used on machines that had previously pulled the image.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This pins the markdown lint image to a specific version tag.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```
make lint-md
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
