### PR TITLE
Pin GCR helper to a tag

### DIFF
--- a/.version-bump.lock
+++ b/.version-bump.lock
@@ -20,6 +20,7 @@
 {"name":"git-commit","key":"https://github.com/awslabs/amazon-ecr-credential-helper.git:main","version":"7f2db5bd753edc4c799d8b932941d8871a70d130"}
 {"name":"git-commit","key":"https://github.com/grafi-tt/lunajson.git:master","version":"e6063d37de97dfdfe2749e24de949472bfad0945"}
 {"name":"git-commit","key":"https://github.com/kikito/semver.lua.git:master","version":"af495adc857d51fd1507a112be18523828a1da0d"}
+{"name":"git-tag-semver","key":"github.com/GoogleCloudPlatform/docker-credential-gcr","version":"v2.1.8"}
 {"name":"git-tag-semver","key":"github.com/dominikh/go-tools","version":"v0.4.3"}
 {"name":"git-tag-semver","key":"github.com/sigstore/cosign","version":"v2.0.2"}
 {"name":"registry-digest-arg","key":"alpine:3","version":"sha256:02bb6f428431fbc2809c5d1b41eab5a68350194fb508869a33cb1af4444c9b11"}

--- a/.version-bump.yml
+++ b/.version-bump.yml
@@ -5,7 +5,7 @@ files:
       - docker-arg-go-tag
       - docker-arg-go
       - git-commit-ecr
-      - git-commit-gcr
+      - git-tag-gcr
       - git-commit-lunajson
       - git-commit-semver
   ".github/workflows/*.yml":
@@ -52,12 +52,12 @@ scans:
       regexp: '^ARG ECR_HELPER_VER=(?P<Version>[0-9a-f]+)\s*$'
       repo: "https://github.com/awslabs/amazon-ecr-credential-helper.git"
       ref: main
-  git-commit-gcr:
+  git-tag-gcr:
     type: "regexp"
-    source: "git-commit"
+    source: "git-tag-semver"
     args:
-      regexp: '^ARG GCR_HELPER_VER=(?P<Version>[0-9a-f]+)\s*$'
-      repo: "https://github.com/GoogleCloudPlatform/docker-credential-gcr.git"
+      regexp: '^ARG GCR_HELPER_VER=(?P<Version>[^\s]+)\s*$'
+      repo: "github.com/GoogleCloudPlatform/docker-credential-gcr"
       ref: master
   git-commit-lunajson:
     type: "regexp"

--- a/build/Dockerfile.regbot
+++ b/build/Dockerfile.regbot
@@ -2,7 +2,7 @@ ARG REGISTRY=docker.io
 ARG ALPINE_VER=3@sha256:02bb6f428431fbc2809c5d1b41eab5a68350194fb508869a33cb1af4444c9b11
 ARG GO_VER=1.20-alpine@sha256:ee2f23f1a612da71b8a4cd78fec827f1e67b0a8546a98d257cca441a4ddbebcb
 ARG ECR_HELPER_VER=7f2db5bd753edc4c799d8b932941d8871a70d130
-ARG GCR_HELPER_VER=62afb2723512fd6572c6300024e0c94f734b0ae3
+ARG GCR_HELPER_VER=v2.1.8
 ARG LUNAJSON_COMMIT=e6063d37de97dfdfe2749e24de949472bfad0945
 ARG SEMVER_COMMIT=af495adc857d51fd1507a112be18523828a1da0d
 
@@ -38,9 +38,16 @@ FROM golang as docker-cred-gcr
 ARG TARGETOS
 ARG TARGETARCH
 ARG GCR_HELPER_VER
