### PR TITLE
Auth failures should not trigger a backoff

### DIFF
--- a/internal/reghttp/http.go
+++ b/internal/reghttp/http.go
@@ -457,7 +457,6 @@ func (resp *clientResp) Next() error {
 								"Err": err,
 							}).Warn("Failed to handle auth request")
 						}
-						backoff = true
 						dropHost = true
 					} else {
 						err = fmt.Errorf("authentication required")


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Copy to a repo where access is lacking results in backoffs before an eventual failure.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Auth errors should not trigger the backoff. These failures should be handled by callers. In the case of a copy, it's possible a registry could provide auth failures on the head/get requests before the repo is created by a push.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```
regctl image copy $src $dest
```

Where `$src` exists and `$dest` is a repo where push access does not exist.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Fix: auth failures do not trigger a backoff
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
