### PR TITLE
Add a fast copy option

### DIFF
--- a/cmd/regctl/image.go
+++ b/cmd/regctl/image.go
@@ -150,6 +150,7 @@ var imageOpts struct {
 	checkSkipConfig bool
 	create          string
 	exportRef       string
+	fastCheck       bool
 	forceRecursive  bool
 	format          string
 	formatFile      string
@@ -172,6 +173,7 @@ func init() {
 	imageCheckBaseCmd.Flags().BoolVarP(&imageOpts.checkSkipConfig, "no-config", "", false, "Skip check of config history")
 	imageCheckBaseCmd.Flags().StringVarP(&imageOpts.platform, "platform", "p", "", "Specify platform (e.g. linux/amd64 or local)")
 
+	imageCopyCmd.Flags().BoolVarP(&imageOpts.fastCheck, "fast", "", false, "Fast check, skip referrers and digest tag checks when image exists, overrides force-recursive")
 	imageCopyCmd.Flags().BoolVarP(&imageOpts.forceRecursive, "force-recursive", "", false, "Force recursive copy of image, repairs missing nested blobs and manifests")
 	imageCopyCmd.Flags().StringVarP(&imageOpts.format, "format", "", "", "Format output with go template syntax")
 	imageCopyCmd.Flags().BoolVarP(&imageOpts.includeExternal, "include-external", "", false, "Include external layers")
@@ -619,6 +621,9 @@ func runImageCopy(cmd *cobra.Command, args []string) error {
 		"digest-tags": imageOpts.digestTags,
 	}).Debug("Image copy")
 	opts := []regclient.ImageOpts{}
+	if imageOpts.fastCheck {
+		opts = append(opts, regclient.ImageWithFastCheck())
+	}
 	if imageOpts.forceRecursive {
 		opts = append(opts, regclient.ImageWithForceRecursive())
 	}

--- a/cmd/regsync/config.go
+++ b/cmd/regsync/config.go
@@ -43,6 +43,7 @@ type ConfigDefaults struct {
 	DigestTags      *bool                  `yaml:"digestTags" json:"digestTags"`
 	Referrers       *bool                  `yaml:"referrers" json:"referrers"`
 	ReferrerFilters []ConfigReferrerFilter `yaml:"referrerFilters" json:"referrerFilters"`
+	FastCheck       *bool                  `yaml:"fastCheck" json:"fastCheck"`
 	ForceRecursive  *bool                  `yaml:"forceRecursive" json:"forceRecursive"`
 	IncludeExternal *bool                  `yaml:"includeExternal" json:"includeExternal"`
 	MediaTypes      []string               `yaml:"mediaTypes" json:"mediaTypes"`
@@ -70,6 +71,7 @@ type ConfigSync struct {
 	ReferrerFilters []ConfigReferrerFilter `yaml:"referrerFilters" json:"referrerFilters"`
 	Platform        string                 `yaml:"platform" json:"platform"`
 	Platforms       []string               `yaml:"platforms" json:"platforms"`
+	FastCheck       *bool                  `yaml:"fastCheck" json:"fastCheck"`
 	ForceRecursive  *bool                  `yaml:"forceRecursive" json:"forceRecursive"`
 	IncludeExternal *bool                  `yaml:"includeExternal" json:"includeExternal"`
 	Backup          string                 `yaml:"backup" json:"backup"`
@@ -241,6 +243,10 @@ func syncSetDefaults(s *ConfigSync, d ConfigDefaults) {
 	}
 	if s.ReferrerFilters == nil {
 		s.ReferrerFilters = d.ReferrerFilters
+	}
+	if s.FastCheck == nil {
+		b := (d.FastCheck != nil && *d.FastCheck)
+		s.FastCheck = &b
 	}
 	if s.ForceRecursive == nil {
 		b := (d.ForceRecursive != nil && *d.ForceRecursive)

--- a/cmd/regsync/regsync_test.go
+++ b/cmd/regsync/regsync_test.go
@@ -109,6 +109,32 @@ func TestRegsyncOnce(t *testing.T) {
 			expErr: nil,
 		},
 		{
+			name: "Fast Check",
+			sync: ConfigSync{
+				Source:     "ocidir://testrepo:v2",
+				Target:     "ocidir://test1:latest",
+				Type:       "image",
+				FastCheck:  &boolTrue,
+				Referrers:  &boolTrue,
+				DigestTags: &boolTrue,
+			},
+			exists: []string{"ocidir://test1:latest"},
+			desired: []string{
+				"test1/index.json",
+				"test1/oci-layout",
+				"test2/blobs/sha256/adab55c36c56f4054a64972a431e38e407d0060ce90888a2470d67598042f7c8", // v2
+			},
+			undesired: []string{
+				"test1/blobs/sha256/4a88e72dd0e4245e6ecfbc6faae751eeeff82861f9ef39634bea07d77dbb1f40", // v1
+				"test1/blobs/sha256/5283ed7b662424a7f9edc47f8e0e266d47f8ce997da51949d454b30eaafb5251", // amd64
+				"test1/blobs/sha256/3f4eb4d2ca4fe85d3da97aab1a56422cb4a05334274a2e275cf848db90a41b18",
+				"test1/blobs/sha256/a7f0466d930515f984dc334bf786a569973119a3afaa2d4290f2268c62a19b12", // arm64
+				"test1/blobs/sha256/798aa97e1710cb04671cad647d0b87159eed85cb6db4596806421ef190108c68", // v2 referrer sbom
+				"test1/blobs/sha256/557451ef26a12318261a561dd4df05dad756dc3dec7ee9d574f4f3f16ed1060f", // v2 referrer sig
+			},
+			expErr: nil,
+		},
+		{
 			name: "RepoTagFilterAllow",
 			sync: ConfigSync{
 				Source: "ocidir://testrepo",
@@ -178,6 +204,7 @@ func TestRegsyncOnce(t *testing.T) {
 				Source:          "ocidir://testrepo:v2",
 				Target:          "ocidir://test-referrer:v2",
 				Type:            "image",
+				FastCheck:       &boolTrue,
 				Referrers:       &boolTrue,
 				ReferrerFilters: []ConfigReferrerFilter{},
 			},

--- a/cmd/regsync/root.go
+++ b/cmd/regsync/root.go
@@ -616,7 +616,8 @@ func (s ConfigSync) processRef(ctx context.Context, src, tgt ref.Ref, action str
 	if err == nil && manifest.GetDigest(mSrc).String() == manifest.GetDigest(mTgt).String() {
 		tgtMatches = true
 	}
-	if tgtMatches && (s.ForceRecursive == nil || !*s.ForceRecursive) {
+	if tgtMatches && ((s.FastCheck != nil && *s.FastCheck) ||
+		((s.ForceRecursive == nil || !*s.ForceRecursive) && s.Referrers != nil && *s.Referrers && s.DigestTags != nil && *s.DigestTags)) {
 		log.WithFields(logrus.Fields{
 			"source": src.CommonName(),
 			"target": tgt.CommonName(),
@@ -813,6 +814,9 @@ func (s ConfigSync) processRef(ctx context.Context, src, tgt ref.Ref, action str
 				opts = append(opts, regclient.ImageWithReferrers(rOpts...))
 			}
 		}
+	}
+	if s.FastCheck != nil && *s.FastCheck {
+		opts = append(opts, regclient.ImageWithFastCheck())
 	}
 	if s.ForceRecursive != nil && *s.ForceRecursive {
 		opts = append(opts, regclient.ImageWithForceRecursive())

--- a/docs/regsync.md
+++ b/docs/regsync.md
@@ -183,6 +183,7 @@ sync:
   - `referrerFilters`: (array) list of filters for referrers to include, by default all referrers are included.
     - `artifactType`: (string) artifact types to include.
     - `annotations`: (map) mapping of annotations for referrers.
+  - `fastCopy`: (bool) skip referrers and digest tag checks when image exists, overrides `forceRecursive`.
   - `forceRecursive`: (bool) forces a copy of all manifests and blobs even when the target parent manifest already exists.
   - `mediaTypes`:
     Array of media types to include.
@@ -214,7 +215,7 @@ sync:
     By default all platforms are copied along with the original upstream manifest list.
     Note that looking up the platform from a multi-platform image counts against the Docker Hub rate limit, and that rate limits are not checked prior to resolving the platform.
     When run with "server", the platform is only resolved once for each multi-platform digest seen.
-  - `backup`, `interval`, `schedule`, `ratelimit`, `digestTags`, `referrers`, `referrerFilters`, `forceRecursive`, and `mediaTypes`:
+  - `backup`, `interval`, `schedule`, `ratelimit`, `digestTags`, `referrers`, `referrerFilters`, `fastCopy`, `forceRecursive`, and `mediaTypes`:
     See description under `defaults`.
 
 - `x-*`:

--- a/image_test.go
+++ b/image_test.go
@@ -149,6 +149,42 @@ func TestCopy(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed to copy: %v", err)
 	}
+	rSrc, err = ref.New("ocidir://./testdata/testrepo:v2")
+	if err != nil {
+		t.Errorf("failed to parse src ref: %v", err)
+	}
+	rTgt, err = ref.New("ocidir://" + tempDir + ":v2")
+	if err != nil {
+		t.Errorf("failed to parse tgt ref: %v", err)
+	}
+	err = rc.ImageCopy(ctx, rSrc, rTgt, ImageWithReferrers(), ImageWithDigestTags())
+	if err != nil {
+		t.Errorf("failed to copy: %v", err)
+	}
+	rSrc, err = ref.New("ocidir://./testdata/testrepo:v3")
+	if err != nil {
+		t.Errorf("failed to parse src ref: %v", err)
+	}
+	rTgt, err = ref.New("ocidir://" + tempDir + ":v3")
+	if err != nil {
+		t.Errorf("failed to parse tgt ref: %v", err)
+	}
+	err = rc.ImageCopy(ctx, rSrc, rTgt)
+	if err != nil {
+		t.Errorf("failed to copy: %v", err)
+	}
+	rSrc, err = ref.New("ocidir://./testdata/testrepo:v3")
+	if err != nil {
+		t.Errorf("failed to parse src ref: %v", err)
+	}
+	rTgt, err = ref.New("ocidir://" + tempDir + ":v3")
+	if err != nil {
+		t.Errorf("failed to parse tgt ref: %v", err)
+	}
+	err = rc.ImageCopy(ctx, rSrc, rTgt, ImageWithReferrers(), ImageWithDigestTags(), ImageWithFastCheck())
+	if err != nil {
+		t.Errorf("failed to copy: %v", err)
+	}
 }
 
 func TestExportImport(t *testing.T) {


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Copying with digest tags and referrers needs to check all manifests for those digest tags and referrers. If that content does not change from the source image, this is a lot of overhead.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This adds a fast check option to skip the referrers and digest tag checks when the manifest is already found at the destination.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```
regctl image copy --fast --referrers --digest-tags $src $dest
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Add a fast check option for copying images with referrers and digest tags.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
