### PR TITLE
Rework the loop detection/handling

### DIFF
--- a/types/error.go
+++ b/types/error.go
@@ -29,6 +29,8 @@ var (
 	ErrInvalidChallenge = errors.New("invalid challenge header")
 	// ErrInvalidReference indicates the reference to an image is has an invalid synax
 	ErrInvalidReference = errors.New("invalid reference")
+	// ErrLoopDetected indicates a child node points back to the parent
+	ErrLoopDetected = errors.New("loop detected")
 	// ErrManifestNotSet indicates the manifest is not set, it must be pulled with a ManifestGet first
 	ErrManifestNotSet = errors.New("manifest not set")
 	// ErrMissingAnnotation returned when a needed annotation is not found


### PR DESCRIPTION

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

The level check from before would return before the manifest was copied. This would break on registries that validate the manifest content already exists (most registries).
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This looks for loops in direct parents, and if encountered, it switches to copy the referrers and digest tags after the manifest is pushed. The manifest wait group is being removed to reduce complexity and remove deadlock issues.

I'm looking at adding a priority queue alternative to the simple throttle that would make it more likely for all manifests to be queries before blob pulls so the interactive UX shows MB remaining with the total value sooner.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```
regctl image copy --digest-tags ghcr.io/sudo-bmitch/oci-sandbox:loop localhost:5001/oci-sandbox:loop
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Fix handling of copy with looping referrers or digest-tags to validating registries
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
