### PR TITLE
Reduce referrer API calls

### DIFF
--- a/scheme/reg/manifest.go
+++ b/scheme/reg/manifest.go
@@ -235,7 +235,7 @@ func (reg *Reg) ManifestPut(ctx context.Context, r ref.Ref, m manifest.Manifest,
 		if err != nil {
 			return err
 		}
-		if mDesc != nil && mDesc.MediaType != "" && mDesc.Size > 0 {
+		if mDesc != nil && mDesc.MediaType != "" && mDesc.Size > 0 && mDesc.Digest.String() != resp.HTTPResponse().Header.Get(OCISubjectHeader) {
 			err = reg.referrerPut(ctx, r, m)
 			if err != nil {
 				return err

--- a/scheme/reg/referrer_test.go
+++ b/scheme/reg/referrer_test.go
@@ -301,31 +301,6 @@ func TestReferrer(t *testing.T) {
 		},
 		{
 			ReqEntry: reqresp.ReqEntry{
-				Name:     "Put A by digest",
-				Method:   "PUT",
-				Path:     "/v2" + repoPath + "/manifests/" + string(artifactDigest),
-				Body:     artifactBody,
-				SetState: "putA",
-			},
-			RespEntry: reqresp.RespEntry{
-				Status: http.StatusCreated,
-			},
-		},
-		{
-			ReqEntry: reqresp.ReqEntry{
-				Name:     "Put B by digest",
-				Method:   "PUT",
-				Path:     "/v2" + repoPath + "/manifests/" + string(artifact2Digest),
-				Body:     artifact2Body,
-				IfState:  []string{"putA", "putARef"},
-				SetState: "putBoth",
-			},
-			RespEntry: reqresp.RespEntry{
-				Status: http.StatusCreated,
-			},
-		},
-		{
-			ReqEntry: reqresp.ReqEntry{
 				Name:    "Get A",
 				Method:  "GET",
 				Path:    "/v2" + repoPath + "/manifests/" + string(artifactDigest),
@@ -380,6 +355,33 @@ func TestReferrer(t *testing.T) {
 			},
 			RespEntry: reqresp.RespEntry{
 				Status: http.StatusAccepted,
+			},
+		},
+	}
+	rrsNoAPIPut := []reqresp.ReqResp{
+		{
+			ReqEntry: reqresp.ReqEntry{
+				Name:     "Put A by digest",
+				Method:   "PUT",
+				Path:     "/v2" + repoPath + "/manifests/" + string(artifactDigest),
+				Body:     artifactBody,
+				SetState: "putA",
+			},
+			RespEntry: reqresp.RespEntry{
+				Status: http.StatusCreated,
+			},
+		},
+		{
+			ReqEntry: reqresp.ReqEntry{
+				Name:     "Put B by digest",
+				Method:   "PUT",
+				Path:     "/v2" + repoPath + "/manifests/" + string(artifact2Digest),
+				Body:     artifact2Body,
+				IfState:  []string{"putA", "putARef"},
+				SetState: "putBoth",
+			},
+			RespEntry: reqresp.RespEntry{
+				Status: http.StatusCreated,
 			},
 		},
 	}
@@ -602,6 +604,37 @@ func TestReferrer(t *testing.T) {
 	rrsAPI := []reqresp.ReqResp{
 		{
 			ReqEntry: reqresp.ReqEntry{
+				Name:     "Put A by digest",
+				Method:   "PUT",
+				Path:     "/v2" + repoPath + "/manifests/" + string(artifactDigest),
+				Body:     artifactBody,
+				SetState: "putA",
+			},
+			RespEntry: reqresp.RespEntry{
+				Status: http.StatusCreated,
+				Headers: http.Header{
+					OCISubjectHeader: []string{mDigest.String()},
+				},
+			},
+		},
+		{
+			ReqEntry: reqresp.ReqEntry{
+				Name:     "Put B by digest",
+				Method:   "PUT",
+				Path:     "/v2" + repoPath + "/manifests/" + string(artifact2Digest),
+				Body:     artifact2Body,
+				IfState:  []string{"putA", "putARef"},
+				SetState: "putBoth",
+			},
+			RespEntry: reqresp.RespEntry{
+				Status: http.StatusCreated,
+				Headers: http.Header{
+					OCISubjectHeader: []string{mDigest.String()},
+				},
+			},
+		},
+		{
+			ReqEntry: reqresp.ReqEntry{
 				Name:    "API empty",
 				Method:  "GET",
 				Path:    "/v2" + repoPath + "/referrers/" + mDigest.String(),
@@ -674,8 +707,10 @@ func TestReferrer(t *testing.T) {
 		},
 	}
 	rrsNoAPI = append(rrsNoAPI, rrs...)
+	rrsNoAPI = append(rrsNoAPI, rrsNoAPIPut...)
 	rrsNoAPI = append(rrsNoAPI, reqresp.BaseEntries...)
 	rrsNoAPIAuth = append(rrsNoAPIAuth, rrs...)
+	rrsNoAPIAuth = append(rrsNoAPIAuth, rrsNoAPIPut...)
 	rrsNoAPIAuth = append(rrsNoAPIAuth, reqresp.BaseEntries...)
 	rrsAPI = append(rrsAPI, rrs...)
 	rrsAPI = append(rrsAPI, reqresp.BaseEntries...)

--- a/scheme/reg/reg.go
+++ b/scheme/reg/reg.go
@@ -30,12 +30,25 @@ type Reg struct {
 	reghttpOpts    []reghttp.Opts
 	log            *logrus.Logger
 	hosts          map[string]*config.Host
+	features       map[featureKey]*featureVal
 	blobChunkSize  int64
 	blobChunkLimit int64
 	blobMaxPut     int64
 	muHost         sync.Mutex
 	muRefTag       sync.Mutex
 }
+
+type featureKey struct {
+	kind string
+	reg  string
+	repo string
+}
+type featureVal struct {
+	enabled bool
+	expire  time.Time
+}
+
+var featureExpire = time.Minute * time.Duration(5)
 
 // Opts provides options to access registries
 type Opts func(*Reg)
@@ -48,6 +61,7 @@ func New(opts ...Opts) *Reg {
 		blobChunkLimit: defaultBlobChunkLimit,
 		blobMaxPut:     defaultBlobMax,
 		hosts:          map[string]*config.Host{},
+		features:       map[featureKey]*featureVal{},
 	}
 	r.reghttpOpts = append(r.reghttpOpts, reghttp.WithConfigHost(r.hostGet))
 	for _, opt := range opts {
@@ -83,6 +97,24 @@ func (reg *Reg) hostGet(hostname string) *config.Host {
 		reg.hosts[hostname] = config.HostNewName(hostname)
 	}
 	return reg.hosts[hostname]
+}
+
+// featureGet returns enabled and ok
+func (reg *Reg) featureGet(kind, registry, repo string) (bool, bool) {
+	reg.muHost.Lock()
+	defer reg.muHost.Unlock()
+	if v, ok := reg.features[featureKey{kind: kind, reg: registry, repo: repo}]; ok {
+		if time.Now().Before(v.expire) {
+			return v.enabled, true
+		}
+	}
+	return false, false
+}
+
+func (reg *Reg) featureSet(kind, registry, repo string, enabled bool) {
+	reg.muHost.Lock()
+	reg.features[featureKey{kind: kind, reg: registry, repo: repo}] = &featureVal{enabled: enabled, expire: time.Now().Add(featureExpire)}
+	reg.muHost.Unlock()
 }
 
 // WithBlobSize overrides default blob sizes


### PR DESCRIPTION

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Copying a multi-platform image results in a lot of failed referrer API calls to OCI v1.0 registries.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Use the OCI-Subject header to know when the referrers API is supported. Cache the result of an API ping to avoid retrying it.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Referrers should still work, but commands pushing or listing referrers should run faster to OCI v1.0 registries.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Handle the OCI-Subject header to detect referrer support.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
