### PR TITLE
Adjust OCI types with upstream

### DIFF
--- a/types/descriptor.go
+++ b/types/descriptor.go
@@ -17,13 +17,13 @@ import (
 // Descriptor is used in manifests to refer to content by media type, size, and digest.
 type Descriptor struct {
 	// MediaType describe the type of the content.
-	MediaType string `json:"mediaType,omitempty"`
+	MediaType string `json:"mediaType"`
 
 	// Size in bytes of content.
-	Size int64 `json:"size,omitempty"`
+	Size int64 `json:"size"`
 
 	// Digest uniquely identifies the content.
-	Digest digest.Digest `json:"digest,omitempty"`
+	Digest digest.Digest `json:"digest"`
 
 	// URLs contains the source URLs of this content.
 	URLs []string `json:"urls,omitempty"`

--- a/types/manifest/oci1.go
+++ b/types/manifest/oci1.go
@@ -165,10 +165,6 @@ func (m *oci1Manifest) GetSubject() (*types.Descriptor, error) {
 	if !m.manifSet {
 		return nil, types.ErrManifestNotSet
 	}
-	// TODO: remove fall back support for refers in a future release
-	if m.Manifest.Subject == nil && m.Manifest.Refers != nil {
-		return m.Manifest.Refers, nil
-	}
 	return m.Manifest.Subject, nil
 }
 func (m *oci1Index) GetSubject() (*types.Descriptor, error) {
@@ -180,10 +176,6 @@ func (m *oci1Index) GetSubject() (*types.Descriptor, error) {
 func (m *oci1Artifact) GetSubject() (*types.Descriptor, error) {
 	if !m.manifSet {
 		return nil, types.ErrManifestNotSet
-	}
-	// TODO: remove fall back support for refers in a future release
-	if m.ArtifactManifest.Subject == nil && m.ArtifactManifest.Refers != nil {
-		return m.ArtifactManifest.Refers, nil
 	}
 	return m.ArtifactManifest.Subject, nil
 }

--- a/types/oci/v1/artifact.go
+++ b/types/oci/v1/artifact.go
@@ -15,10 +15,6 @@ type ArtifactManifest struct {
 	// Blobs is a collection of blobs referenced by this manifest.
 	Blobs []types.Descriptor `json:"blobs,omitempty"`
 
-	// Refers indicates this manifest references another manifest
-	// TODO: deprecated, delete this from future releases
-	Refers *types.Descriptor `json:"refers,omitempty"`
-
 	// Subject is an optional link from the image manifest to another manifest forming an association between the image manifest and the other manifest.
 	Subject *types.Descriptor `json:"subject,omitempty"`
 

--- a/types/oci/v1/config.go
+++ b/types/oci/v1/config.go
@@ -1,5 +1,8 @@
 package v1
 
+// Docker specific content in this file is included from
+// https://github.com/moby/moby/blob/master/api/types/container/config.go
+
 import (
 	"time"
 	// crypto libraries included for go-digest
@@ -39,6 +42,10 @@ type ImageConfig struct {
 	// StopSignal contains the system call signal that will be sent to the container to exit.
 	StopSignal string `json:"StopSignal,omitempty"`
 
+	// StopTimeout is the time in seconds to stop the container.
+	// This is a Docker specific extension to the config, and not part of the OCI spec.
+	StopTimeout *int `json:",omitempty"`
+
 	// ArgsEscaped `[Deprecated]` - This field is present only for legacy
 	// compatibility with Docker and should not be used by new image builders.
 	// It is used by Docker for Windows images to indicate that the `Entrypoint`
@@ -47,6 +54,18 @@ type ImageConfig struct {
 	// the value in `Entrypoint` or `Cmd` should be used as-is to avoid double
 	// escaping.
 	ArgsEscaped bool `json:"ArgsEscaped,omitempty"`
+
+	// Healthcheck describes how to check if the container is healthy.
+	// This is a Docker specific extension to the config, and not part of the OCI spec.
+	Healthcheck *HealthConfig `json:"Healthcheck,omitempty"`
+
+	// OnBuild lists any ONBUILD steps defined in the Dockerfile.
+	// This is a Docker specific extension to the config, and not part of the OCI spec.
+	OnBuild []string `json:"OnBuild,omitempty"`
+
+	// Shell for the shell-form of RUN, CMD, and ENTRYPOINT.
+	// This is a Docker specific extension to the config, and not part of the OCI spec.
+	Shell []string `json:"Shell,omitempty"`
 }
 
 // RootFS describes a layer content addresses
@@ -96,4 +115,26 @@ type Image struct {
 
 	// History describes the history of each layer.
 	History []History `json:"history,omitempty"`
+}
+
+// HealthConfig holds configuration settings for the HEALTHCHECK feature.
+// This is a Docker specific extension to the config, and not part of the OCI spec.
+type HealthConfig struct {
+	// Test is the test to perform to check that the container is healthy.
+	// An empty slice means to inherit the default.
+	// The options are:
+	// {} : inherit healthcheck
+	// {"NONE"} : disable healthcheck
+	// {"CMD", args...} : exec arguments directly
+	// {"CMD-SHELL", command} : run command with system's default shell
+	Test []string `json:",omitempty"`
+
+	// Zero means to inherit. Durations are expressed as integer nanoseconds.
+	Interval    time.Duration `json:",omitempty"` // Interval is the time to wait between checks.
+	Timeout     time.Duration `json:",omitempty"` // Timeout is the time to wait before considering the check to have hung.
+	StartPeriod time.Duration `json:",omitempty"` // The start period for the container to initialize before the retries starts to count down.
+
+	// Retries is the number of consecutive failures needed to consider a container as unhealthy.
+	// Zero means inherit.
+	Retries int `json:",omitempty"`
 }

--- a/types/oci/v1/manifest.go
+++ b/types/oci/v1/manifest.go
@@ -27,13 +27,9 @@ type Manifest struct {
 	// Layers is an indexed list of layers referenced by the manifest.
 	Layers []types.Descriptor `json:"layers"`
 
-	// Annotations contains arbitrary metadata for the image manifest.
-	Annotations map[string]string `json:"annotations,omitempty"`
-
-	// Refers indicates this manifest references another manifest
-	// TODO: deprecated, delete this from future releases
-	Refers *types.Descriptor `json:"refers,omitempty"`
-
 	// Subject is an optional link from the image manifest to another manifest forming an association between the image manifest and the other manifest.
 	Subject *types.Descriptor `json:"subject,omitempty"`
+
+	// Annotations contains arbitrary metadata for the image manifest.
+	Annotations map[string]string `json:"annotations,omitempty"`
 }


### PR DESCRIPTION

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

The OCI descriptor requires mediatype, size, and digest.

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

- Descriptor fields mediatype, size, and digest are no longer omitted if empty.
- Refers field is no longer needed, replaced by subject.
- Docker specific config settings are added for showing docker images.
- Annotations should be after the subject field.

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Fields like shell and healthcheck are now shown with:

```
regctl image config $img
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Chore: sync OCI types to align with upstream sources.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
