### PR TITLE
Adjust progress display of image copy

### DIFF
--- a/cmd/regctl/image.go
+++ b/cmd/regctl/image.go
@@ -735,7 +735,6 @@ func (ip *imageProgress) display(w io.Writer, final bool) {
 	if !ip.changed && !final {
 		return // skip since no changes since last display and not the final display
 	}
-	now := time.Now()
 	var manifestTotal, manifestFinished, sum, skipped, queued int64
 	// sort entry keys by start time
 	keys := make([]string, 0, len(ip.entries))
@@ -795,16 +794,15 @@ func (ip *imageProgress) display(w io.Writer, final bool) {
 		}
 	}
 	// show stats summary
-	ip.asciOut.Add([]byte(fmt.Sprintf("%d/%d manifests, %s/s, %s copied, %s skipped",
+	ip.asciOut.Add([]byte(fmt.Sprintf("Manifests: %d/%d | Blobs: %s copied, %s skipped",
 		manifestFinished, manifestTotal,
-		units.HumanSize(float64(sum)/now.Sub(ip.start).Seconds()),
 		units.HumanSize(float64(sum)),
 		units.HumanSize(float64(skipped)))))
 	if queued > 0 {
 		ip.asciOut.Add([]byte(fmt.Sprintf(", %s queued",
 			units.HumanSize(float64(queued)))))
 	}
-	ip.asciOut.Add([]byte("\n"))
+	ip.asciOut.Add([]byte(fmt.Sprintf(" | Elapsed: %ds\n", int64(time.Since(ip.start).Seconds()))))
 	ip.asciOut.Flush()
 	if !final {
 		ip.asciOut.Return()

--- a/internal/units/size.go
+++ b/internal/units/size.go
@@ -32,28 +32,26 @@ func getSizeAndUnit(size float64, base float64, unitList []string) (float64, str
 	return size, unitList[i]
 }
 
-// CustomSize returns a human-readable approximation of a size
-// using custom format.
+// CustomSize returns a human-readable approximation of a size using custom format.
 func CustomSize(format string, size float64, base float64, unitList []string) string {
 	size, unit := getSizeAndUnit(size, base, unitList)
 	return fmt.Sprintf(format, size, unit)
 }
 
-// HumanSizeWithPrecision allows the size to be in any precision,
-// instead of 4 digit precision used in units.HumanSize.
-func HumanSizeWithPrecision(size float64, precision int) string {
+// HumanSizeWithPrecision allows the size to be in any precision.
+func HumanSizeWithPrecision(size float64, width, precision int) string {
 	size, unit := getSizeAndUnit(size, 1000.0, decimapAbbrs)
-	return fmt.Sprintf("%.*g%s", precision, size, unit)
+	return fmt.Sprintf("%*.*f%s", width, precision, size, unit)
 }
 
 // HumanSize returns a human-readable approximation of a size
-// capped at 4 valid numbers (eg. "2.746 MB", "796 KB").
+// with a width of 5 (eg. "2.746MB", "796.0KB").
 func HumanSize(size float64) string {
-	return HumanSizeWithPrecision(size, 4)
+	return HumanSizeWithPrecision(size, 5, 3)
 }
 
 // BytesSize returns a human-readable size in bytes, kibibytes,
-// mebibytes, gibibytes, or tebibytes (eg. "44kiB", "17MiB").
+// mebibytes, gibibytes, or tebibytes (eg. "44.2kiB", "17.6MiB").
 func BytesSize(size float64) string {
-	return CustomSize("%.4g%s", size, 1024.0, binaryAbbrs)
+	return CustomSize("%5.3f%s", size, 1024.0, binaryAbbrs)
 }

--- a/internal/units/size_test.go
+++ b/internal/units/size_test.go
@@ -11,7 +11,7 @@ func TestHuman(t *testing.T) {
 		{
 			name:   "zero",
 			size:   0,
-			result: "0B",
+			result: "0.000B",
 		},
 		{
 			name:   "1.024kB",
@@ -21,7 +21,7 @@ func TestHuman(t *testing.T) {
 		{
 			name:   "1MB",
 			size:   1000099,
-			result: "1MB",
+			result: "1.000MB",
 		},
 	}
 


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

The progress line doesn't differentiate between manifests and blobs very well, and the bandwidth isn't useful if much of the work is round trips that aren't counted.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Separate the manifests, blobs, and add an elapsed time. This also switches human readable numbers to a fixed width to avoid the display jumping every time the number ends with a 0 in the decimal.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Output from:
```
regctl image copy $src $dst
```
should be easier to follow.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Update `regctl image copy` for tty displays.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
