### PR TITLE
Repo names may have multiple dashes

### DIFF
--- a/types/ref/ref.go
+++ b/types/ref/ref.go
@@ -30,7 +30,7 @@ var (
 	hostDomainS = `(?:` + hostPartS + `(?:(?:` + regexp.QuoteMeta(`.`) + hostPartS + `)+` + regexp.QuoteMeta(`.`) + `?|` + regexp.QuoteMeta(`.`) + `))`
 	hostUpperS  = `(?:[a-zA-Z0-9]*[A-Z][a-zA-Z0-9-]*[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[A-Z][a-zA-Z0-9]*)`
 	registryS   = `(?:` + hostDomainS + `|` + hostPortS + `|` + hostUpperS + `|localhost(?:` + regexp.QuoteMeta(`:`) + `[0-9]+))`
-	repoPartS   = `[a-z0-9]+(?:(?:[_.-]|__)[a-z0-9]+)*`
+	repoPartS   = `[a-z0-9]+(?:(?:\.|_|__|-+)[a-z0-9]+)*`
 	pathS       = `[/a-zA-Z0-9_\-. ]+`
 	tagS        = `[\w][\w.-]{0,127}`
 	digestS     = `[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,}`

--- a/types/ref/ref_test.go
+++ b/types/ref/ref_test.go
@@ -164,10 +164,10 @@ func TestRef(t *testing.T) {
 		},
 		{
 			name:       "separators in repo",
-			ref:        "e.xample.co/g-r.o__u_p/image:a",
+			ref:        "e.xample.co/g-r.o__u_p/im----age:a",
 			scheme:     "reg",
 			registry:   "e.xample.co",
-			repository: "g-r.o__u_p/image",
+			repository: "g-r.o__u_p/im----age",
 			tag:        "a",
 			digest:     "",
 			path:       "",
@@ -319,8 +319,8 @@ func TestRef(t *testing.T) {
 			wantE: types.ErrInvalidReference,
 		},
 		{
-			name:  "invalid repo multiple dash",
-			ref:   "project/image--x:tag",
+			name:  "invalid repo triple underscore",
+			ref:   "project/image___x:tag",
 			wantE: types.ErrInvalidReference,
 		},
 		{


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

OCI allows multiple `-`'s in repo names.
See https://github.com/opencontainers/distribution-spec/pull/426
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

The regexp for repo names is adjusted to support those separators.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```
regctl image copy $src localhost:5000/test---repo:latest
```

<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Support multiple dashes in repo names.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
