### PR TITLE
Cleanup docker image builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -69,12 +69,14 @@ jobs:
             TAGS="${TAGS},${GHCR_IMAGE}:${{ matrix.type }}"
           fi
         fi
-        VCS_DATE="$(date -d "@$(git log -1 --format=%at)" +%Y-%m-%dT%H:%M:%SZ --utc)"
+        VCS_SEC="$(git log -1 --format=%ct)"
+        VCS_DATE="$(date -d "@${VCS_SEC}" +%Y-%m-%dT%H:%M:%SZ --utc)"
         REPO_URL="${{github.server_url}}/${{github.repository}}.git"
         echo "version=${VERSION}" >>$GITHUB_OUTPUT
         echo "image_hub=${HUB_IMAGE}" >>$GITHUB_OUTPUT
         echo "image_ghcr=${GHCR_IMAGE}" >>$GITHUB_OUTPUT
         echo "tags=${TAGS}" >>$GITHUB_OUTPUT
+        echo "vcs_sec=${VCS_SEC}" >>$GITHUB_OUTPUT
         echo "created=${VCS_DATE}" >>$GITHUB_OUTPUT
         echo "repo_url=${REPO_URL}" >>$GITHUB_OUTPUT
 
@@ -105,6 +107,8 @@ jobs:
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/ppc64le,linux/s390x
         target: release-${{ matrix.type }}
         outputs: type=oci,dest=output/${{matrix.image}}-${{matrix.type}}.tar
+        build-args: |
+          SOURCE_DATE_EPOC=${{ steps.prep.outputs.vcs_sec }}
         labels: |
           org.opencontainers.image.created=${{ steps.prep.outputs.created }}
           org.opencontainers.image.source=${{ steps.prep.outputs.repo_url }}

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ VCS_REF?=$(shell git rev-list -1 HEAD)
 ifneq ($(shell git status --porcelain 2>/dev/null),)
   VCS_REF := $(VCS_REF)-dirty
 endif
-VCS_DATE?=$(shell date -d "@$(shell git log -1 --format=%at)" +%Y-%m-%dT%H:%M:%SZ --utc)
 VCS_TAG?=$(shell git describe --tags --abbrev=0 2>/dev/null || true)
 LD_FLAGS?=-s -w -extldflags -static -buildid= -X \"github.com/regclient/regclient/internal/version.vcsTag=$(VCS_TAG)\"
 GO_BUILD_FLAGS?=-trimpath -ldflags "$(LD_FLAGS)" -tags nolegacy
@@ -97,6 +96,7 @@ artifact-pre:
 	mkdir -p artifacts
 
 artifacts/%: artifact-pre .FORCE
+	set -e; \
 	@target="$*"; \
 	command="$${target%%-*}"; \
 	platform_ext="$${target#*-}"; \

--- a/build/Dockerfile.regbot
+++ b/build/Dockerfile.regbot
@@ -2,7 +2,7 @@ ARG REGISTRY=docker.io
 ARG ALPINE_VER=3@sha256:02bb6f428431fbc2809c5d1b41eab5a68350194fb508869a33cb1af4444c9b11
 ARG GO_VER=1.20-alpine@sha256:b036c52b3bcc8e4e31be19a7a902bb9897b2bf18028f40fd306a9778bab5771c
 ARG ECR_HELPER_VER=7f2db5bd753edc4c799d8b932941d8871a70d130
-ARG GCR_HELPER_VER=v2.1.8
+ARG GCR_HELPER_VER=v2.1.10
 ARG LUNAJSON_COMMIT=e6063d37de97dfdfe2749e24de949472bfad0945
 ARG SEMVER_COMMIT=af495adc857d51fd1507a112be18523828a1da0d
 
@@ -16,13 +16,11 @@ RUN adduser -D appuser \
  && chown -R appuser /home/appuser
 WORKDIR /src
 
-FROM golang as dev
+FROM golang as build
+COPY Makefile go.mod go.sum /src/
+RUN make vendor
 COPY . /src/