-RUN CGO_ENABLED=0 go install -trimpath -ldflags=-buildid= github.com/GoogleCloudPlatform/docker-credential-gcr@${GCR_HELPER_VER} \
- && ( cp "${GOPATH}/bin/docker-credential-gcr" /usr/local/bin/docker-credential-gcr \
-   || cp "${GOPATH}/bin/${TARGETOS}_${TARGETARCH}/docker-credential-gcr" /usr/local/bin/docker-credential-gcr )
+# TODO: remove workaround, pending issue https://github.com/GoogleCloudPlatform/docker-credential-gcr/issues/128
+RUN git clone https://github.com/GoogleCloudPlatform/docker-credential-gcr.git -b ${GCR_HELPER_VER} --depth 1
+WORKDIR ./docker-credential-gcr
+RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=0 \
+    go build -trimpath -ldflags="-buildid= -s -w -X github.com/GoogleCloudPlatform/docker-credential-gcr/config.Version=${GCR_HELPER_VER#v}" . \
+ && cp docker-credential-gcr /usr/local/bin/docker-credential-gcr
+# RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=0 \
+#     go install -trimpath -ldflags=-buildid= github.com/GoogleCloudPlatform/docker-credential-gcr@${GCR_HELPER_VER} \
+#  && ( cp "${GOPATH}/bin/docker-credential-gcr" /usr/local/bin/docker-credential-gcr \
+#    || cp "${GOPATH}/bin/${TARGETOS}_${TARGETARCH}/docker-credential-gcr" /usr/local/bin/docker-credential-gcr )
 
 FROM ${REGISTRY}/library/alpine:${ALPINE_VER} as lua-mods
 # COPY may pull in old timestamps, use a touch command below to reset them

--- a/build/Dockerfile.regbot.buildkit
+++ b/build/Dockerfile.regbot.buildkit
@@ -4,7 +4,7 @@ ARG REGISTRY=docker.io
 ARG ALPINE_VER=3@sha256:02bb6f428431fbc2809c5d1b41eab5a68350194fb508869a33cb1af4444c9b11
 ARG GO_VER=1.20-alpine@sha256:ee2f23f1a612da71b8a4cd78fec827f1e67b0a8546a98d257cca441a4ddbebcb
 ARG ECR_HELPER_VER=7f2db5bd753edc4c799d8b932941d8871a70d130
-ARG GCR_HELPER_VER=62afb2723512fd6572c6300024e0c94f734b0ae3
+ARG GCR_HELPER_VER=v2.1.8
 ARG LUNAJSON_COMMIT=e6063d37de97dfdfe2749e24de949472bfad0945
 ARG SEMVER_COMMIT=af495adc857d51fd1507a112be18523828a1da0d
 
@@ -52,12 +52,20 @@ FROM --platform=$BUILDPLATFORM golang as docker-cred-gcr
 ARG TARGETOS
 ARG TARGETARCH
 ARG GCR_HELPER_VER
+# TODO: remove workaround, pending issue https://github.com/GoogleCloudPlatform/docker-credential-gcr/issues/128
+RUN git clone https://github.com/GoogleCloudPlatform/docker-credential-gcr.git -b ${GCR_HELPER_VER} --depth 1
+WORKDIR ./docker-credential-gcr
 RUN --mount=type=cache,id=gomod,target=/go/pkg/mod/cache \
     --mount=type=cache,id=goroot,target=/root/.cache/go-build \
     GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=0 \
-    go install -trimpath -ldflags=-buildid= github.com/GoogleCloudPlatform/docker-credential-gcr@${GCR_HELPER_VER} \
- && ( cp "${GOPATH}/bin/docker-credential-gcr" /usr/local/bin/docker-credential-gcr \
-   || cp "${GOPATH}/bin/${TARGETOS}_${TARGETARCH}/docker-credential-gcr" /usr/local/bin/docker-credential-gcr )
+    go build -trimpath -ldflags="-buildid= -s -w -X github.com/GoogleCloudPlatform/docker-credential-gcr/config.Version=${GCR_HELPER_VER#v}" . \
+ && cp docker-credential-gcr /usr/local/bin/docker-credential-gcr
+# RUN --mount=type=cache,id=gomod,target=/go/pkg/mod/cache \
+#     --mount=type=cache,id=goroot,target=/root/.cache/go-build \
+#     GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=0 \
+#     go install -trimpath -ldflags=-buildid= github.com/GoogleCloudPlatform/docker-credential-gcr@${GCR_HELPER_VER} \
+#  && ( cp "${GOPATH}/bin/docker-credential-gcr" /usr/local/bin/docker-credential-gcr \
+#    || cp "${GOPATH}/bin/${TARGETOS}_${TARGETARCH}/docker-credential-gcr" /usr/local/bin/docker-credential-gcr )
 
 FROM --platform=$BUILDPLATFORM ${REGISTRY}/library/alpine:${ALPINE_VER} as lua-mods
 # COPY may pull in old timestamps, use a touch command below to reset them

