### PR TITLE
Add an in memory cache of manifests and referrers

### DIFF
--- a/cmd/regctl/root.go
+++ b/cmd/regctl/root.go
@@ -101,6 +101,7 @@ func newRegClient() *regclient.RegClient {
 
 	rcOpts := []regclient.Opt{
 		regclient.WithLog(log),
+		regclient.WithRegOpts(reg.WithCache(time.Minute*5, 500)),
 	}
 	if rootOpts.userAgent != "" {
 		rcOpts = append(rcOpts, regclient.WithUserAgent(rootOpts.userAgent))

--- a/cmd/regsync/config.go
+++ b/cmd/regsync/config.go
@@ -13,16 +13,12 @@ import (
 )
 
 // delay checking for at least 5 minutes when rate limit is exceeded
-var rateLimitRetryMin time.Duration
+var rateLimitRetryMin = time.Minute * 5
 var defaultMediaTypes = []string{
 	types.MediaTypeDocker2Manifest,
 	types.MediaTypeDocker2ManifestList,
 	types.MediaTypeOCI1Manifest,
 	types.MediaTypeOCI1ManifestList,
-}
-
-func init() {
-	rateLimitRetryMin, _ = time.ParseDuration("5m")
 }
 
 // Config is parsed configuration file for regsync
@@ -49,9 +45,11 @@ type ConfigDefaults struct {
 	MediaTypes      []string               `yaml:"mediaTypes" json:"mediaTypes"`
 	Hooks           ConfigHooks            `yaml:"hooks" json:"hooks"`
 	// general options
-	BlobLimit      int64  `yaml:"blobLimit" json:"blobLimit"`
-	SkipDockerConf bool   `yaml:"skipDockerConfig" json:"skipDockerConfig"`
-	UserAgent      string `yaml:"userAgent" json:"userAgent"`
+	BlobLimit      int64         `yaml:"blobLimit" json:"blobLimit"`
+	CacheCount     int           `yaml:"cacheCount" json:"cacheCount"`
+	CacheTime      time.Duration `yaml:"cacheTime" json:"cacheTime"`
+	SkipDockerConf bool          `yaml:"skipDockerConfig" json:"skipDockerConfig"`
+	UserAgent      string        `yaml:"userAgent" json:"userAgent"`
 }
 
 // ConfigRateLimit is for rate limit settings

--- a/cmd/regsync/regsync_test.go
+++ b/cmd/regsync/regsync_test.go
@@ -783,6 +783,7 @@ func TestProcessRef(t *testing.T) {
 }
 
 func TestConfigRead(t *testing.T) {
+	// CAUTION: the below yaml is space indented and will not parse with tabs
 	cRead := bytes.NewReader([]byte(`
     version: 1
     creds:
@@ -796,6 +797,8 @@ func TestConfigRead(t *testing.T) {
       parallel: 2
       interval: 60m
       backup: "bkup-{{.Ref.Tag}}"
+      cacheCount: 500
+      cacheTime: "5m"
     x-sync-hub: &sync-hub
       target: registry:5000/hub/{{ .Sync.Source }}
     x-sync-gcr: &sync-gcr

--- a/cmd/regsync/root.go
+++ b/cmd/regsync/root.go
@@ -347,6 +347,9 @@ func loadConf() error {
 	if conf.Defaults.BlobLimit != 0 {
 		rcOpts = append(rcOpts, regclient.WithRegOpts(reg.WithBlobLimit(conf.Defaults.BlobLimit)))
 	}
+	if conf.Defaults.CacheCount > 0 && conf.Defaults.CacheTime > 0 {
+		rcOpts = append(rcOpts, regclient.WithRegOpts(reg.WithCache(conf.Defaults.CacheTime, conf.Defaults.CacheCount)))
+	}
 	if !conf.Defaults.SkipDockerConf {
 		rcOpts = append(rcOpts, regclient.WithDockerCreds(), regclient.WithDockerCerts())
 	}

--- a/docs/regsync.md
+++ b/docs/regsync.md
@@ -199,6 +199,12 @@ sync:
     Array of media types to include.
     These must also be supported by regclient.
     Defaults to: `["application/vnd.docker.distribution.manifest.v2+json", "application/vnd.docker.distribution.manifest.list.v2+json", "application/vnd.oci.image.manifest.v1+json", "application/vnd.oci.image.index.v1+json"]`
+  - `cacheCount`:
+    Number of items to cache for various registry API requests, per item type.
+    `cacheTime` must also be set for this to apply.
+  - `cacheTime`:
+    Duration for items to remain in the cache for various registry API requests.
+    `cacheCount` must also be set for this to apply.
   - `skipDockerConfig`:
     Do not read the user credentials in `${HOME}/.docker/config.json`.
   - `userAgent`:

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -1,0 +1,182 @@
+//go:build go1.18
+// +build go1.18
+
+// Package cache is used to store values with limits.
+// Items are automatically pruned when too many entries are stored, or values become stale.
+package cache
+
+import (
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/regclient/regclient/types"
+)
+
+type Cache[k comparable, v any] struct {
+	mu       sync.Mutex
+	minAge   time.Duration
+	maxAge   time.Duration
+	minCount int
+	maxCount int
+	timer    *time.Timer
+	entries  map[k]*Entry[v]
+}
+
+type Entry[v any] struct {
+	used  time.Time
+	value v
+}
+
+type sortKeys[k comparable] struct {
+	keys   []k
+	lessFn func(a, b k) bool
+}
+
+type conf struct {
+	minAge   time.Duration
+	maxCount int
+}
+
+type cacheOpts func(*conf)
+
+func WithAge(age time.Duration) cacheOpts {
+	return func(c *conf) {
+		c.minAge = age
+	}
+}
+
+func WithCount(count int) cacheOpts {
+	return func(c *conf) {
+		c.maxCount = count
+	}
+}
+
+func New[k comparable, v any](opts ...cacheOpts) Cache[k, v] {
+	c := conf{}
+	for _, opt := range opts {
+		opt(&c)
+	}
+	maxAge := c.minAge + (c.minAge / 10)
+	minCount := 0
+	if c.maxCount > 0 {
+		minCount = int(float64(c.maxCount) * 0.9)
+	}
+	return Cache[k, v]{
+		minAge:   c.minAge,
+		maxAge:   maxAge,
+		minCount: minCount,
+		maxCount: c.maxCount,
+		entries:  map[k]*Entry[v]{},
+	}
+}
+
+func (c *Cache[k, v]) Delete(key k) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.entries, key)
+	if len(c.entries) == 0 && c.timer != nil {
+		c.timer.Stop()
+		c.timer = nil
+	}
+}
+
+func (c *Cache[k, v]) Set(key k, val v) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries[key] = &Entry[v]{
+		used:  time.Now(),
+		value: val,
+	}
+	if len(c.entries) > c.maxCount {
+		c.pruneLocked()
+	} else if c.timer == nil {
+		// prune resets the timer, so this is only needed if the prune wasn't triggered
+		c.timer = time.AfterFunc(c.maxAge, c.prune)
+	}
+}
+
+func (c *Cache[k, v]) Get(key k) (v, error) {
+	if c == nil {
+		var val v
+		return val, types.ErrNotFound
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if e, ok := c.entries[key]; ok {
+		if e.used.Add(c.minAge).Before(time.Now()) {
+			// entry expired
+			go c.prune()
+		} else {
+			c.entries[key].used = time.Now()
+			return e.value, nil
+		}
+	}
+	var val v
+	return val, types.ErrNotFound
+}
+
+func (c *Cache[k, v]) prune() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.pruneLocked()
+}
+
+func (c *Cache[k, v]) pruneLocked() {
+	// sort key list by last used date
+	keyList := make([]k, 0, len(c.entries))
+	for key := range c.entries {
+		keyList = append(keyList, key)
+	}
+	sk := sortKeys[k]{
+		keys: keyList,
+		lessFn: func(a, b k) bool {
+			return c.entries[a].used.Before(c.entries[b].used)
+		},
+	}
+	sort.Sort(&sk)
+	// prune entries
+	now := time.Now()
+	cutoff := now.Add(c.minAge * -1)
+	nextTime := now
+	delCount := len(keyList) - c.minCount
+	for i, key := range keyList {
+		if i < delCount || c.entries[key].used.Before(cutoff) {
+			delete(c.entries, key)
+		} else {
+			nextTime = c.entries[key].used
+			break
+		}
+	}
+	// set next timer
+	if len(c.entries) > 0 {
+		dur := nextTime.Sub(now) + c.maxAge
+		if c.timer == nil {
+			// this shouldn't be possible
+			c.timer = time.AfterFunc(dur, c.prune)
+		} else {
+			c.timer.Reset(dur)
+		}
+	} else if c.timer != nil {
+		c.timer.Stop()
+		c.timer = nil
+	}
+}
+
+func (sk *sortKeys[k]) Len() int {
+	return len(sk.keys)
+}
+
+func (sk *sortKeys[k]) Less(i, j int) bool {
+	return sk.lessFn(sk.keys[i], sk.keys[j])
+}
+
+func (sk *sortKeys[k]) Swap(i, j int) {
+	sk.keys[i], sk.keys[j] = sk.keys[j], sk.keys[i]
+}

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -1,0 +1,91 @@
+//go:build go1.18
+// +build go1.18
+
+package cache
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCache(t *testing.T) {
+	testData := []string{
+		"a", "b", "c", "d", "e", "f", "g", "h", "i", "j",
+		"k", "l", "m", "n", "o", "p", "q", "r", "s", "t",
+	}
+	count := 10
+	pruneCount := int(float64(count) * 1.1)
+	timeout := time.Millisecond * 250
+	timeoutHalf := timeout / 2
+	timePrune := timeout + (timeout / 10)
+	c := New[int, string](WithAge(timeout), WithCount(count))
+	// add entries beyond limit
+	for i, v := range testData {
+		c.Set(i, v)
+	}
+	// delete last 2 entries
+	for i := len(testData) - 2; i < len(testData); i++ {
+		c.Delete(i)
+	}
+	// get entries, verify some deleted
+	pruneCutoff := len(testData) - pruneCount
+	saveCutoff := len(testData) - count
+	checkCutoff := len(testData) - (count / 2)
+	for i, v := range testData {
+		getVal, err := c.Get(i)
+		if i < pruneCutoff || i >= len(testData)-2 {
+			if err == nil {
+				t.Errorf("value found that should have been pruned: %d", i)
+			}
+		} else if i >= saveCutoff && i < len(testData)-2 {
+			if err != nil {
+				t.Errorf("value not found: %d", i)
+			} else if getVal != v {
+				t.Errorf("value mismatch: %d, expect %s, received %s", i, v, getVal)
+			}
+		}
+	}
+	// track used time
+	start := time.Now()
+	// delay to before minAge and check some entries
+	time.Sleep(timeoutHalf)
+	for i, v := range testData {
+		if i >= saveCutoff && i < checkCutoff {
+			getVal, err := c.Get(i)
+			if err != nil {
+				t.Errorf("value not found: %d", i)
+			} else if getVal != v {
+				t.Errorf("value mismatch: %d, expect %s, received %s", i, v, getVal)
+			}
+		}
+	}
+	// delay to after maxAge from 1st used time
+	time.Sleep(timePrune - time.Since(start))
+	for i, v := range testData {
+		getVal, err := c.Get(i)
+		if i >= saveCutoff && i < checkCutoff {
+			if err != nil {
+				t.Errorf("value not found: %d", i)
+			} else if getVal != v {
+				t.Errorf("value mismatch: %d, expect %s, received %s", i, v, getVal)
+			}
+		} else {
+			if err == nil {
+				t.Errorf("value not pruned: %d", i)
+			}
+		}
+	}
+	// delay to after maxAge for all entries
+	time.Sleep(timePrune)
+	for i := range testData {
+		_, err := c.Get(i)
+		if err == nil {
+			t.Errorf("value not pruned: %d", i)
+		}
+	}
+	// set and delete a key
+	c.Set(42, "x")
+	c.Delete(42)
+	// delete non-existent key
+	c.Delete(42)
+}

--- a/scheme/reg/manifest.go
+++ b/scheme/reg/manifest.go
@@ -47,6 +47,10 @@ func (reg *Reg) ManifestDelete(ctx context.Context, r ref.Ref, opts ...scheme.Ma
 			}
 		}
 	}
+	rCache := r
+	rCache.Tag = ""
+	rCache.Reference = rCache.CommonName()
+	reg.cacheMan.Delete(rCache)
 
 	// build/send request
 	req := &reghttp.Req{
@@ -76,6 +80,12 @@ func (reg *Reg) ManifestDelete(ctx context.Context, r ref.Ref, opts ...scheme.Ma
 func (reg *Reg) ManifestGet(ctx context.Context, r ref.Ref) (manifest.Manifest, error) {
 	var tagOrDigest string
 	if r.Digest != "" {
+		rCache := r
+		rCache.Tag = ""
+		rCache.Reference = rCache.CommonName()
+		if m, err := reg.cacheMan.Get(rCache); err == nil {
+			return m, nil
+		}
 		tagOrDigest = r.Digest
 	} else if r.Tag != "" {
 		tagOrDigest = r.Tag
@@ -121,11 +131,20 @@ func (reg *Reg) ManifestGet(ctx context.Context, r ref.Ref) (manifest.Manifest, 
 		return nil, fmt.Errorf("error reading manifest for %s: %w", r.CommonName(), err)
 	}
 
-	return manifest.New(
+	m, err := manifest.New(
 		manifest.WithRef(r),
 		manifest.WithHeader(resp.HTTPResponse().Header),
 		manifest.WithRaw(rawBody),
 	)
+	if err != nil {
+		return nil, err
+	}
+	rCache := r
+	rCache.Tag = ""
+	rCache.Digest = m.GetDescriptor().Digest.String()
+	rCache.Reference = rCache.CommonName()
+	reg.cacheMan.Set(rCache, m)
+	return m, nil
 }
 
 // ManifestHead returns metadata on the manifest from the registry
@@ -133,6 +152,12 @@ func (reg *Reg) ManifestHead(ctx context.Context, r ref.Ref) (manifest.Manifest,
 	// build the request
 	var tagOrDigest string
 	if r.Digest != "" {
+		rCache := r
+		rCache.Tag = ""
+		rCache.Reference = rCache.CommonName()
+		if m, err := reg.cacheMan.Get(rCache); err == nil {
+			return m, nil
+		}
 		tagOrDigest = r.Digest
 	} else if r.Tag != "" {
 		tagOrDigest = r.Tag
@@ -229,16 +254,29 @@ func (reg *Reg) ManifestPut(ctx context.Context, r ref.Ref, m manifest.Manifest,
 		return fmt.Errorf("failed to put manifest %s: %w", r.CommonName(), reghttp.HTTPError(resp.HTTPResponse().StatusCode))
 	}
 
+	rCache := r
+	rCache.Tag = ""
+	rCache.Digest = m.GetDescriptor().Digest.String()
+	rCache.Reference = rCache.CommonName()
+	reg.cacheMan.Set(rCache, m)
+
 	// update referrers if defined on this manifest
 	if mr, ok := m.(manifest.Subjecter); ok {
 		mDesc, err := mr.GetSubject()
 		if err != nil {
 			return err
 		}
-		if mDesc != nil && mDesc.MediaType != "" && mDesc.Size > 0 && mDesc.Digest.String() != resp.HTTPResponse().Header.Get(OCISubjectHeader) {
-			err = reg.referrerPut(ctx, r, m)
-			if err != nil {
-				return err
+		if mDesc != nil && mDesc.MediaType != "" && mDesc.Size > 0 && mDesc.Digest.String() != "" {
+			rSubj := r
+			rSubj.Tag = ""
+			rSubj.Digest = mDesc.Digest.String()
+			rSubj.Reference = rSubj.CommonName()
+			reg.cacheRL.Delete(rSubj)
+			if mDesc.Digest.String() != resp.HTTPResponse().Header.Get(OCISubjectHeader) {
+				err = reg.referrerPut(ctx, r, m)
+				if err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/scheme/reg/referrer_test.go
+++ b/scheme/reg/referrer_test.go
@@ -757,13 +757,14 @@ func TestReferrer(t *testing.T) {
 		WithConfigHosts(rcHosts),
 		WithLog(log),
 		WithDelay(delayInit, delayMax),
+		WithCache(time.Minute*5, 500),
 	)
 
 	// list empty
 	t.Run("List empty NoAPI", func(t *testing.T) {
 		r, err := ref.New(tsURLNoAPI.Host + repoPath + ":" + tagV1)
 		if err != nil {
-			t.Errorf("Failed creating getRef: %v", err)
+			t.Errorf("Failed creating ref: %v", err)
 			return
 		}
 		rl, err := reg.ReferrerList(ctx, r)
@@ -779,7 +780,7 @@ func TestReferrer(t *testing.T) {
 	t.Run("List empty NoAPIAuth", func(t *testing.T) {
 		r, err := ref.New(tsURLNoAPIAuth.Host + repoPath + ":" + tagV1)
 		if err != nil {
-			t.Errorf("Failed creating getRef: %v", err)
+			t.Errorf("Failed creating ref: %v", err)
 			return
 		}
 		rl, err := reg.ReferrerList(ctx, r)
@@ -795,7 +796,7 @@ func TestReferrer(t *testing.T) {
 	t.Run("List empty API", func(t *testing.T) {
 		r, err := ref.New(tsURLAPI.Host + repoPath + ":" + tagV1)
 		if err != nil {
-			t.Errorf("Failed creating getRef: %v", err)
+			t.Errorf("Failed creating ref: %v", err)
 		}
 		rl, err := reg.ReferrerList(ctx, r)
 		if err != nil {
@@ -812,7 +813,7 @@ func TestReferrer(t *testing.T) {
 	t.Run("Put A NoAPI", func(t *testing.T) {
 		r, err := ref.New(tsURLNoAPI.Host + repoPath + "@" + artifactM.GetDescriptor().Digest.String())
 		if err != nil {
-			t.Errorf("Failed creating getRef: %v", err)
+			t.Errorf("Failed creating ref: %v", err)
 		}
 		err = reg.ManifestPut(ctx, r, artifactM)
 		if err != nil {
@@ -823,7 +824,7 @@ func TestReferrer(t *testing.T) {
 	t.Run("Put A NoAPIAuth", func(t *testing.T) {
 		r, err := ref.New(tsURLNoAPIAuth.Host + repoPath + "@" + artifactM.GetDescriptor().Digest.String())
 		if err != nil {
-			t.Errorf("Failed creating getRef: %v", err)
+			t.Errorf("Failed creating ref: %v", err)
 		}
 		err = reg.ManifestPut(ctx, r, artifactM)
 		if err != nil {
@@ -834,7 +835,7 @@ func TestReferrer(t *testing.T) {
 	t.Run("Put A API", func(t *testing.T) {
 		r, err := ref.New(tsURLAPI.Host + repoPath + "@" + artifactM.GetDescriptor().Digest.String())
 		if err != nil {
-			t.Errorf("Failed creating getRef: %v", err)
+			t.Errorf("Failed creating ref: %v", err)
 		}
 		err = reg.ManifestPut(ctx, r, artifactM)
 		if err != nil {
@@ -847,7 +848,7 @@ func TestReferrer(t *testing.T) {
 	t.Run("List A NoAPI", func(t *testing.T) {
 		r, err := ref.New(tsURLNoAPI.Host + repoPath + ":" + tagV1)
 		if err != nil {
-			t.Errorf("Failed creating getRef: %v", err)
+			t.Errorf("Failed creating ref: %v", err)
 			return
 		}
 		rl, err := reg.ReferrerList(ctx, r)
@@ -872,7 +873,7 @@ func TestReferrer(t *testing.T) {
 	t.Run("List A NoAPIAuth", func(t *testing.T) {
 		r, err := ref.New(tsURLNoAPIAuth.Host + repoPath + ":" + tagV1)
 		if err != nil {
-			t.Errorf("Failed creating getRef: %v", err)
+			t.Errorf("Failed creating ref: %v", err)
 			return
 		}
 		rl, err := reg.ReferrerList(ctx, r)
@@ -897,7 +898,7 @@ func TestReferrer(t *testing.T) {
 	t.Run("List A API", func(t *testing.T) {
 		r, err := ref.New(tsURLAPI.Host + repoPath + ":" + tagV1)
 		if err != nil {
-			t.Errorf("Failed creating getRef: %v", err)
+			t.Errorf("Failed creating ref: %v", err)
 		}
 		rl, err := reg.ReferrerList(ctx, r)
 		if err != nil {
@@ -923,7 +924,7 @@ func TestReferrer(t *testing.T) {
 	t.Run("Put B NoAPI", func(t *testing.T) {
 		r, err := ref.New(tsURLNoAPI.Host + repoPath + "@" + artifact2M.GetDescriptor().Digest.String())
 		if err != nil {
-			t.Errorf("Failed creating getRef: %v", err)
+			t.Errorf("Failed creating ref: %v", err)
 		}
 		err = reg.ManifestPut(ctx, r, artifact2M)
 		if err != nil {
@@ -934,7 +935,7 @@ func TestReferrer(t *testing.T) {
 	t.Run("Put B API", func(t *testing.T) {
 		r, err := ref.New(tsURLAPI.Host + repoPath + "@" + artifact2M.GetDescriptor().Digest.String())
 		if err != nil {
-			t.Errorf("Failed creating getRef: %v", err)
+			t.Errorf("Failed creating ref: %v", err)
 		}
 		err = reg.ManifestPut(ctx, r, artifact2M)
 		if err != nil {
@@ -947,7 +948,7 @@ func TestReferrer(t *testing.T) {
 	t.Run("List Both NoAPI", func(t *testing.T) {
 		r, err := ref.New(tsURLNoAPI.Host + repoPath + ":" + tagV1)
 		if err != nil {
-			t.Errorf("Failed creating getRef: %v", err)
+			t.Errorf("Failed creating ref: %v", err)
 			return
 		}
 		rl, err := reg.ReferrerList(ctx, r)
@@ -980,7 +981,7 @@ func TestReferrer(t *testing.T) {
 	t.Run("List Both API", func(t *testing.T) {
 		r, err := ref.New(tsURLAPI.Host + repoPath + ":" + tagV1)
 		if err != nil {
-			t.Errorf("Failed creating getRef: %v", err)
+			t.Errorf("Failed creating ref: %v", err)
 		}
 		rl, err := reg.ReferrerList(ctx, r)
 		if err != nil {
@@ -1013,7 +1014,7 @@ func TestReferrer(t *testing.T) {
 	t.Run("List with artifact filter API", func(t *testing.T) {
 		r, err := ref.New(tsURLAPI.Host + repoPath + ":" + tagV1)
 		if err != nil {
-			t.Errorf("Failed creating getRef: %v", err)
+			t.Errorf("Failed creating ref: %v", err)
 			return
 		}
 		rl, err := reg.ReferrerList(ctx, r, scheme.WithReferrerAT(configMTA))
@@ -1038,7 +1039,7 @@ func TestReferrer(t *testing.T) {
 	t.Run("List with annotation filter", func(t *testing.T) {
 		r, err := ref.New(tsURLAPI.Host + repoPath + ":" + tagV1)
 		if err != nil {
-			t.Errorf("Failed creating getRef: %v", err)
+			t.Errorf("Failed creating ref: %v", err)
 			return
 		}
 		rl, err := reg.ReferrerList(ctx, r, scheme.WithReferrerAnnotations(map[string]string{extraAnnot: extraValue2}))
@@ -1073,7 +1074,7 @@ func TestReferrer(t *testing.T) {
 	t.Run("List for platform", func(t *testing.T) {
 		r, err := ref.New(tsURLAPI.Host + repoPath + ":" + tagV1List)
 		if err != nil {
-			t.Errorf("Failed creating getRef: %v", err)
+			t.Errorf("Failed creating ref: %v", err)
 			return
 		}
 		rl, err := reg.ReferrerList(ctx, r, scheme.WithReferrerPlatform(platStr))
@@ -1091,7 +1092,7 @@ func TestReferrer(t *testing.T) {
 	t.Run("Delete B NoAPI", func(t *testing.T) {
 		r, err := ref.New(tsURLNoAPI.Host + repoPath + "@" + artifact2M.GetDescriptor().Digest.String())
 		if err != nil {
-			t.Errorf("Failed creating getRef: %v", err)
+			t.Errorf("Failed creating ref: %v", err)
 		}
 		err = reg.ManifestDelete(ctx, r, scheme.WithManifestCheckReferrers())
 		if err != nil {
@@ -1102,7 +1103,7 @@ func TestReferrer(t *testing.T) {
 	t.Run("Delete B API", func(t *testing.T) {
 		r, err := ref.New(tsURLAPI.Host + repoPath + "@" + artifact2M.GetDescriptor().Digest.String())
 		if err != nil {
-			t.Errorf("Failed creating getRef: %v", err)
+			t.Errorf("Failed creating ref: %v", err)
 		}
 		err = reg.ManifestDelete(ctx, r, scheme.WithManifestCheckReferrers())
 		if err != nil {
@@ -1114,7 +1115,7 @@ func TestReferrer(t *testing.T) {
 	t.Run("Delete A NoAPI", func(t *testing.T) {
 		r, err := ref.New(tsURLNoAPI.Host + repoPath + "@" + artifactM.GetDescriptor().Digest.String())
 		if err != nil {
-			t.Errorf("Failed creating getRef: %v", err)
+			t.Errorf("Failed creating ref: %v", err)
 		}
 		err = reg.ManifestDelete(ctx, r, scheme.WithManifest(artifactM))
 		if err != nil {
@@ -1125,7 +1126,7 @@ func TestReferrer(t *testing.T) {
 	t.Run("Delete A API", func(t *testing.T) {
 		r, err := ref.New(tsURLAPI.Host + repoPath + "@" + artifactM.GetDescriptor().Digest.String())
 		if err != nil {
-			t.Errorf("Failed creating getRef: %v", err)
+			t.Errorf("Failed creating ref: %v", err)
 		}
 		err = reg.ManifestDelete(ctx, r, scheme.WithManifest(artifactM))
 		if err != nil {
@@ -1138,7 +1139,7 @@ func TestReferrer(t *testing.T) {
 	t.Run("List empty after delete NoAPI", func(t *testing.T) {
 		r, err := ref.New(tsURLNoAPI.Host + repoPath + ":" + tagV1)
 		if err != nil {
-			t.Errorf("Failed creating getRef: %v", err)
+			t.Errorf("Failed creating ref: %v", err)
 			return
 		}
 		rl, err := reg.ReferrerList(ctx, r)
@@ -1154,7 +1155,7 @@ func TestReferrer(t *testing.T) {
 	t.Run("List empty after delete API", func(t *testing.T) {
 		r, err := ref.New(tsURLAPI.Host + repoPath + ":" + tagV1)
 		if err != nil {
-			t.Errorf("Failed creating getRef: %v", err)
+			t.Errorf("Failed creating ref: %v", err)
 		}
 		rl, err := reg.ReferrerList(ctx, r)
 		if err != nil {


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Describe the change

This adds an optional cache of manifests and referrers. The manifests are only cached by digest. The cache has a fixed number of items and a timeout. `regctl` sets this to a 5 minute timeout and 500 items, neither of which are ever expected to be reached. `regsync` supports caching if `defaults.cacheCount` and `defaults.cacheTime` are set, which may speed up the copy of images with referrers that have multiple tags to the same manifest. Library users can use `regclient.WithCache` to enable caching.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Commands that would pull a manifest multiple times no longer do this. `regctl index create` with the same ref multiple times is one example.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Add in memory caching support.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