-ENV PATH=${PATH}:/src/bin
-CMD make bin/regbot && bin/regbot
-
-FROM dev as build
-RUN make vendor bin/regbot
+RUN make bin/regbot
 USER appuser
 CMD [ "/src/bin/regbot" ]
 
@@ -38,22 +36,18 @@ FROM golang as docker-cred-gcr
 ARG TARGETOS
 ARG TARGETARCH
 ARG GCR_HELPER_VER
-# TODO: remove workaround, pending issue https://github.com/GoogleCloudPlatform/docker-credential-gcr/issues/128
-RUN git clone https://github.com/GoogleCloudPlatform/docker-credential-gcr.git -b ${GCR_HELPER_VER} --depth 1
-WORKDIR ./docker-credential-gcr
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=0 \
-    go build -trimpath -ldflags="-buildid= -s -w -X github.com/GoogleCloudPlatform/docker-credential-gcr/config.Version=${GCR_HELPER_VER#v}" . \
- && cp docker-credential-gcr /usr/local/bin/docker-credential-gcr
-# RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=0 \
-#     go install -trimpath -ldflags=-buildid= github.com/GoogleCloudPlatform/docker-credential-gcr@${GCR_HELPER_VER} \
-#  && ( cp "${GOPATH}/bin/docker-credential-gcr" /usr/local/bin/docker-credential-gcr \
-#    || cp "${GOPATH}/bin/${TARGETOS}_${TARGETARCH}/docker-credential-gcr" /usr/local/bin/docker-credential-gcr )
+    go install -trimpath -ldflags="-buildid= -s -w" \
+      github.com/GoogleCloudPlatform/docker-credential-gcr/v2@${GCR_HELPER_VER} \
+ && ( cp "${GOPATH}/bin/docker-credential-gcr" /usr/local/bin/docker-credential-gcr \
+   || cp "${GOPATH}/bin/${TARGETOS}_${TARGETARCH}/docker-credential-gcr" /usr/local/bin/docker-credential-gcr )
 
 FROM ${REGISTRY}/library/alpine:${ALPINE_VER} as lua-mods
 # COPY may pull in old timestamps, use a touch command below to reset them
 COPY cmd/regbot/lua/ /lua/
 ARG LUNAJSON_COMMIT
 ARG SEMVER_COMMIT
+ARG SOURCE_DATE_EPOCH
 RUN apk add curl \
  && mkdir -p /lua/lunajson \
  && curl -fL https://raw.githubusercontent.com/grafi-tt/lunajson/${LUNAJSON_COMMIT}/src/lunajson.lua > /lua/lunajson.lua \
@@ -63,7 +57,7 @@ RUN apk add curl \
  && curl -fL https://raw.githubusercontent.com/kikito/semver.lua/${SEMVER_COMMIT}/semver.lua > /lua/semver.lua \
  && cd /lua \
  && ln -s lunajson.lua json.lua \
- && find . -exec touch '{}' \;
+ && SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH}:-$(date +%s)}" find . -exec touch --date="@${SOURCE_DATE_EPOCH}" '{}' \;
 
 FROM ${REGISTRY}/library/alpine:${ALPINE_VER} as release-alpine
 COPY --from=build /etc/passwd /etc/group /etc/

--- a/build/Dockerfile.regbot.buildkit
+++ b/build/Dockerfile.regbot.buildkit
@@ -4,7 +4,7 @@ ARG REGISTRY=docker.io
 ARG ALPINE_VER=3@sha256:02bb6f428431fbc2809c5d1b41eab5a68350194fb508869a33cb1af4444c9b11
 ARG GO_VER=1.20-alpine@sha256:b036c52b3bcc8e4e31be19a7a902bb9897b2bf18028f40fd306a9778bab5771c
 ARG ECR_HELPER_VER=7f2db5bd753edc4c799d8b932941d8871a70d130
-ARG GCR_HELPER_VER=v2.1.8
+ARG GCR_HELPER_VER=v2.1.10
 ARG LUNAJSON_COMMIT=e6063d37de97dfdfe2749e24de949472bfad0945
 ARG SEMVER_COMMIT=af495adc857d51fd1507a112be18523828a1da0d
 
