### PR TITLE
Add the ability to access the OCI index in tag ls

### DIFF
--- a/cmd/regctl/tag.go
+++ b/cmd/regctl/tag.go
@@ -19,8 +19,12 @@ var tagDeleteCmd = &cobra.Command{
 	Use:     "delete <image_ref>",
 	Aliases: []string{"del", "rm", "remove"},
 	Short:   "delete a tag in a repo",
-	Long: `Delete a tag in a repository without removing other tags pointing to the
-same manifest`,
+	Long: `Delete a tag in a repository.
+This avoids deleting the manifest when multiple tags reference the same image.
+For registries that do not support the OCI tag delete API, this is implemented
+by pushing a unique dummy manifest and deleting that by digest.
+If the registry does not support the delete API, the dummy manifest will remain.
+`,
 	Args:              cobra.ExactArgs(1),
 	ValidArgsFunction: completeArgTag,
 	RunE:              runTagDelete,
@@ -30,7 +34,9 @@ var tagLsCmd = &cobra.Command{
 	Aliases: []string{"list"},
 	Short:   "list tags in a repo",
 	Long: `List tags in a repository.
-Note: most registries ignore the pagination options.`,
+Note: many registries ignore the pagination options.
+For an OCI Layout, the index is available as Index (--format "{{.Index}}").
+`,
 	Args:      cobra.ExactArgs(1),
 	ValidArgs: []string{},
 	RunE:      runTagLs,

--- a/scheme/ocidir/tag.go
+++ b/scheme/ocidir/tag.go
@@ -84,6 +84,7 @@ func (o *OCIDir) TagList(ctx context.Context, r ref.Ref, opts ...scheme.TagOpts)
 		tag.WithRaw(ib),
 		tag.WithRef(r),
 		tag.WithMT(types.MediaTypeOCI1ManifestList),
+		tag.WithLayoutIndex(index),
 		tag.WithTags(tl),
 	)
 	if err != nil {

--- a/types/tag/taglist.go
+++ b/types/tag/taglist.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/regclient/regclient/types"
+	ociv1 "github.com/regclient/regclient/types/oci/v1"
 	"github.com/regclient/regclient/types/ref"
 )
 
@@ -21,6 +22,7 @@ type List struct {
 	tagCommon
 	DockerList
 	GCRList
+	LayoutList
 }
 
 type tagCommon struct {
@@ -44,11 +46,17 @@ type GCRList struct {
 	Manifests map[string]GCRManifestInfo `json:"manifest,omitempty"`
 }
 
+// LayoutList includes the OCI Index from an OCI Layout
+type LayoutList struct {
+	Index ociv1.Index
+}
+
 type tagConfig struct {
 	ref    ref.Ref
 	mt     string
 	raw    []byte
 	header http.Header
+	index  ociv1.Index
 	tags   []string
 	url    *url.URL
 }
@@ -77,6 +85,9 @@ func New(opts ...Opts) (*List, error) {
 	if len(conf.tags) > 0 {
 		tl.Tags = conf.tags
 	}
+	if conf.index.Manifests != nil {
+		tl.LayoutList.Index = conf.index
+	}
 	if len(conf.raw) > 0 {
 		mt := types.MediaTypeBase(conf.mt)
 		switch mt {
@@ -100,6 +111,13 @@ func New(opts ...Opts) (*List, error) {
 func WithHeaders(header http.Header) Opts {
 	return func(tConf *tagConfig) {
 		tConf.header = header
+	}
+}
+
+// WithLayoutIndex include the index from an OCI Layout
+func WithLayoutIndex(index ociv1.Index) Opts {
+	return func(tConf *tagConfig) {
+		tConf.index = index
 	}
 }
 


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

There is no way to access the nested contents of an OCI Index from the tag listing.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This stores the index and exposes it as `{{.Index}}`.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
regctl tag ls ocidir://output/regctl --format '{{range $manifest := .Index.Manifests}}{{println $manifest.Digest}}{{end}}'
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Expose the underlying OCI Layout Index to `regctl tag ls --format`
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [ ] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
