### PR TITLE
Cleanup artifact annotations

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -179,15 +179,15 @@ jobs:
             | regctl artifact put --subject "ocidir://output/${{matrix.image}}@${digest}" \
                 --artifact-type application/vnd.cyclonedx+json \
                 -m application/vnd.cyclonedx+json \
-                --annotation "org.opencontainers.artifact.created=${now_date}" \
-                --annotation "org.opencontainers.artifact.description=CycloneDX JSON SBOM"
+                --annotation "org.opencontainers.image.created=${now_date}" \
+                --annotation "org.opencontainers.image.description=CycloneDX JSON SBOM"
           ${{steps.syft.outputs.cmd}} packages -q "oci-dir:output/${{matrix.image}}-sbom" \
               --source-name "docker:docker.io/regclient/${{matrix.image}}@${digest}" -o spdx-json \
             | regctl artifact put --subject "ocidir://output/${{matrix.image}}@${digest}" \
                 --artifact-type application/spdx+json \
                 -m application/spdx+json \
-                --annotation "org.opencontainers.artifact.created=${now_date}" \
-                --annotation "org.opencontainers.artifact.description=SPDX JSON SBOM"
+                --annotation "org.opencontainers.image.created=${now_date}" \
+                --annotation "org.opencontainers.image.description=SPDX JSON SBOM"
           rm -r output/${{matrix.image}}-sbom
         done
 

--- a/build/oci-image.sh
+++ b/build/oci-image.sh
@@ -111,14 +111,14 @@ for digest in $(regctl manifest get ocidir://output/${image}:${release} --format
     | regctl artifact put --subject "ocidir://output/${image}@${digest}" \
         --artifact-type application/vnd.cyclonedx+json \
         -m application/vnd.cyclonedx+json \
-        --annotation "org.opencontainers.artifact.created=${now_date}" \
-        --annotation "org.opencontainers.artifact.description=CycloneDX JSON SBOM"
+        --annotation "org.opencontainers.image.created=${now_date}" \
+        --annotation "org.opencontainers.image.description=CycloneDX JSON SBOM"
   syft packages -q "oci-dir:output/${image}-sbom" --source-name "docker:docker.io/regclient/${image}@${digest}" -o spdx-json \
     | regctl artifact put --subject "ocidir://output/${image}@${digest}" \
         --artifact-type application/spdx+json \
         -m application/spdx+json \
-        --annotation "org.opencontainers.artifact.created=${now_date}" \
-        --annotation "org.opencontainers.artifact.description=SPDX JSON SBOM"
+        --annotation "org.opencontainers.image.created=${now_date}" \
+        --annotation "org.opencontainers.image.description=SPDX JSON SBOM"
   rm -r output/${image}-sbom
 done
 

--- a/scheme/ocidir/referrer_test.go
+++ b/scheme/ocidir/referrer_test.go
@@ -41,7 +41,7 @@ func TestReferrer(t *testing.T) {
 	aType := "application/example.sbom"
 	bType := "application/example.sig"
 	cType := "application/example.attestation"
-	extraAnnot := "org.opencontainers.artifact.sbom.format"
+	extraAnnot := "org.example.sbom.format"
 	timeAnnot := "org.opencontainers.image.created"
 	extraValueA := "json"
 	extraValueB := "yaml"

--- a/scheme/reg/referrer_test.go
+++ b/scheme/reg/referrer_test.go
@@ -30,7 +30,7 @@ func TestReferrer(t *testing.T) {
 	repoPath := "/proj"
 	tagV1 := "v1"
 	tagV1List := "v1-list"
-	extraAnnot := "org.opencontainers.artifact.sbom.format"
+	extraAnnot := "org.example.sbom.format"
 	extraValue := "json"
 	extraValue2 := "x509"
 	digest1 := digest.FromString("example1")


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Artifact annotations were removed from OCI release candidates and shouldn't be used.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This changes back to image annotations where appropriate, and example annotations in tests.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Generated `regclient/reg*` images should no longer have `org.opencontainers.artifact.*` annotations.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Switch `org.opencontainers.artifact.*` to `org.opencontainers.image.*` annotations in regclient images.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
