### PR TITLE
Fix log from warning header messages

### DIFF
--- a/types/warning/warning.go
+++ b/types/warning/warning.go
@@ -77,6 +77,6 @@ func Handle(ctx context.Context, log *logrus.Logger, msg string) {
 
 func logMsg(log *logrus.Logger, msg string) {
 	log.WithFields(logrus.Fields{
-		msg: msg,
+		"warning": msg,
 	}).Warn("Registry warning message")
 }


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Warning headers generate a bad log message.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This changes the log message field name to the string "warning".
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

google/go-containerregistry includes a warning header in 1% of requests.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Warning header log message is fixed.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
