### PR TITLE
Support OCI manifests without mediaType

### DIFF
--- a/types/manifest/manifest.go
+++ b/types/manifest/manifest.go
@@ -436,12 +436,14 @@ func fromCommon(c common) (Manifest, error) {
 	// extract common data from from rawBody
 	if len(c.rawBody) > 0 {
 		c.manifSet = true
-		// extract media type from body if needed
+		// extract media type from body, either explicitly or with duck typing
 		if c.desc.MediaType == "" {
 			mt := struct {
-				MediaType     string        `json:"mediaType,omitempty"`
-				SchemaVersion int           `json:"schemaVersion,omitempty"`
-				Signatures    []interface{} `json:"signatures,omitempty"`
+				MediaType     string             `json:"mediaType,omitempty"`
+				SchemaVersion int                `json:"schemaVersion,omitempty"`
+				Signatures    []interface{}      `json:"signatures,omitempty"`
+				Manifests     []types.Descriptor `json:"manifests,omitempty"`
+				Layers        []types.Descriptor `json:"layers,omitempty"`
 			}{}
 			err = json.Unmarshal(c.rawBody, &mt)
 			if mt.MediaType != "" {
@@ -450,6 +452,18 @@ func fromCommon(c common) (Manifest, error) {
 				c.desc.MediaType = types.MediaTypeDocker1ManifestSigned
 			} else if mt.SchemaVersion == 1 {
 				c.desc.MediaType = types.MediaTypeDocker1Manifest
+			} else if len(mt.Manifests) > 0 {
+				if strings.HasPrefix(mt.Manifests[0].MediaType, "application/vnd.docker.") {
+					c.desc.MediaType = types.MediaTypeDocker2ManifestList
+				} else {
+					c.desc.MediaType = types.MediaTypeOCI1ManifestList
+				}
+			} else if len(mt.Layers) > 0 {
+				if strings.HasPrefix(mt.Layers[0].MediaType, "application/vnd.docker.") {
+					c.desc.MediaType = types.MediaTypeDocker2Manifest
+				} else {
+					c.desc.MediaType = types.MediaTypeOCI1Manifest
+				}
 			}
 		}
 		// compute digest

--- a/types/manifest/manifest_test.go
+++ b/types/manifest/manifest_test.go
@@ -254,6 +254,55 @@ var (
 			}
 		}
 	`)
+	rawOCIImageDuck = []byte(`
+		{
+			"schemaVersion": 2,
+			"config": {
+				"mediaType": "application/vnd.oci.image.config.v1+json",
+				"size": 733,
+				"digest": "sha256:35481f6488745b7eb5748f759b939deb063f458e9c3f9f998abc423e6652ece5"
+			},
+			"layers": [
+				{
+					"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+					"size": 657696,
+					"digest": "sha256:b49b96595fd4bd6de7cb7253fe5e89d242d0eb4f993b2b8280c0581c3a62ddc2"
+				},
+				{
+					"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+					"size": 127,
+					"digest": "sha256:250c06f7c38e52dc77e5c7586c3e40280dc7ff9bb9007c396e06d96736cf8542"
+				},
+				{
+					"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+					"size": 1136676,
+					"digest": "sha256:c6690738d95e2b3d3c9ddfd34aa88ddce6e8d6e31c826989b869c25f8888f158"
+				}
+			],
+			"annotations": {
+				"org.example.test": "hello world"
+			}
+		}
+	`)
+	rawOCIIndexDuck = []byte(`
+		{
+			"schemaVersion": 2,
+			"manifests": [
+				{
+					"mediaType": "application/vnd.oci.image.manifest.v1+json",
+					"size": 659,
+					"digest": "sha256:bdde23183a221cc31fb66df0d93b834b11f2a0c2e8a03e6304c5e17d3cd5038f",
+					"platform": {
+						"architecture": "amd64",
+						"os": "linux"
+					}
+				}
+			],
+			"annotations": {
+				"org.example.test": "hello world"
+			}
+		}
+	`)
 	rawOCI1Artifact = []byte(`
 		{
 			"schemaVersion": 2,
@@ -325,6 +374,8 @@ var (
 	digestDockerSchema1Signed, _ = digest.Parse("sha256:f3ef067962554c3352dc0c659ca563f73cc396fe0dea2a2c23a7964c6290f782")
 	digestOCIImage               = digest.FromBytes(rawOCIImage)
 	digestOCIIndex               = digest.FromBytes(rawOCIIndex)
+	digestOCIImageDuck           = digest.FromBytes(rawOCIImageDuck)
+	digestOCIIndexDuck           = digest.FromBytes(rawOCIIndexDuck)
 	digestOCIArtifact            = digest.FromBytes(rawOCI1Artifact)
 )
 
@@ -745,6 +796,32 @@ func TestNew(t *testing.T) {
 				WithOrig(manifestInvalid),
 			},
 			wantE: fmt.Errorf("manifest contains an unexpected media type: expected %s, received %s", types.MediaTypeDocker2Manifest, types.MediaTypeOCI1Manifest),
+		},
+		{
+			name: "OCI Image without mediaType",
+			opts: []Opts{
+				WithRaw(rawOCIImageDuck),
+			},
+			wantE: nil,
+			isSet: true,
+			wantDesc: types.Descriptor{
+				MediaType: types.MediaTypeOCI1Manifest,
+				Size:      int64(len(rawOCIImageDuck)),
+				Digest:    digestOCIImageDuck,
+			},
+		},
+		{
+			name: "OCI Index without mediaType",
+			opts: []Opts{
+				WithRaw(rawOCIIndexDuck),
+			},
+			wantE: nil,
+			isSet: true,
+			wantDesc: types.Descriptor{
+				MediaType: types.MediaTypeOCI1ManifestList,
+				Size:      int64(len(rawOCIIndexDuck)),
+				Digest:    digestOCIIndexDuck,
+			},
 		},
 
 		// TODO: add more tests to improve coverage


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Manifests without a mediaType can't be processed from sources without a descriptor or http header that includes the mediaType.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This evaluates the manifest with duck typing, looking for manifests or layers, and the media types inside the first descriptor to decide if it's a Docker or OCI image or index.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Fetching the manifest by digest from an OCIDir should not fail even if the manifest mediaType is missing.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Support manifests missing a mediaType field.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
