### PR TITLE
Referrers chores

### DIFF
--- a/cmd/regctl/artifact.go
+++ b/cmd/regctl/artifact.go
@@ -799,6 +799,9 @@ func treeAddResult(ctx context.Context, rc *regclient.RegClient, r ref.Ref, seen
 		return nil, err
 	}
 	tr.Manifest = m
+	if r.Digest == "" {
+		r.Digest = m.GetDescriptor().Digest.String()
+	}
 
 	// track already seen manifests
 	dig := m.GetDescriptor().Digest.String()

--- a/scheme/reg/referrer.go
+++ b/scheme/reg/referrer.go
@@ -16,7 +16,6 @@ import (
 	"github.com/regclient/regclient/types/platform"
 	"github.com/regclient/regclient/types/ref"
 	"github.com/regclient/regclient/types/referrer"
-	"github.com/sirupsen/logrus"
 )
 
 const OCISubjectHeader = "OCI-Subject"
@@ -96,10 +95,6 @@ func (reg *Reg) referrerListByAPI(ctx context.Context, r ref.Ref, config scheme.
 	for {
 		rlAdd, respNext, err := reg.referrerListByAPIPage(ctx, r, config, link)
 		if err != nil {
-			reg.log.WithFields(logrus.Fields{
-				"err": err,
-				"ref": r.CommonName(),
-			}).Debug("referrers API failed")
 			return rl, err
 		}
 		if rl.Manifest == nil {


### PR DESCRIPTION

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Debugging output is overly verbose when copying referrers on some registries that don't support referrers.
There's an unneeded manifest head request on the artifact tree command.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

- Remove debugging on referrer API failure, this can be overly verbose on some registries.
- Set the digest for for a given ref in artifact tree to avoid an extra HEAD request.

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Debugging output should be cleaner in commands like `artifact tree`.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