--- a/build/Dockerfile.regctl
+++ b/build/Dockerfile.regctl
@@ -2,7 +2,7 @@ ARG REGISTRY=docker.io
 ARG ALPINE_VER=3@sha256:02bb6f428431fbc2809c5d1b41eab5a68350194fb508869a33cb1af4444c9b11
 ARG GO_VER=1.20-alpine@sha256:ee2f23f1a612da71b8a4cd78fec827f1e67b0a8546a98d257cca441a4ddbebcb
 ARG ECR_HELPER_VER=7f2db5bd753edc4c799d8b932941d8871a70d130
-ARG GCR_HELPER_VER=62afb2723512fd6572c6300024e0c94f734b0ae3
+ARG GCR_HELPER_VER=v2.1.8
 
 FROM ${REGISTRY}/library/golang:${GO_VER} as golang
 RUN apk add --no-cache \
@@ -36,9 +36,16 @@ FROM golang as docker-cred-gcr
 ARG TARGETOS
 ARG TARGETARCH
 ARG GCR_HELPER_VER
-RUN CGO_ENABLED=0 go install -trimpath -ldflags=-buildid= github.com/GoogleCloudPlatform/docker-credential-gcr@${GCR_HELPER_VER} \
- && ( cp "${GOPATH}/bin/docker-credential-gcr" /usr/local/bin/docker-credential-gcr \
-   || cp "${GOPATH}/bin/${TARGETOS}_${TARGETARCH}/docker-credential-gcr" /usr/local/bin/docker-credential-gcr )
+# TODO: remove workaround, pending issue https://github.com/GoogleCloudPlatform/docker-credential-gcr/issues/128
+RUN git clone https://github.com/GoogleCloudPlatform/docker-credential-gcr.git -b ${GCR_HELPER_VER} --depth 1
+WORKDIR ./docker-credential-gcr
+RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=0 \
+    go build -trimpath -ldflags="-buildid= -s -w -X github.com/GoogleCloudPlatform/docker-credential-gcr/config.Version=${GCR_HELPER_VER#v}" . \
+ && cp docker-credential-gcr /usr/local/bin/docker-credential-gcr
+# RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=0 \
+#     go install -trimpath -ldflags=-buildid= github.com/GoogleCloudPlatform/docker-credential-gcr@${GCR_HELPER_VER} \
+#  && ( cp "${GOPATH}/bin/docker-credential-gcr" /usr/local/bin/docker-credential-gcr \
+#    || cp "${GOPATH}/bin/${TARGETOS}_${TARGETARCH}/docker-credential-gcr" /usr/local/bin/docker-credential-gcr )
 
 FROM ${REGISTRY}/library/alpine:${ALPINE_VER} as release-alpine
 COPY --from=build /etc/passwd /etc/group /etc/

--- a/build/Dockerfile.regctl.buildkit
+++ b/build/Dockerfile.regctl.buildkit
@@ -4,7 +4,7 @@ ARG REGISTRY=docker.io
 ARG ALPINE_VER=3@sha256:02bb6f428431fbc2809c5d1b41eab5a68350194fb508869a33cb1af4444c9b11
 ARG GO_VER=1.20-alpine@sha256:ee2f23f1a612da71b8a4cd78fec827f1e67b0a8546a98d257cca441a4ddbebcb
 ARG ECR_HELPER_VER=7f2db5bd753edc4c799d8b932941d8871a70d130
-ARG GCR_HELPER_VER=62afb2723512fd6572c6300024e0c94f734b0ae3
+ARG GCR_HELPER_VER=v2.1.8
 
 FROM --platform=$BUILDPLATFORM ${REGISTRY}/library/golang:${GO_VER} as golang
 RUN apk add --no-cache \
@@ -50,12 +50,20 @@ FROM --platform=$BUILDPLATFORM golang as docker-cred-gcr
 ARG TARGETOS
 ARG TARGETARCH
 ARG GCR_HELPER_VER
