### PR TITLE
Add option to import a specific image or tag name

### DIFF
--- a/cmd/regctl/image.go
+++ b/cmd/regctl/image.go
@@ -154,6 +154,7 @@ var imageOpts struct {
 	forceRecursive  bool
 	format          string
 	formatFile      string
+	importName      string
 	includeExternal bool
 	digestTags      bool
 	list            bool
@@ -197,6 +198,8 @@ func init() {
 
 	imageExportCmd.Flags().StringVar(&imageOpts.exportRef, "name", "", "Name of image to embed for docker load")
 	imageExportCmd.Flags().StringVarP(&imageOpts.platform, "platform", "p", "", "Specify platform (e.g. linux/amd64 or local)")
+
+	imageImportCmd.Flags().StringVar(&imageOpts.importName, "name", "", "Name of image or tag to import when multiple images are packaged in the tar")
 
 	imageInspectCmd.Flags().StringVarP(&imageOpts.platform, "platform", "p", "", "Specify platform (e.g. linux/amd64 or local)")
 	imageInspectCmd.Flags().StringVarP(&imageOpts.format, "format", "", "{{printPretty .}}", "Format output with go template syntax")
@@ -981,6 +984,10 @@ func runImageImport(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	opts := []regclient.ImageOpts{}
+	if imageOpts.importName != "" {
+		opts = append(opts, regclient.ImageWithImportName(imageOpts.importName))
+	}
 	rs, err := os.Open(args[1])
 	if err != nil {
 		return err
@@ -993,7 +1000,7 @@ func runImageImport(cmd *cobra.Command, args []string) error {
 		"file": args[1],
 	}).Debug("Image import")
 
-	return rc.ImageImport(ctx, r, rs)
+	return rc.ImageImport(ctx, r, rs, opts...)
 }
 
 func runImageInspect(cmd *cobra.Command, args []string) error {

--- a/cmd/regctl/image_test.go
+++ b/cmd/regctl/image_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestImageExportImport(t *testing.T) {
+	tmpDir := t.TempDir()
+	srcRef := "ocidir://../../testdata/testrepo:v2"
+	exportFile := tmpDir + "/export.tar"
+	exportName := "registry.example.com/repo:v2"
+	importRefA := fmt.Sprintf("ocidir://%s/repo:v2", tmpDir)
+	saveOpts := imageOpts
+
+	out, err := cobraTest(t, "image", "export", "--name", exportName, srcRef, exportFile)
+	imageOpts = saveOpts
+	if err != nil {
+		t.Errorf("failed to run image export: %v", err)
+		return
+	}
+	if out != "" {
+		t.Errorf("unexpected output: %v", out)
+	}
+
+	out, err = cobraTest(t, "image", "import", importRefA, exportFile)
+	imageOpts = saveOpts
+	if err != nil {
+		t.Errorf("failed to run image import: %v", err)
+		return
+	}
+	if out != "" {
+		t.Errorf("unexpected output: %v", out)
+	}
+
+	out, err = cobraTest(t, "image", "export", "--name", exportName, "--platform", "linux/amd64", srcRef, exportFile)
+	imageOpts = saveOpts
+	if err != nil {
+		t.Errorf("failed to run image export: %v", err)
+		return
+	}
+	if out != "" {
+		t.Errorf("unexpected output: %v", out)
+	}
+}


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Fixes #480 
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This adds a `--name` option to `regctl image import` to select an image name from a `docker save` or a tag from an OCI layout. This is only needed when multiple images are included in the export.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```
docker save alpine busybox >export.tar
regctl image import --name busybox:latest localhost:5000/library/busybox:import export.tar
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Add option to import a specific image or tag from an export of multiple images
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