@@ -19,18 +19,19 @@ RUN addgroup -g 1000 appuser \
  && chown -R appuser /home/appuser
 WORKDIR /src
 
-FROM --platform=$BUILDPLATFORM golang as dev
-COPY . /src/
-ENV PATH=${PATH}:/src/bin
-CMD make bin/regbot && bin/regbot
-
-FROM --platform=$BUILDPLATFORM dev as build
+FROM --platform=$BUILDPLATFORM golang as build
+COPY Makefile go.mod go.sum /src/
 ARG TARGETOS
 ARG TARGETARCH
 RUN --mount=type=cache,id=gomod,target=/go/pkg/mod/cache \
     --mount=type=cache,id=goroot,target=/root/.cache/go-build \
     GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
-    make vendor bin/regbot
+    make vendor
+COPY . /src/
+RUN --mount=type=cache,id=gomod,target=/go/pkg/mod/cache \
+    --mount=type=cache,id=goroot,target=/root/.cache/go-build \
+    GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+    make bin/regbot
 USER appuser
 CMD [ "bin/regbot" ]
 
@@ -52,26 +53,20 @@ FROM --platform=$BUILDPLATFORM golang as docker-cred-gcr
 ARG TARGETOS
 ARG TARGETARCH
 ARG GCR_HELPER_VER
-# TODO: remove workaround, pending issue https://github.com/GoogleCloudPlatform/docker-credential-gcr/issues/128
-RUN git clone https://github.com/GoogleCloudPlatform/docker-credential-gcr.git -b ${GCR_HELPER_VER} --depth 1
-WORKDIR ./docker-credential-gcr
 RUN --mount=type=cache,id=gomod,target=/go/pkg/mod/cache \
     --mount=type=cache,id=goroot,target=/root/.cache/go-build \
     GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=0 \
-    go build -trimpath -ldflags="-buildid= -s -w -X github.com/GoogleCloudPlatform/docker-credential-gcr/config.Version=${GCR_HELPER_VER#v}" . \
- && cp docker-credential-gcr /usr/local/bin/docker-credential-gcr
-# RUN --mount=type=cache,id=gomod,target=/go/pkg/mod/cache \
-#     --mount=type=cache,id=goroot,target=/root/.cache/go-build \
-#     GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=0 \
-#     go install -trimpath -ldflags=-buildid= github.com/GoogleCloudPlatform/docker-credential-gcr@${GCR_HELPER_VER} \
-#  && ( cp "${GOPATH}/bin/docker-credential-gcr" /usr/local/bin/docker-credential-gcr \
-#    || cp "${GOPATH}/bin/${TARGETOS}_${TARGETARCH}/docker-credential-gcr" /usr/local/bin/docker-credential-gcr )
+    go install -trimpath -ldflags="-buildid= -s -w" \
+      github.com/GoogleCloudPlatform/docker-credential-gcr/v2@${GCR_HELPER_VER} \
+ && ( cp "${GOPATH}/bin/docker-credential-gcr" /usr/local/bin/docker-credential-gcr \
+   || cp "${GOPATH}/bin/${TARGETOS}_${TARGETARCH}/docker-credential-gcr" /usr/local/bin/docker-credential-gcr )
 
 FROM --platform=$BUILDPLATFORM ${REGISTRY}/library/alpine:${ALPINE_VER} as lua-mods
 # COPY may pull in old timestamps, use a touch command below to reset them
 COPY cmd/regbot/lua/ /lua/
 ARG LUNAJSON_COMMIT
 ARG SEMVER_COMMIT
+ARG SOURCE_DATE_EPOCH
 RUN apk add curl \
  && mkdir -p /lua/lunajson \
  && curl -fL https://raw.githubusercontent.com/grafi-tt/lunajson/${LUNAJSON_COMMIT}/src/lunajson.lua > /lua/lunajson.lua \
