### PR TITLE
Mod annotations on platform manifests in an index

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -150,13 +150,13 @@ jobs:
         regctl image mod "${local_tag}" --replace \
           --to-oci-referrers \
           --time-max "${vcs_date}" \
-          --annotation "oci.opencontainers.image.created=${vcs_date}" \
-          --annotation "oci.opencontainers.image.source=${{ steps.prep.outputs.repo_url }}" \
-          --annotation "oci.opencontainers.image.revision=${{ github.sha }}"
+          --annotation "[*]oci.opencontainers.image.created=${vcs_date}" \
+          --annotation "[*]oci.opencontainers.image.source=${{ steps.prep.outputs.repo_url }}" \
+          --annotation "[*]oci.opencontainers.image.revision=${{ github.sha }}"
         if [ -n "$base_name" ] && [ -n "$base_digest" ]; then
           regctl image mod "${local_tag}" --replace \
-            --annotation "oci.opencontainers.image.base.name=${base_name}" \
-            --annotation "oci.opencontainers.image.base.digest=${base_digest}"
+            --annotation "[*]oci.opencontainers.image.base.name=${base_name}" \
+            --annotation "[*]oci.opencontainers.image.base.digest=${base_digest}"
         fi
         echo "digest=$(regctl image digest ${local_tag})" >>$GITHUB_OUTPUT
 
@@ -168,7 +168,7 @@ jobs:
         for digest in $(regctl manifest get ocidir://output/${{matrix.image}}:${{matrix.type}} \
                         --format '{{range .Manifests}}{{printf "%s\n" .Digest}}{{end}}'); do
           echo "Attaching SBOMs for ${{matrix.image}}@${digest}"
-          regctl image copy ocidir://output/${{matrix.image}}@${digest} ocidir://output/${{matrix.image}}-sbom
+          regctl image copy ocidir://output/${{matrix.image}}@${digest} ocidir://output/${{matrix.image}}-sbom -v warn >/dev/null
           ${{steps.syft.outputs.cmd}} packages -q "oci-dir:output/${{matrix.image}}-sbom" \
               --name "docker:docker.io/regclient/${{matrix.image}}@${digest}" -o cyclonedx-json \
             | regctl artifact put --subject "ocidir://output/${{matrix.image}}@${digest}" \

--- a/cmd/regctl/image.go
+++ b/cmd/regctl/image.go
@@ -227,7 +227,7 @@ func init() {
 			}
 			return nil
 		},
