### PR TITLE
Close blob reader when converting to a config

### DIFF
--- a/types/blob/reader.go
+++ b/types/blob/reader.go
@@ -153,6 +153,7 @@ func (b *reader) ToOCIConfig() (OCIConfig, error) {
 		return nil, fmt.Errorf("unable to convert after read has been performed")
 	}
 	blobBody, err := io.ReadAll(b)
+	b.Close()
 	if err != nil {
 		return nil, fmt.Errorf("error reading image config for %s: %w", b.r.CommonName(), err)
 	}


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

A deadlock can occur when reading too many configs (e.g. `regctl image mod` on a multi-platform image).
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This closes the blob reader when converting it to a config.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

`regctl image mod` on an image with lots of platforms does not deadlock.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Fix: close reader when converting a blob to an OCI config
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