@@ -81,7 +76,7 @@ RUN apk add curl \
  && curl -fL https://raw.githubusercontent.com/kikito/semver.lua/${SEMVER_COMMIT}/semver.lua > /lua/semver.lua \
  && cd /lua \
  && ln -s lunajson.lua json.lua \
- && find . -exec touch '{}' \;
+ && SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH}:-$(date +%s)}" find . -exec touch --date="@${SOURCE_DATE_EPOCH}" '{}' \;
 
 FROM ${REGISTRY}/library/alpine:${ALPINE_VER} as release-alpine
 COPY --from=build /etc/passwd /etc/group /etc/

--- a/build/Dockerfile.regctl
+++ b/build/Dockerfile.regctl
@@ -2,7 +2,7 @@ ARG REGISTRY=docker.io
 ARG ALPINE_VER=3@sha256:02bb6f428431fbc2809c5d1b41eab5a68350194fb508869a33cb1af4444c9b11
 ARG GO_VER=1.20-alpine@sha256:b036c52b3bcc8e4e31be19a7a902bb9897b2bf18028f40fd306a9778bab5771c
 ARG ECR_HELPER_VER=7f2db5bd753edc4c799d8b932941d8871a70d130
-ARG GCR_HELPER_VER=v2.1.8
+ARG GCR_HELPER_VER=v2.1.10
 
 FROM ${REGISTRY}/library/golang:${GO_VER} as golang
 RUN apk add --no-cache \
@@ -14,13 +14,11 @@ RUN adduser -D appuser \
  && chown -R appuser /home/appuser/.regctl
 WORKDIR /src
 
-FROM golang as dev
+FROM golang as build
+COPY Makefile go.mod go.sum /src/
+RUN make vendor
 COPY . /src/
-ENV PATH=${PATH}:/src/bin
-CMD make bin/regctl && bin/regctl
-
-FROM dev as build
-RUN make vendor bin/regctl
+RUN make bin/regctl
 USER appuser
 CMD [ "bin/regctl" ]
 
@@ -36,16 +34,11 @@ FROM golang as docker-cred-gcr
 ARG TARGETOS
 ARG TARGETARCH
 ARG GCR_HELPER_VER
-# TODO: remove workaround, pending issue https://github.com/GoogleCloudPlatform/docker-credential-gcr/issues/128
-RUN git clone https://github.com/GoogleCloudPlatform/docker-credential-gcr.git -b ${GCR_HELPER_VER} --depth 1
-WORKDIR ./docker-credential-gcr
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=0 \
-    go build -trimpath -ldflags="-buildid= -s -w -X github.com/GoogleCloudPlatform/docker-credential-gcr/config.Version=${GCR_HELPER_VER#v}" . \
- && cp docker-credential-gcr /usr/local/bin/docker-credential-gcr
-# RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=0 \
-#     go install -trimpath -ldflags=-buildid= github.com/GoogleCloudPlatform/docker-credential-gcr@${GCR_HELPER_VER} \
-#  && ( cp "${GOPATH}/bin/docker-credential-gcr" /usr/local/bin/docker-credential-gcr \
-#    || cp "${GOPATH}/bin/${TARGETOS}_${TARGETARCH}/docker-credential-gcr" /usr/local/bin/docker-credential-gcr )
+    go install -trimpath -ldflags="-buildid= -s -w" \
+      github.com/GoogleCloudPlatform/docker-credential-gcr/v2@${GCR_HELPER_VER} \
+ && ( cp "${GOPATH}/bin/docker-credential-gcr" /usr/local/bin/docker-credential-gcr \
+   || cp "${GOPATH}/bin/${TARGETOS}_${TARGETARCH}/docker-credential-gcr" /usr/local/bin/docker-credential-gcr )
 
 FROM ${REGISTRY}/library/alpine:${ALPINE_VER} as release-alpine
 COPY --from=build /etc/passwd /etc/group /etc/

