### PR TITLE
Chore: switching from strings to an enum

### DIFF
--- a/cmd/regsync/regsync_test.go
+++ b/cmd/regsync/regsync_test.go
@@ -369,7 +369,7 @@ func TestRegsyncOnce(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// run each test
 			syncSetDefaults(&tt.sync, conf.Defaults)
-			err = tt.sync.process(ctx, "once")
+			err = tt.sync.process(ctx, actionCopy)
 			// validate err
 			if tt.expErr != nil {
 				if err == nil {
@@ -434,7 +434,7 @@ func TestProcess(t *testing.T) {
 		name         string
 		src          string
 		tgt          string
-		action       string
+		action       actionType
 		expErr       error
 		checkTgtEq   bool
 		checkTgtDiff bool
@@ -447,21 +447,21 @@ func TestProcess(t *testing.T) {
 			name:         "check v1",
 			src:          "v1",
 			tgt:          "tgt",
-			action:       "check",
+			action:       actionCheck,
 			checkTgtDiff: true,
 		},
 		{
 			name:       "copy v1",
 			src:        "v1",
 			tgt:        "tgt",
-			action:     "copy",
+			action:     actionCopy,
 			checkTgtEq: true,
 		},
 		{
 			name:         "missing only on v2",
 			src:          "v2",
 			tgt:          "tgt",
-			action:       "missing",
+			action:       actionMissing,
 			checkTgtDiff: true,
 		},
 	}


### PR DESCRIPTION

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

The various actions in regsync should be differentiated using an enum rather than strings.

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

No user visible changes.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
