### PR TITLE
Created artifacts should always set artifactType

### DIFF
--- a/cmd/regctl/artifact.go
+++ b/cmd/regctl/artifact.go
@@ -519,30 +519,29 @@ func runArtifactPut(cmd *cobra.Command, args []string) error {
 	}
 
 	// validate/set artifactType and config.mediaType
+	if artifactOpts.artifactType == "" {
+		// always set artifactType field
+		if artifactOpts.artifactConfigMT != "" {
+			artifactOpts.artifactType = artifactOpts.artifactConfigMT
+		} else {
+			log.Warnf("using default value for artifact-type is not recommended")
+			artifactOpts.artifactType = defaultMTArtifact
+		}
+	}
 	if hasConfig && artifactOpts.artifactConfigMT == "" {
 		if artifactOpts.artifactConfig == "" {
 			artifactOpts.artifactConfigMT = types.MediaTypeOCI1Empty
-			if artifactOpts.artifactType == "" {
-				log.Warnf("using default value for artifact-type is not recommended")
-				artifactOpts.artifactType = defaultMTArtifact
-			}
 		} else {
 			if artifactOpts.artifactType != "" {
 				artifactOpts.artifactConfigMT = artifactOpts.artifactType
-				artifactOpts.artifactType = ""
-				log.Warnf("setting config-type using artifact-type is deprecated")
+				log.Warnf("setting config-type using artifact-type")
 			} else {
 				return fmt.Errorf("config-type is required for config-file")
 			}
 		}
-	} else if !hasConfig {
-		if artifactOpts.artifactConfig != "" || artifactOpts.artifactConfigMT != "" {
-			return fmt.Errorf("cannot set config-type or config-file on %s%.0w", artifactOpts.artifactMT, types.ErrUnsupportedMediaType)
-		}
-		if artifactOpts.artifactType == "" {
-			log.Warnf("using default value for artifact-type is not recommended")
-			artifactOpts.artifactType = defaultMTArtifact
-		}
+	}
+	if !hasConfig && (artifactOpts.artifactConfig != "" || artifactOpts.artifactConfigMT != "") {
+		return fmt.Errorf("cannot set config-type or config-file on %s%.0w", artifactOpts.artifactMT, types.ErrUnsupportedMediaType)
 	}
 
 	// validate artifact files with media types


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

The OCI guidance is changing to recommend new artifacts always set the `artifactType` field.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This adjusts the `regctl artifact put` command to set `artifactType` even if only the `--config-type` flag is passed.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```
echo '{"config": "test"}' >config.json
echo test | regctl artifact put --config-type application/vnd.example+json --config-file config.json ocidir://test:artifact
```

<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Always set `artifactType` with `regctl artifact put`
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [ ] Tests have been added or not applicable
- [ ] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