--- a/build/Dockerfile.regctl.buildkit
+++ b/build/Dockerfile.regctl.buildkit
@@ -4,7 +4,7 @@ ARG REGISTRY=docker.io
 ARG ALPINE_VER=3@sha256:02bb6f428431fbc2809c5d1b41eab5a68350194fb508869a33cb1af4444c9b11
 ARG GO_VER=1.20-alpine@sha256:b036c52b3bcc8e4e31be19a7a902bb9897b2bf18028f40fd306a9778bab5771c
 ARG ECR_HELPER_VER=7f2db5bd753edc4c799d8b932941d8871a70d130
-ARG GCR_HELPER_VER=v2.1.8
+ARG GCR_HELPER_VER=v2.1.10
 
 FROM --platform=$BUILDPLATFORM ${REGISTRY}/library/golang:${GO_VER} as golang
 RUN apk add --no-cache \
@@ -17,18 +17,19 @@ RUN addgroup -g 1000 appuser \
  && chown -R appuser /home/appuser/.regctl
 WORKDIR /src
 
-FROM --platform=$BUILDPLATFORM golang as dev
-COPY . /src/
-ENV PATH=${PATH}:/src/bin
-CMD make bin/regctl && bin/regctl
-
-FROM --platform=$BUILDPLATFORM dev as build
+FROM --platform=$BUILDPLATFORM golang as build
+COPY Makefile go.mod go.sum /src/
 ARG TARGETOS
 ARG TARGETARCH
 RUN --mount=type=cache,id=gomod,target=/go/pkg/mod/cache \
     --mount=type=cache,id=goroot,target=/root/.cache/go-build \
     GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
-    make vendor bin/regctl
+    make vendor
+COPY . /src/
+RUN --mount=type=cache,id=gomod,target=/go/pkg/mod/cache \
+    --mount=type=cache,id=goroot,target=/root/.cache/go-build \
+    GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+    make bin/regctl
 USER appuser
 CMD [ "bin/regctl" ]
 
@@ -50,20 +51,13 @@ FROM --platform=$BUILDPLATFORM golang as docker-cred-gcr
 ARG TARGETOS
 ARG TARGETARCH
 ARG GCR_HELPER_VER
-# TODO: remove workaround, pending issue https://github.com/GoogleCloudPlatform/docker-credential-gcr/issues/128
-RUN git clone https://github.com/GoogleCloudPlatform/docker-credential-gcr.git -b ${GCR_HELPER_VER} --depth 1
-WORKDIR ./docker-credential-gcr
 RUN --mount=type=cache,id=gomod,target=/go/pkg/mod/cache \
     --mount=type=cache,id=goroot,target=/root/.cache/go-build \
     GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=0 \
-    go build -trimpath -ldflags="-buildid= -s -w -X github.com/GoogleCloudPlatform/docker-credential-gcr/config.Version=${GCR_HELPER_VER#v}" . \
- && cp docker-credential-gcr /usr/local/bin/docker-credential-gcr
-# RUN --mount=type=cache,id=gomod,target=/go/pkg/mod/cache \
-#     --mount=type=cache,id=goroot,target=/root/.cache/go-build \
-#     GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=0 \
-#     go install -trimpath -ldflags=-buildid= github.com/GoogleCloudPlatform/docker-credential-gcr@${GCR_HELPER_VER} \
-#  && ( cp "${GOPATH}/bin/docker-credential-gcr" /usr/local/bin/docker-credential-gcr \
-#    || cp "${GOPATH}/bin/${TARGETOS}_${TARGETARCH}/docker-credential-gcr" /usr/local/bin/docker-credential-gcr )
+    go install -trimpath -ldflags="-buildid= -s -w" \
+      github.com/GoogleCloudPlatform/docker-credential-gcr/v2@${GCR_HELPER_VER} \
+ && ( cp "${GOPATH}/bin/docker-credential-gcr" /usr/local/bin/docker-credential-gcr \
+   || cp "${GOPATH}/bin/${TARGETOS}_${TARGETARCH}/docker-credential-gcr" /usr/local/bin/docker-credential-gcr )
 
 FROM ${REGISTRY}/library/alpine:${ALPINE_VER} as release-alpine
 COPY --from=build /etc/passwd /etc/group /etc/

