### PR TITLE
OCI embedded Platform in the image config

### DIFF
--- a/scheme/reg/tag.go
+++ b/scheme/reg/tag.go
@@ -24,6 +24,7 @@ import (
 	"github.com/regclient/regclient/types/docker/schema2"
 	"github.com/regclient/regclient/types/manifest"
 	v1 "github.com/regclient/regclient/types/oci/v1"
+	"github.com/regclient/regclient/types/platform"
 	"github.com/regclient/regclient/types/ref"
 	"github.com/regclient/regclient/types/tag"
 	"github.com/sirupsen/logrus"
@@ -86,8 +87,10 @@ func (reg *Reg) TagDelete(ctx context.Context, r ref.Ref) error {
 				"delete-date": now.String(),
 			},
 		},
-		OS:           "linux",
-		Architecture: "amd64",
+		Platform: platform.Platform{
+			OS:           "linux",
+			Architecture: "amd64",
+		},
 		History: []v1.History{
 			{
 				Created:   &now,

--- a/types/oci/v1/config.go
+++ b/types/oci/v1/config.go
@@ -7,6 +7,7 @@ import (
 	_ "crypto/sha512"
 
 	digest "github.com/opencontainers/go-digest"
+	"github.com/regclient/regclient/types/platform"
 )
 
 // ImageConfig defines the execution parameters which should be used as a base when running a container using an image.
@@ -84,22 +85,8 @@ type Image struct {
 	// Author defines the name and/or email address of the person or entity which created and is responsible for maintaining the image.
 	Author string `json:"author,omitempty"`
 
-	// Architecture is the CPU architecture which the binaries in this image are built to run on.
-	Architecture string `json:"architecture"`
-
-	// Variant is the variant of the specified CPU architecture which image binaries are intended to run on.
-	Variant string `json:"variant,omitempty"`
-
-	// OS is the name of the operating system which the image is built to run on.
-	OS string `json:"os"`
-
-	// OSVersion is an optional field specifying the operating system
-	// version, for example on Windows `10.0.14393.1066`.
-	OSVersion string `json:"os.version,omitempty"`
-
-	// OSFeatures is an optional field specifying an array of strings,
-	// each listing a required OS feature (for example on Windows `win32k`).
-	OSFeatures []string `json:"os.features,omitempty"`
+	// Platform describes the platform which the image in the manifest runs on.
+	platform.Platform
 
 	// Config defines the execution parameters which should be used as a base when running a container using the image.
 	Config ImageConfig `json:"config,omitempty"`


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Embed the Platform field directly in the `ImageConfig`, rather than including the individual Platform components.
This aligns with the upstream OCI spec, and makes it easier to extract the platform from an image config.
Any code that initializes the ImageConfig may need a minor change.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

No user visible changes in the CLIs.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

regclient: embed the `Platform` field directly in the `ImageConfig`
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
