### PR TITLE
Fix copy with referrers and digest tags

### DIFF
--- a/image.go
+++ b/image.go
@@ -679,10 +679,15 @@ func (rc *RegClient) imageCopyOpt(ctx context.Context, refSrc ref.Ref, refTgt re
 		for _, tag := range opt.tagList {
 			if strings.HasPrefix(tag, prefix) {
 				// skip referrers that were copied above
+				found := false
 				for _, referrerTag := range referrerTags {
 					if referrerTag == tag {
-						continue
+						found = true
+						break
 					}
+				}
+				if found {
+					continue
 				}
 				refTagSrc := refSrc
 				refTagSrc.Tag = tag


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Copying an image with referrers and digest-tags fails when trying to copy the fallback tag.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Fix the check when copying digest-tags to skip the referrers fallback tag.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```
regctl image copy --referrers --digest-tags ghcr.io/regclient/regctl:edge localhost:5000/regclient/regctl:edge
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Fix copy when both referrers and digest-tags are included.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [ ] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
