### PR TITLE
Only check digest on EOF

### DIFF
--- a/cmd/regctl/blob.go
+++ b/cmd/regctl/blob.go
@@ -352,7 +352,6 @@ func runBlobGetFile(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer blob.Close()
 	tr, err := blob.ToTarReader()
 	if err != nil {
 		return err
@@ -382,6 +381,12 @@ func runBlobGetFile(cmd *cobra.Command, args []string) error {
 	}
 	_, err = io.Copy(w, rdr)
 	if err != nil {
+		return err
+	}
+	if err := tr.Close(); err != nil {
+		return err
+	}
+	if err := blob.Close(); err != nil {
 		return err
 	}
 	return nil

--- a/types/blob/reader.go
+++ b/types/blob/reader.go
@@ -111,7 +111,7 @@ func (b *reader) Read(p []byte) (int, error) {
 		if b.desc.Digest == "" {
 			b.desc.Digest = b.digester.Digest()
 		} else if b.desc.Digest != b.digester.Digest() {
-			err = fmt.Errorf("expected digest mismatch [expected %s, calculated %s]: %w", b.desc.Digest.String(), b.digester.Digest().String(), err)
+			err = fmt.Errorf("%w [expected %s, calculated %s]: %v", types.ErrDigestMismatch, b.desc.Digest.String(), b.digester.Digest().String(), err)
 		}
 	}
 	return size, err


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

On a partial tar read, closing the reader should not compare the digest. Fixes #502.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This moves the digest compare to only run after an EOF.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```
regctl image get-file alpine /etc/hosts
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Fix digest check when running `regctl image get-file`
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