--- a/build/Dockerfile.regsync
+++ b/build/Dockerfile.regsync
@@ -2,7 +2,7 @@ ARG REGISTRY=docker.io
 ARG ALPINE_VER=3@sha256:02bb6f428431fbc2809c5d1b41eab5a68350194fb508869a33cb1af4444c9b11
 ARG GO_VER=1.20-alpine@sha256:b036c52b3bcc8e4e31be19a7a902bb9897b2bf18028f40fd306a9778bab5771c
 ARG ECR_HELPER_VER=7f2db5bd753edc4c799d8b932941d8871a70d130
-ARG GCR_HELPER_VER=v2.1.8
+ARG GCR_HELPER_VER=v2.1.10
 
 FROM ${REGISTRY}/library/golang:${GO_VER} as golang
 RUN apk add --no-cache \
@@ -14,14 +14,11 @@ RUN adduser -D appuser \
  && chown -R appuser /home/appuser
 WORKDIR /src
 
-FROM golang as dev
+FROM golang as build
+COPY Makefile go.mod go.sum /src/
+RUN make vendor
 COPY . /src/
-ENV PATH=${PATH}:/src/bin
-CMD make bin/regsync && bin/regsync
-
-FROM dev as build
-ARG LD_FLAGS
-RUN make vendor bin/regsync
+RUN make bin/regsync
 USER appuser
 CMD [ "bin/regsync" ]
 
@@ -37,16 +34,11 @@ FROM golang as docker-cred-gcr
 ARG TARGETOS
 ARG TARGETARCH
 ARG GCR_HELPER_VER
-# TODO: remove workaround, pending issue https://github.com/GoogleCloudPlatform/docker-credential-gcr/issues/128
-RUN git clone https://github.com/GoogleCloudPlatform/docker-credential-gcr.git -b ${GCR_HELPER_VER} --depth 1
-WORKDIR ./docker-credential-gcr
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=0 \
-    go build -trimpath -ldflags="-buildid= -s -w -X github.com/GoogleCloudPlatform/docker-credential-gcr/config.Version=${GCR_HELPER_VER#v}" . \
- && cp docker-credential-gcr /usr/local/bin/docker-credential-gcr
-# RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=0 \
-#     go install -trimpath -ldflags=-buildid= github.com/GoogleCloudPlatform/docker-credential-gcr@${GCR_HELPER_VER} \
-#  && ( cp "${GOPATH}/bin/docker-credential-gcr" /usr/local/bin/docker-credential-gcr \
-#    || cp "${GOPATH}/bin/${TARGETOS}_${TARGETARCH}/docker-credential-gcr" /usr/local/bin/docker-credential-gcr )
+    go install -trimpath -ldflags="-buildid= -s -w" \
+      github.com/GoogleCloudPlatform/docker-credential-gcr/v2@${GCR_HELPER_VER} \
+ && ( cp "${GOPATH}/bin/docker-credential-gcr" /usr/local/bin/docker-credential-gcr \
+   || cp "${GOPATH}/bin/${TARGETOS}_${TARGETARCH}/docker-credential-gcr" /usr/local/bin/docker-credential-gcr )
 
 FROM ${REGISTRY}/library/alpine:${ALPINE_VER} as release-alpine
 COPY --from=build /etc/passwd /etc/group /etc/

--- a/build/Dockerfile.regsync.buildkit
+++ b/build/Dockerfile.regsync.buildkit
@@ -4,7 +4,7 @@ ARG REGISTRY=docker.io
 ARG ALPINE_VER=3@sha256:02bb6f428431fbc2809c5d1b41eab5a68350194fb508869a33cb1af4444c9b11
 ARG GO_VER=1.20-alpine@sha256:b036c52b3bcc8e4e31be19a7a902bb9897b2bf18028f40fd306a9778bab5771c
 ARG ECR_HELPER_VER=7f2db5bd753edc4c799d8b932941d8871a70d130