+# TODO: remove workaround, pending issue https://github.com/GoogleCloudPlatform/docker-credential-gcr/issues/128
+RUN git clone https://github.com/GoogleCloudPlatform/docker-credential-gcr.git -b ${GCR_HELPER_VER} --depth 1
+WORKDIR ./docker-credential-gcr
 RUN --mount=type=cache,id=gomod,target=/go/pkg/mod/cache \
     --mount=type=cache,id=goroot,target=/root/.cache/go-build \
     GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=0 \
-    go install -trimpath -ldflags=-buildid= github.com/GoogleCloudPlatform/docker-credential-gcr@${GCR_HELPER_VER} \
- && ( cp "${GOPATH}/bin/docker-credential-gcr" /usr/local/bin/docker-credential-gcr \
-   || cp "${GOPATH}/bin/${TARGETOS}_${TARGETARCH}/docker-credential-gcr" /usr/local/bin/docker-credential-gcr )
+    go build -trimpath -ldflags="-buildid= -s -w -X github.com/GoogleCloudPlatform/docker-credential-gcr/config.Version=${GCR_HELPER_VER#v}" . \
+ && cp docker-credential-gcr /usr/local/bin/docker-credential-gcr
+# RUN --mount=type=cache,id=gomod,target=/go/pkg/mod/cache \
+#     --mount=type=cache,id=goroot,target=/root/.cache/go-build \
+#     GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=0 \
+#     go install -trimpath -ldflags=-buildid= github.com/GoogleCloudPlatform/docker-credential-gcr@${GCR_HELPER_VER} \
+#  && ( cp "${GOPATH}/bin/docker-credential-gcr" /usr/local/bin/docker-credential-gcr \
+#    || cp "${GOPATH}/bin/${TARGETOS}_${TARGETARCH}/docker-credential-gcr" /usr/local/bin/docker-credential-gcr )
 
 FROM ${REGISTRY}/library/alpine:${ALPINE_VER} as release-alpine
 COPY --from=build /etc/passwd /etc/group /etc/

--- a/build/Dockerfile.regsync
+++ b/build/Dockerfile.regsync
@@ -2,7 +2,7 @@ ARG REGISTRY=docker.io
 ARG ALPINE_VER=3@sha256:02bb6f428431fbc2809c5d1b41eab5a68350194fb508869a33cb1af4444c9b11
 ARG GO_VER=1.20-alpine@sha256:ee2f23f1a612da71b8a4cd78fec827f1e67b0a8546a98d257cca441a4ddbebcb
 ARG ECR_HELPER_VER=7f2db5bd753edc4c799d8b932941d8871a70d130
-ARG GCR_HELPER_VER=62afb2723512fd6572c6300024e0c94f734b0ae3
+ARG GCR_HELPER_VER=v2.1.8
 
 FROM ${REGISTRY}/library/golang:${GO_VER} as golang
 RUN apk add --no-cache \
@@ -37,9 +37,16 @@ FROM golang as docker-cred-gcr
 ARG TARGETOS
 ARG TARGETARCH
 ARG GCR_HELPER_VER
-RUN CGO_ENABLED=0 go install -trimpath -ldflags=-buildid= github.com/GoogleCloudPlatform/docker-credential-gcr@${GCR_HELPER_VER} \
- && ( cp "${GOPATH}/bin/docker-credential-gcr" /usr/local/bin/docker-credential-gcr \
-   || cp "${GOPATH}/bin/${TARGETOS}_${TARGETARCH}/docker-credential-gcr" /usr/local/bin/docker-credential-gcr )
+# TODO: remove workaround, pending issue https://github.com/GoogleCloudPlatform/docker-credential-gcr/issues/128
+RUN git clone https://github.com/GoogleCloudPlatform/docker-credential-gcr.git -b ${GCR_HELPER_VER} --depth 1
+WORKDIR ./docker-credential-gcr
+RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=0 \
+    go build -trimpath -ldflags="-buildid= -s -w -X github.com/GoogleCloudPlatform/docker-credential-gcr/config.Version=${GCR_HELPER_VER#v}" . \
+ && cp docker-credential-gcr /usr/local/bin/docker-credential-gcr
+# RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=0 \
+#     go install -trimpath -ldflags=-buildid= github.com/GoogleCloudPlatform/docker-credential-gcr@${GCR_HELPER_VER} \
+#  && ( cp "${GOPATH}/bin/docker-credential-gcr" /usr/local/bin/docker-credential-gcr \
+#    || cp "${GOPATH}/bin/${TARGETOS}_${TARGETARCH}/docker-credential-gcr" /usr/local/bin/docker-credential-gcr )
 
 FROM ${REGISTRY}/library/alpine:${ALPINE_VER} as release-alpine
 COPY --from=build /etc/passwd /etc/group /etc/

