### PR TITLE
Add artifact support to OCI Index

### DIFF
--- a/types/manifest/manifest_test.go
+++ b/types/manifest/manifest_test.go
@@ -516,6 +516,44 @@ func TestNew(t *testing.T) {
 			hasSubject:  true,
 		},
 		{
+			name: "OCI 1 Manifest",
+			opts: []Opts{
+				WithRef(r),
+				WithRaw(rawOCIImage),
+			},
+			wantR: r,
+			wantDesc: types.Descriptor{
+				MediaType: types.MediaTypeOCI1Manifest,
+				Size:      int64(len(rawOCIImage)),
+				Digest:    digestOCIImage,
+			},
+			wantE:       nil,
+			isSet:       true,
+			testAnnot:   true,
+			testSubject: true,
+			hasAnnot:    true,
+			hasSubject:  true,
+		},
+		{
+			name: "OCI 1 Manifest List",
+			opts: []Opts{
+				WithRef(r),
+				WithRaw(rawOCIIndex),
+			},
+			wantR: r,
+			wantDesc: types.Descriptor{
+				MediaType: types.MediaTypeOCI1ManifestList,
+				Size:      int64(len(rawOCIIndex)),
+				Digest:    digestOCIIndex,
+			},
+			wantE:       nil,
+			isSet:       true,
+			testAnnot:   true,
+			testSubject: true,
+			hasAnnot:    true,
+			hasSubject:  true,
+		},
+		{
 			name: "Header Request Docker 2 Manifest",
 			opts: []Opts{
 				WithRef(r),

--- a/types/manifest/oci1.go
+++ b/types/manifest/oci1.go
@@ -171,6 +171,12 @@ func (m *oci1Manifest) GetSubject() (*types.Descriptor, error) {
 	}
 	return m.Manifest.Subject, nil
 }
+func (m *oci1Index) GetSubject() (*types.Descriptor, error) {
+	if !m.manifSet {
+		return nil, types.ErrManifestNotSet
+	}
+	return m.Index.Subject, nil
+}
 func (m *oci1Artifact) GetSubject() (*types.Descriptor, error) {
 	if !m.manifSet {
 		return nil, types.ErrManifestNotSet
@@ -272,6 +278,9 @@ func (m *oci1Index) MarshalPretty() ([]byte, error) {
 		fmt.Fprintf(tw, "Name:\t%s\n", m.r.Reference)
 	}
 	fmt.Fprintf(tw, "MediaType:\t%s\n", m.desc.MediaType)
+	if m.ArtifactType != "" {
+		fmt.Fprintf(tw, "ArtifactType:\t%s\n", m.ArtifactType)
+	}
 	fmt.Fprintf(tw, "Digest:\t%s\n", m.desc.Digest.String())
 	if m.Annotations != nil && len(m.Annotations) > 0 {
 		fmt.Fprintf(tw, "Annotations:\t\n")
@@ -295,6 +304,14 @@ func (m *oci1Index) MarshalPretty() ([]byte, error) {
 			fmt.Fprintf(tw, "  Name:\t%s\n", dRef.CommonName())
 		}
 		err := d.MarshalPrettyTW(tw, "  ")
+		if err != nil {
+			return []byte{}, err
+		}
+	}
+	if m.Subject != nil {
+		fmt.Fprintf(tw, "\t\n")
+		fmt.Fprintf(tw, "Subject:\t\n")
+		err := m.Subject.MarshalPrettyTW(tw, "  ")
 		if err != nil {
 			return []byte{}, err
 		}
@@ -473,6 +490,13 @@ func (m *oci1Manifest) SetSubject(d *types.Descriptor) error {
 		return types.ErrManifestNotSet
 	}
 	m.Manifest.Subject = d
+	return m.updateDesc()
+}
+func (m *oci1Index) SetSubject(d *types.Descriptor) error {
+	if !m.manifSet {
+		return types.ErrManifestNotSet
+	}
+	m.Index.Subject = d
 	return m.updateDesc()
 }
 

--- a/types/oci/v1/index.go
+++ b/types/oci/v1/index.go
@@ -18,8 +18,14 @@ type Index struct {
 	// MediaType specifies the type of this document data structure e.g. `application/vnd.oci.image.index.v1+json`
 	MediaType string `json:"mediaType,omitempty"`
 
+	// ArtifactType specifies the IANA media type of artifact when the manifest is used for an artifact.
+	ArtifactType string `json:"artifactType,omitempty"`
+
 	// Manifests references platform specific manifests.
 	Manifests []types.Descriptor `json:"manifests"`
+
+	// Subject is an optional link from the image manifest to another manifest forming an association between the image manifest and the other manifest.
+	Subject *types.Descriptor `json:"subject,omitempty"`
 
 	// Annotations contains arbitrary metadata for the image index.
 	Annotations map[string]string `json:"annotations,omitempty"`

--- a/types/referrer/referrer.go
+++ b/types/referrer/referrer.go
@@ -48,6 +48,9 @@ func (rl *ReferrerList) Add(m manifest.Manifest) error {
 		} else {
 			mDesc.ArtifactType = mOrig.Config.MediaType
 		}
+	case v1.Index:
+		mDesc.Annotations = mOrig.Annotations
+		mDesc.ArtifactType = mOrig.ArtifactType
 	default:
 		// other types are not supported
 		return fmt.Errorf("invalid manifest for referrer \"%t\": %w", m.GetOrig(), types.ErrUnsupportedMediaType)

--- a/types/referrer/referrer_test.go
+++ b/types/referrer/referrer_test.go
@@ -67,6 +67,7 @@ const bOCIIndex = `
 {
   "schemaVersion": 2,
   "mediaType": "application/vnd.oci.image.index.v1+json",
+	"artifactType": "application/vnd.example.data",
   "manifests": [
     {
       "mediaType": "application/vnd.oci.image.manifest.v1+json",
@@ -86,7 +87,16 @@ const bOCIIndex = `
         "os": "linux"
       }
     }
-	]
+	],
+	"annotations": {
+		"com.example.instance": "test",
+		"com.example.version": "1.0"
+	},
+  "subject": {
+    "mediaType": "application/vnd.oci.image.manifest.v1+json",
+    "size": 1024,
+    "digest": "sha256:81b44ad77a83506e00079bfb7df04240df39d8da45891018b2e5e00d5d69aff3"
+  }
 }
 `
 
@@ -118,9 +128,19 @@ var dOCIImg = types.Descriptor{
 }
 var dOCIImgAT = types.Descriptor{
 	MediaType:    "application/vnd.oci.image.manifest.v1+json",
-	ArtifactType: "application/vnd.example.config.v1+json",
+	ArtifactType: "application/vnd.example.data",
 	Size:         int64(len(bOCIImgAT)),
 	Digest:       digest.FromString(bOCIImgAT),
+	Annotations: map[string]string{
+		"com.example.instance": "test",
+		"com.example.version":  "1.0",
+	},
+}
+var dOCIIndex = types.Descriptor{
+	MediaType:    "application/vnd.oci.image.index.v1+json",
+	ArtifactType: "application/vnd.example.data",
+	Size:         int64(len(bOCIIndex)),
+	Digest:       digest.FromString(bOCIIndex),
 	Annotations: map[string]string{
 		"com.example.instance": "test",
 		"com.example.version":  "1.0",
@@ -170,6 +190,7 @@ func TestEmpty(t *testing.T) {
 		Descriptors: []types.Descriptor{
 			dOCIImg,
 			dOCIImgAT,
+			dOCIIndex,
 		},
 		Annotations: map[string]string{},
 		Tags:        []string{},
@@ -180,6 +201,7 @@ func TestEmpty(t *testing.T) {
 		Manifests: []types.Descriptor{
 			dOCIImg,
 			dOCIImgAT,
+			dOCIIndex,
 		},
 	}))
 	if err != nil {
@@ -210,9 +232,8 @@ func TestAdd(t *testing.T) {
 			m:    mOCIImg,
 		},
 		{
-			name:        "OCI Index",
-			m:           mOCIIndex,
-			expectedErr: types.ErrUnsupportedMediaType,
+			name: "OCI Index",
+			m:    mOCIIndex,
 		},
 		{
 			name:        "Docker Image",
@@ -250,9 +271,9 @@ func TestAdd(t *testing.T) {
 			}
 		})
 	}
-	// 3 success - 1 dup
-	if len(rl.Descriptors) != 2 {
-		t.Errorf("number of descriptors, expected 2, received %d", len(rl.Descriptors))
+	// 4 success - 1 dup
+	if len(rl.Descriptors) != 3 {
+		t.Errorf("number of descriptors, expected 3, received %d", len(rl.Descriptors))
 	}
 	for _, d := range rl.Descriptors {
 		if d.ArtifactType == types.MediaTypeOCI1Empty || d.ArtifactType == "" {
@@ -276,6 +297,7 @@ func TestDelete(t *testing.T) {
 		Manifests: []types.Descriptor{
 			dOCIImg,
 			dOCIImgAT,
+			dOCIIndex,
 		},
 	}))
 	if err != nil {
@@ -302,9 +324,8 @@ func TestDelete(t *testing.T) {
 			expectedErr: types.ErrNotFound,
 		},
 		{
-			name:        "OCI Index",
-			m:           mOCIIndex,
-			expectedErr: types.ErrNotFound,
+			name: "OCI Index",
+			m:    mOCIIndex,
 		},
 		{
 			name:        "Docker Image",


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

OCI Index needs to support artifactType and subject.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

OCI has added these features recently, so they now need to be supported here:

- https://github.com/opencontainers/image-spec/pull/1020
- https://github.com/opencontainers/image-spec/pull/1066
- https://github.com/opencontainers/image-spec/pull/1077

This updates the subject support to align with the Image manifest, and updates the pretty printer. Some of the tests were already being done by the loop test.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```
regctl manifest get ghcr.io/sudo-bmitch/oci-sandbox:loop
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Support artifactType and subject fields on OCI Index
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
