### PR TITLE
Add manifest and blob get/put limits

### DIFF
--- a/internal/limitread/limitread.go
+++ b/internal/limitread/limitread.go
@@ -1,0 +1,29 @@
+// Package limitread provides a reader that will error if the limit is ever exceeded
+package limitread
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/regclient/regclient/types"
+)
+
+type LimitRead struct {
+	Reader io.Reader
+	Limit  int64
+}
+
+func (lr *LimitRead) Read(p []byte) (int, error) {
+	if lr.Limit < 0 {
+		return 0, fmt.Errorf("read limit exceeded%.0w", types.ErrSizeLimitExceeded)
+	}
+	if int64(len(p)) > lr.Limit+1 {
+		p = p[0 : lr.Limit+1]
+	}
+	n, err := lr.Reader.Read(p)
+	lr.Limit -= int64(n)
+	if lr.Limit < 0 {
+		return n, fmt.Errorf("read limit exceeded%.0w", types.ErrSizeLimitExceeded)
+	}
+	return n, err
+}

--- a/internal/limitread/limitread_test.go
+++ b/internal/limitread/limitread_test.go
@@ -1,0 +1,103 @@
+package limitread
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/regclient/regclient/types"
+)
+
+func TestLimitRead(t *testing.T) {
+	byte0 := []byte("")
+	byte5 := []byte("12345")
+	byte10 := []byte("1234567890")
+	tt := []struct {
+		name        string
+		limit       int64
+		src         []byte
+		try         int64
+		expectBytes []byte
+		expectLen   int
+		expectErr   error
+	}{
+		{
+			name:        "empty",
+			limit:       0,
+			src:         byte0,
+			try:         0,
+			expectBytes: byte0,
+			expectLen:   0,
+			expectErr:   io.EOF,
+		},
+		{
+			name:        "exact length",
+			limit:       5,
+			src:         byte5,
+			try:         5,
+			expectBytes: byte5,
+			expectLen:   5,
+			expectErr:   nil,
+		},
+		{
+			name:        "read less",
+			limit:       5,
+			src:         byte10,
+			try:         5,
+			expectBytes: byte5,
+			expectLen:   5,
+			expectErr:   nil,
+		},
+		{
+			name:        "try more",
+			limit:       5,
+			src:         byte5,
+			try:         10,
+			expectBytes: byte5,
+			expectLen:   5,
+			expectErr:   io.EOF,
+		},
+		{
+			name:      "read more",
+			limit:     9,
+			src:       byte10,
+			try:       10,
+			expectErr: types.ErrSizeLimitExceeded,
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			lr := LimitRead{
+				Reader: bytes.NewReader(tc.src),
+				Limit:  tc.limit,
+			}
+			tgt := make([]byte, tc.try)
+			result, err := lr.Read(tgt)
+			// on a short read, try again for the EOF
+			if err == nil && result < int(tc.try) {
+				result2, err2 := lr.Read(tgt[result:])
+				result += result2
+				err = err2
+			}
+			if tc.expectErr != nil {
+				if err == nil {
+					t.Errorf("read did not fail")
+				} else if tc.expectErr.Error() != err.Error() && !errors.Is(err, tc.expectErr) {
+					t.Errorf("unexpected error, expected %v, received %v", tc.expectErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("read failed: %v", err)
+				return
+			}
+			if result != tc.expectLen {
+				t.Errorf("read length mismatch, expected %d, received %d", tc.expectLen, result)
+			}
+			if !bytes.Equal(tgt[:result], tc.expectBytes) {
+				t.Errorf("read bytes mismatch, expected %s, received %s", string(tc.expectBytes), string(tgt[:result]))
+			}
+		})
+	}
+}

--- a/internal/reghttp/http_test.go
+++ b/internal/reghttp/http_test.go
@@ -719,6 +719,11 @@ func TestRegHttp(t *testing.T) {
 				"server-error." + tsHost,
 			},
 		},
+		"retry." + tsHost: {
+			Name:     "retry." + tsHost,
+			Hostname: tsHost,
+			TLS:      config.TLSDisabled,
+		},
 	}
 
 	// create APIs for requests to run
@@ -1589,7 +1594,7 @@ func TestRegHttp(t *testing.T) {
 			},
 		}
 		retryReq := &Req{
-			Host: tsHost,
+			Host: "retry." + tsHost,
 			APIs: apiRetry,
 		}
 		resp, err := hc.Do(ctx, retryReq)

--- a/scheme/reg/manifest.go
+++ b/scheme/reg/manifest.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 
+	"github.com/regclient/regclient/internal/limitread"
 	"github.com/regclient/regclient/internal/reghttp"
 	"github.com/regclient/regclient/internal/wraperr"
 	"github.com/regclient/regclient/scheme"
@@ -125,8 +127,18 @@ func (reg *Reg) ManifestGet(ctx context.Context, r ref.Ref) (manifest.Manifest, 
 		return nil, fmt.Errorf("failed to get manifest %s: %w", r.CommonName(), reghttp.HTTPError(resp.HTTPResponse().StatusCode))
 	}
 
+	// limit length
+	size, _ := strconv.Atoi(resp.HTTPResponse().Header.Get("Content-Length"))
+	if size > 0 && reg.manifestMaxPull > 0 && int64(size) > reg.manifestMaxPull {
+		return nil, fmt.Errorf("manifest too large, received %d, limit %d: %s%.0w", size, reg.manifestMaxPull, r.CommonName(), types.ErrSizeLimitExceeded)
+	}
+	rdr := &limitread.LimitRead{
+		Reader: resp,
+		Limit:  reg.manifestMaxPull,
+	}
+
 	// read manifest
-	rawBody, err := io.ReadAll(resp)
+	rawBody, err := io.ReadAll(rdr)
 	if err != nil {
 		return nil, fmt.Errorf("error reading manifest for %s: %w", r.CommonName(), err)
 	}
@@ -225,6 +237,11 @@ func (reg *Reg) ManifestPut(ctx context.Context, r ref.Ref, m manifest.Manifest,
 			"err": err,
 		}).Warn("Error marshaling manifest")
 		return fmt.Errorf("error marshalling manifest for %s: %w", r.CommonName(), err)
+	}
+
+	// limit length
+	if reg.manifestMaxPush > 0 && int64(len(mj)) > reg.manifestMaxPush {
+		return fmt.Errorf("manifest too large, calculated %d, limit %d: %s%.0w", len(mj), reg.manifestMaxPush, r.CommonName(), types.ErrSizeLimitExceeded)
 	}
 
 	// build/send request

--- a/types/error.go
+++ b/types/error.go
@@ -59,6 +59,10 @@ var (
 	ErrParsingFailed = errors.New("parsing failed")
 	// ErrRetryNeeded indicates a request needs to be retried
 	ErrRetryNeeded = errors.New("retry needed")
+	// ErrShortRead if contents are less than expected the size
+	ErrShortRead = errors.New("short read")
+	// ErrSizeLimitExceeded if contents exceed the size limit
+	ErrSizeLimitExceeded = errors.New("size limit exceeded")
 	// ErrUnavailable when a requested value is not available
 	ErrUnavailable = errors.New("unavailable")
 	// ErrUnsupported indicates the request was unsupported


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

OCI recommends a 4MB manifest limit that clients should avoid exceeding when creating new manifests.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

- This adds a 4MB manifest put limit (per the OCI spec).
- It also adds an 8MB manifest get limit to prevent DOS attacks.
- Blob reads also stop when the expected length is reached.
- HTTP retry backoff checks were added to read/close methods.

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

A manifest put for a very large manifest should fail.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Add size limits on manifests
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
