### PR TITLE
Fail faster when target of copy is down

### DIFF
--- a/image.go
+++ b/image.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/url"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -486,6 +487,10 @@ func (rc *RegClient) imageCopyOpt(ctx context.Context, refSrc ref.Ref, refTgt re
 	}
 	// check target with head request
 	mTgt, err = rc.ManifestHead(ctx, refTgt, WithManifestRequireDigest())
+	var urlError *url.Error
+	if err != nil && errors.As(err, &urlError) {
+		return fmt.Errorf("failed to access target registry: %w", err)
+	}
 	// for non-recursive copies, compare to source digest
 	if err == nil && (opt.fastCheck || (!opt.forceRecursive && opt.referrerConfs == nil && !opt.digestTags)) {
 		if sDig == "" {


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Copy to a down target results in multiple retry tests for every manifest and blob.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

The manifest head request to the target typically ignores errors since the target may not exist. This checks a resulting error for `*url.Error` that results from an HTTP connection failure.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
regctl image copy $src localhost:12345/no-such-registry # where nothing is listening on 12345
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Fail faster on image copy when target registry is unreachable
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [ ] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