-	}, "annotation", "", `set an annotation (name=value)`)
+	}, "annotation", "", `set an annotation (name=value, omit value to delete, prefix with platform list [p1,p2] or [*] for all images)`)
 	imageModCmd.Flags().VarP(&modFlagFunc{
 		t: "stringArray",
 		f: func(val string) error {

--- a/docs/regctl.md
+++ b/docs/regctl.md
@@ -137,6 +137,7 @@ Available Commands:
   import      import image
   inspect     inspect image
   manifest    show manifest or manifest list
+  mod         modify an image
   ratelimit   show the current rate limit
 ```
 
@@ -163,6 +164,10 @@ This can be useful with image pruning scripts, or other tools that need the imag
 
 The `manifest` command shows the low level layers and digests that can be pulled from the registry to retrieve individual components of an image.
 This is also useful for analyzing multi-platform manifest lists to see what platforms are available for a particular image.
+
+The `mod` command is used to modify existing images.
+This is useful for making changes to an image that aren't available in the build tooling, or to convert images received from an external source.
+Example uses include converting from Docker to OCI media types, adding annotations, adjusting timestamps, and rebasing images.
 
 The `ratelimit` command shows the current rate limit on the manifest API using a http HEAD request that does not count against the Docker Hub limits.
 

--- a/mod/dag.go
+++ b/mod/dag.go
@@ -37,6 +37,7 @@ type dagConfig struct {
 type dagManifest struct {
 	mod       changes
 	top       bool // indicates the top level manifest (needed for manifest lists)
+	origDesc  types.Descriptor
 	newDesc   types.Descriptor
 	m         manifest.Manifest
 	config    *dagOCIConfig
@@ -69,6 +70,7 @@ func dagGet(ctx context.Context, rc *regclient.RegClient, rSrc ref.Ref, d types.
 	if err != nil {
 		return nil, err
 	}
+	dm.origDesc = dm.m.GetDescriptor()
 	if mi, ok := dm.m.(manifest.Indexer); ok {
 		dl, err := mi.GetManifestList()
 		if err != nil {

--- a/mod/mod_test.go
+++ b/mod/mod_test.go
@@ -115,24 +115,21 @@ func TestMod(t *testing.T) {
 				WithManifestToDocker(),
 				WithRefTgt(rTgt1),
 			},
-			ref:      "ocidir://testrepo:v1",
-			wantSame: false,
+			ref: "ocidir://testrepo:v1",
 		},
 		{
 			name: "Docker To OCI",
 			opts: []Opts{
 				WithManifestToOCI(),
 			},
-			ref:      rTgt1.CommonName(),
-			wantSame: false,
+			ref: rTgt1.CommonName(),
 		},
 		{
 			name: "To OCI Referrers",
 			opts: []Opts{
 				WithManifestToOCIReferrers(),
 			},
-			ref:      "ocidir://testrepo:v1",
-			wantSame: false,
+			ref: "ocidir://testrepo:v1",
 		},
 		{
 			name: "Add Annotation",
@@ -142,11 +139,49 @@ func TestMod(t *testing.T) {
 			ref: "ocidir://testrepo:v1",
 		},
 		{
+			name: "Add Annotation All",
+			opts: []Opts{
+				WithAnnotation("[*]test", "hello"),
+			},
+			ref: "ocidir://testrepo:v1",
+		},
+		{
+			name: "Add Annotation AMD64/ARM64",
+			opts: []Opts{
+				WithAnnotation("[linux/amd64,linux/arm64]test", "hello"),
+			},
+			ref: "ocidir://testrepo:v1",
+		},
+		{
+			name: "Add Annotation Missing",
+			opts: []Opts{
+				WithAnnotation("[linux/i386,linux/s390x]test", "hello"),
+			},
+			ref:      "ocidir://testrepo:v1",
+			wantSame: true,
+		},
+		{
+			name: "Add Annotation Platform Parse Error",
+			opts: []Opts{
+				WithAnnotation("[linux/invalid.arch!]test", "hello"),
+			},
+			ref:     "ocidir://testrepo:v1",
+			wantErr: fmt.Errorf("failed to parse annotation platform linux/invalid.arch!: invalid platform component invalid.arch! in linux/invalid.arch!"),
+		},
+		{
 			name: "Delete Annotation",
 			opts: []Opts{
 				WithAnnotation("org.example.version", ""),
 			},
 			ref: "ocidir://testrepo:v1",
+		},
+		{
+			name: "Delete Missing Annotation",
+			opts: []Opts{
+				WithAnnotation("[*]missing", ""),
+			},
+			ref:      "ocidir://testrepo:v1",
+			wantSame: true,
 		},
 		{
 			name: "Add Base Annotations",

--- a/types/manifest/docker2.go
+++ b/types/manifest/docker2.go
@@ -223,7 +223,11 @@ func (m *docker2Manifest) SetAnnotation(key, val string) error {
 	if m.Annotations == nil {
 		m.Annotations = map[string]string{}
 	}
-	m.Annotations[key] = val
+	if val != "" {
+		m.Annotations[key] = val
+	} else {
+		delete(m.Annotations, key)
+	}
 	return m.updateDesc()
 }
 func (m *docker2ManifestList) SetAnnotation(key, val string) error {
@@ -233,7 +237,11 @@ func (m *docker2ManifestList) SetAnnotation(key, val string) error {
 	if m.Annotations == nil {
 		m.Annotations = map[string]string{}
 	}
-	m.Annotations[key] = val
+	if val != "" {
+		m.Annotations[key] = val
+	} else {
+		delete(m.Annotations, key)
+	}
 	return m.updateDesc()
 }
 

--- a/types/manifest/manifest_test.go
+++ b/types/manifest/manifest_test.go
@@ -1407,6 +1407,15 @@ func TestSet(t *testing.T) {
 				if m.GetDescriptor().Digest == prevDig {
 					t.Errorf("digest did not change after setting annotation")
 				}
+				prevDig = m.GetDescriptor().Digest
+				err = ma.SetAnnotation("new annotation", "")
+				if err != nil {
+					t.Errorf("failed removing annotation: %v", err)
+					return
+				}
+				if m.GetDescriptor().Digest == prevDig {
+					t.Errorf("digest did not change after removing annotation")
+				}
 			} else if tt.expectAnnot {
 				t.Errorf("annotation methods not found")
 			}

--- a/types/manifest/oci1.go
+++ b/types/manifest/oci1.go
@@ -359,7 +359,11 @@ func (m *oci1Manifest) SetAnnotation(key, val string) error {
 	if m.Annotations == nil {
 		m.Annotations = map[string]string{}
 	}
-	m.Annotations[key] = val
+	if val != "" {
+		m.Annotations[key] = val
+	} else {
+		delete(m.Annotations, key)
+	}
 	return m.updateDesc()
 }
 func (m *oci1Index) SetAnnotation(key, val string) error {
@@ -369,7 +373,11 @@ func (m *oci1Index) SetAnnotation(key, val string) error {
 	if m.Annotations == nil {
 		m.Annotations = map[string]string{}
 	}
-	m.Annotations[key] = val
+	if val != "" {
+		m.Annotations[key] = val
+	} else {
+		delete(m.Annotations, key)
+	}
 	return m.updateDesc()
 }
 func (m *oci1Artifact) SetAnnotation(key, val string) error {
@@ -379,7 +387,11 @@ func (m *oci1Artifact) SetAnnotation(key, val string) error {
 	if m.Annotations == nil {
 		m.Annotations = map[string]string{}
 	}
-	m.Annotations[key] = val
+	if val != "" {
+		m.Annotations[key] = val
+	} else {
+		delete(m.Annotations, key)
+	}
 	return m.updateDesc()
 }
 


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Platform specific manifests are missing annotations after a regctl image mod.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This adds the ability to configure annotations on individual platforms, all manifests, or only the index, in the multi-platform manifest.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

The reproducible image build has the following example to update all manifests (using `[*]`):

```
regctl image mod \
  "ocidir://output/${image}:${release}" --replace \
  --to-oci-referrers \
  --time-max "${vcs_date}" \
  --annotation "[*]oci.opencontainers.image.created=${vcs_date}" \
  --annotation "[*]oci.opencontainers.image.source=${vcs_repo}" \
  --annotation "[*]oci.opencontainers.image.revision=${vcs_sha}"
```

Individual platforms can be modded using:

```
regctl image mod --annotation "[linux/amd64,linux/arm64]name=value" ...
```

<!-- Include steps that can be taken to verify the change -->

### Changelog text

Support updating annotations on platform specific manifests in a manifest list.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