-ARG GCR_HELPER_VER=v2.1.8
+ARG GCR_HELPER_VER=v2.1.10
 
 FROM --platform=$BUILDPLATFORM ${REGISTRY}/library/golang:${GO_VER} as golang
 RUN apk add --no-cache \
@@ -17,18 +17,19 @@ RUN addgroup -g 1000 appuser \
  && chown -R appuser /home/appuser
 WORKDIR /src
 
-FROM --platform=$BUILDPLATFORM golang as dev
-COPY . /src/
-ENV PATH=${PATH}:/src/bin
-CMD make bin/regsync && bin/regsync
-
-FROM --platform=$BUILDPLATFORM dev as build
+FROM --platform=$BUILDPLATFORM golang as build
+COPY Makefile go.mod go.sum /src/
 ARG TARGETOS
 ARG TARGETARCH
 RUN --mount=type=cache,id=gomod,target=/go/pkg/mod/cache \
     --mount=type=cache,id=goroot,target=/root/.cache/go-build \
     GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
-    make vendor bin/regsync
+    make vendor
+COPY . /src/
+RUN --mount=type=cache,id=gomod,target=/go/pkg/mod/cache \
+    --mount=type=cache,id=goroot,target=/root/.cache/go-build \
+    GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+    make bin/regsync
 USER appuser
 CMD [ "bin/regsync" ]
 
@@ -50,20 +51,13 @@ FROM --platform=$BUILDPLATFORM golang as docker-cred-gcr
 ARG TARGETOS
 ARG TARGETARCH
 ARG GCR_HELPER_VER
-# TODO: remove workaround, pending issue https://github.com/GoogleCloudPlatform/docker-credential-gcr/issues/128
-RUN git clone https://github.com/GoogleCloudPlatform/docker-credential-gcr.git -b ${GCR_HELPER_VER} --depth 1
-WORKDIR ./docker-credential-gcr
 RUN --mount=type=cache,id=gomod,target=/go/pkg/mod/cache \
     --mount=type=cache,id=goroot,target=/root/.cache/go-build \
     GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=0 \
-    go build -trimpath -ldflags="-buildid= -s -w -X github.com/GoogleCloudPlatform/docker-credential-gcr/config.Version=${GCR_HELPER_VER#v}" . \
- && cp docker-credential-gcr /usr/local/bin/docker-credential-gcr
-# RUN --mount=type=cache,id=gomod,target=/go/pkg/mod/cache \
-#     --mount=type=cache,id=goroot,target=/root/.cache/go-build \
-#     GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=0 \
-#     go install -trimpath -ldflags=-buildid= github.com/GoogleCloudPlatform/docker-credential-gcr@${GCR_HELPER_VER} \
-#  && ( cp "${GOPATH}/bin/docker-credential-gcr" /usr/local/bin/docker-credential-gcr \
-#    || cp "${GOPATH}/bin/${TARGETOS}_${TARGETARCH}/docker-credential-gcr" /usr/local/bin/docker-credential-gcr )
+    go install -trimpath -ldflags="-buildid= -s -w" \
+      github.com/GoogleCloudPlatform/docker-credential-gcr/v2@${GCR_HELPER_VER} \
+ && ( cp "${GOPATH}/bin/docker-credential-gcr" /usr/local/bin/docker-credential-gcr \
+   || cp "${GOPATH}/bin/${TARGETOS}_${TARGETARCH}/docker-credential-gcr" /usr/local/bin/docker-credential-gcr )
 
 FROM ${REGISTRY}/library/alpine:${ALPINE_VER} as release-alpine
 COPY --from=build /etc/passwd /etc/group /etc/


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This leverages the `SOURCE_DATE_EPOCH` build arg that's now being supported by buildkit, removing some of the variability in the builds. It also removes the "dev" build stage to simplify the Dockerfiles. To speed up the builds, vendoring is run separate before the compile so that it's cached more often.

This also removes the temporary workaround from GCR credential helper install.

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

No user visible changes.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Use `SOURCE_DATE_EPOCH` build arg support in buildkit.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
