### PR TITLE
Avoid and clean stale content in ocidir

### DIFF
--- a/cmd/regctl/artifact.go
+++ b/cmd/regctl/artifact.go
@@ -758,7 +758,11 @@ func runArtifactPut(cmd *cobra.Command, args []string) error {
 	}
 
 	// push manifest
-	err = rc.ManifestPut(ctx, r, mm)
+	putOpts := []regclient.ManifestOpts{}
+	if rArt.IsZero() {
+		putOpts = append(putOpts, regclient.WithManifestChild())
+	}
+	err = rc.ManifestPut(ctx, r, mm, putOpts...)
 	if err != nil {
 		return err
 	}

--- a/scheme/ocidir/manifest.go
+++ b/scheme/ocidir/manifest.go
@@ -51,7 +51,7 @@ func (o *OCIDir) ManifestDelete(ctx context.Context, r ref.Ref, opts ...scheme.M
 			if err == nil && sDesc != nil && sDesc.MediaType != "" && sDesc.Size > 0 {
 				// attempt to delete the referrer, but ignore if the referrer entry wasn't found
 				err = o.referrerDelete(ctx, r, mc.Manifest)
-				if err != nil && !errors.Is(err, types.ErrNotFound) {
+				if err != nil && !errors.Is(err, types.ErrNotFound) && !errors.Is(err, fs.ErrNotExist) {
 					return err
 				}
 			}


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Running reproducible build script leaves stale referrers from previous builds.

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

- manifest delete should not fail when referrer file is missing
- artifact put of referrer should not add a manifest reference in ocidir
- reproducible image creation scripts should prune stale referrers

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```
make oci-image
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Fix: manifest delete should not fail when referrer file is missing
- Fix: artifact put of referrer should not add a manifest reference in ocidir
- Fix: reproducible image creation scripts should prune stale referrers

<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