--- a/build/Dockerfile.regsync.buildkit
+++ b/build/Dockerfile.regsync.buildkit
@@ -4,7 +4,7 @@ ARG REGISTRY=docker.io
 ARG ALPINE_VER=3@sha256:02bb6f428431fbc2809c5d1b41eab5a68350194fb508869a33cb1af4444c9b11
 ARG GO_VER=1.20-alpine@sha256:ee2f23f1a612da71b8a4cd78fec827f1e67b0a8546a98d257cca441a4ddbebcb
 ARG ECR_HELPER_VER=7f2db5bd753edc4c799d8b932941d8871a70d130
-ARG GCR_HELPER_VER=62afb2723512fd6572c6300024e0c94f734b0ae3
+ARG GCR_HELPER_VER=v2.1.8
 
 FROM --platform=$BUILDPLATFORM ${REGISTRY}/library/golang:${GO_VER} as golang
 RUN apk add --no-cache \
@@ -50,12 +50,20 @@ FROM --platform=$BUILDPLATFORM golang as docker-cred-gcr
 ARG TARGETOS
 ARG TARGETARCH
 ARG GCR_HELPER_VER
+# TODO: remove workaround, pending issue https://github.com/GoogleCloudPlatform/docker-credential-gcr/issues/128
+RUN git clone https://github.com/GoogleCloudPlatform/docker-credential-gcr.git -b ${GCR_HELPER_VER} --depth 1
+WORKDIR ./docker-credential-gcr
 RUN --mount=type=cache,id=gomod,target=/go/pkg/mod/cache \
     --mount=type=cache,id=goroot,target=/root/.cache/go-build \
     GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=0 \
-    go install -trimpath -ldflags=-buildid= github.com/GoogleCloudPlatform/docker-credential-gcr@${GCR_HELPER_VER} \
- && ( cp "${GOPATH}/bin/docker-credential-gcr" /usr/local/bin/docker-credential-gcr \
-   || cp "${GOPATH}/bin/${TARGETOS}_${TARGETARCH}/docker-credential-gcr" /usr/local/bin/docker-credential-gcr )
+    go build -trimpath -ldflags="-buildid= -s -w -X github.com/GoogleCloudPlatform/docker-credential-gcr/config.Version=${GCR_HELPER_VER#v}" . \
+ && cp docker-credential-gcr /usr/local/bin/docker-credential-gcr
+# RUN --mount=type=cache,id=gomod,target=/go/pkg/mod/cache \
+#     --mount=type=cache,id=goroot,target=/root/.cache/go-build \
+#     GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=0 \
+#     go install -trimpath -ldflags=-buildid= github.com/GoogleCloudPlatform/docker-credential-gcr@${GCR_HELPER_VER} \
+#  && ( cp "${GOPATH}/bin/docker-credential-gcr" /usr/local/bin/docker-credential-gcr \
+#    || cp "${GOPATH}/bin/${TARGETOS}_${TARGETARCH}/docker-credential-gcr" /usr/local/bin/docker-credential-gcr )
 
 FROM ${REGISTRY}/library/alpine:${ALPINE_VER} as release-alpine
 COPY --from=build /etc/passwd /etc/group /etc/


### PR DESCRIPTION

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

GCR doesn't build correctly against the master branch.
Fixes #453.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This pins to a version and injects that version in the go build.
Ideally this will be fixed upstream to allow `go install` to work again.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```
$ docker run regclient/regctl:alpine /usr/local/bin/docker-credential-gcr version
Google Container Registry Docker credential helper v2.1.8
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Fix GCR credential helper to work on Artifact Registry
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [x] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
