### PR TITLE
Make mod time aware of base images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -153,7 +153,6 @@ jobs:
         echo "Modifying image for reproducibility"
         regctl image mod "${local_tag}" --replace \
           --to-oci-referrers \
-          --time-max "${vcs_date}" \
           --annotation "[*]org.opencontainers.image.created=${vcs_date}" \
           --annotation "[*]org.opencontainers.image.source=${{ steps.prep.outputs.repo_url }}" \
           --annotation "[*]org.opencontainers.image.version=${{ steps.prep.outputs.version }}" \
@@ -161,10 +160,13 @@ jobs:
         if [ -n "$base_name" ] && [ -n "$base_digest" ]; then
           regctl image mod "${local_tag}" --replace \
             --annotation "[*]org.opencontainers.image.base.name=${base_name}" \
-            --annotation "[*]org.opencontainers.image.base.digest=${base_digest}"
+            --annotation "[*]org.opencontainers.image.base.digest=${base_digest}" \
+            --time "set=${vcs_date},base-ref=${base_name}@${base_digest}"
+        else
+          regctl image mod "${local_tag}" --replace \
+            --time "set=${vcs_date}"
         fi
         echo "digest=$(regctl image digest ${local_tag})" >>$GITHUB_OUTPUT
-
     - name: Attach SBOMs
       if: github.event_name != 'pull_request' && github.repository_owner == 'regclient'
       id: sbom

--- a/build/oci-image.sh
+++ b/build/oci-image.sh
@@ -88,7 +88,6 @@ echo "Modding image"
 regctl image mod \
   "ocidir://output/${image}:${release}" --replace \
   --to-oci-referrers \
-  --time-max "${vcs_date}" \
   --annotation "[*]org.opencontainers.image.created=${vcs_date}" \
   --annotation "[*]org.opencontainers.image.source=${vcs_repo}" \
   --annotation "[*]org.opencontainers.image.version=${vcs_version}" \
@@ -100,6 +99,12 @@ if [ -n "$base_name" ] && [ -n "$base_digest" ]; then
     "ocidir://output/${image}:${release}" --replace \
     --annotation "[*]org.opencontainers.image.base.name=${base_name}" \
     --annotation "[*]org.opencontainers.image.base.digest=${base_digest}" \
+    --time "set=${vcs_date},base-ref=${base_name}@${base_digest}" \
+    >/dev/null
+else
+  regctl image mod \
+    "ocidir://output/${image}:${release}" --replace \
+    --time "set=${vcs_date}" \
     >/dev/null
 fi
 

--- a/cmd/regctl/image_test.go
+++ b/cmd/regctl/image_test.go
@@ -43,3 +43,22 @@ func TestImageExportImport(t *testing.T) {
 		t.Errorf("unexpected output: %v", out)
 	}
 }
+
+func TestImageMod(t *testing.T) {
+	tmpDir := t.TempDir()
+	srcRef := "ocidir://../../testdata/testrepo:v3"
+	baseRef := "ocidir://../../testdata/testrepo:b1"
+	modRef := fmt.Sprintf("ocidir://%s/repo:mod", tmpDir)
+	saveOpts := imageOpts
+
+	out, err := cobraTest(t, "image", "mod", srcRef, "--create", modRef, "--time", "set=2000-01-01T00:00:00Z,base-ref="+baseRef)
+	imageOpts = saveOpts
+	if err != nil {
+		t.Errorf("failed to run image import: %v", err)
+		return
+	}
+	if out == "" {
+		t.Errorf("missing output")
+	}
+
+}

--- a/mod/config.go
+++ b/mod/config.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/regclient/regclient"
+	"github.com/regclient/regclient/types"
+	"github.com/regclient/regclient/types/manifest"
 	"github.com/regclient/regclient/types/ref"
 )
 
@@ -50,7 +52,116 @@ func WithBuildArgRm(arg string, value *regexp.Regexp) Opts {
 	}
 }
 
+// WithConfigTimestamp sets the timestamp on the config entries based on options
+func WithConfigTimestamp(optTime OptTime) Opts {
+	return func(dc *dagConfig, dm *dagManifest) error {
+		if optTime.Set.IsZero() && optTime.FromLabel == "" {
+			return fmt.Errorf("WithConfigTimestamp requires a time to set")
+		}
+		dc.stepsOCIConfig = append(dc.stepsOCIConfig, func(c context.Context, rc *regclient.RegClient, rSrc, rTgt ref.Ref, doc *dagOCIConfig) error {
+			oc := doc.oc.GetConfig()
+			// lookup start time from label
+			if optTime.FromLabel != "" {
+				tl, ok := oc.Config.Labels[optTime.FromLabel]
+				if !ok {
+					return fmt.Errorf("label not found: %s", optTime.FromLabel)
+				}
+				tNew, err := time.Parse(time.RFC3339, tl)
+				if err != nil {
+					// TODO: add fallbacks
+					return fmt.Errorf("could not parse time %s from %s: %w", tl, optTime.FromLabel, err)
+				}
+				if !optTime.Set.IsZero() && !optTime.Set.Equal(tNew) {
+					return fmt.Errorf("conflicting time labels found %s and %s", optTime.Set.String(), tNew.String())
+				}
+				optTime.Set = tNew
+			}
+			startHistory := 0
+			// offset startHistory by base layer count
+			if optTime.BaseLayers > 0 {
+				layersCount := 0
+				for i, history := range oc.History {
+					if !history.EmptyLayer {
+						layersCount++
+					}
+					if layersCount == optTime.BaseLayers {
+						startHistory = i + 1
+						break
+					}
+				}
+				if startHistory == 0 {
+					startHistory = len(oc.History)
+				}
+			}
+			// offset startHistory from base image history
+			if !optTime.BaseRef.IsZero() {
+				var d types.Descriptor
+				for {
+					mOpts := []regclient.ManifestOpts{}
+					if d.Digest != "" {
+						mOpts = append(mOpts, regclient.WithManifestDesc(d))
+					}
+					m, err := rc.ManifestGet(c, optTime.BaseRef, mOpts...)
+					if err != nil {
+						return fmt.Errorf("unable to get base image: %w", err)
+					}
+					if mi, ok := m.(manifest.Imager); ok {
+						cd, err := mi.GetConfig()
+						if err != nil {
+							return fmt.Errorf("unable to get base image config descriptor: %w", err)
+						}
+						d = cd
+						break
+					} else if _, ok := m.(manifest.Indexer); ok {
+						pd, err := manifest.GetPlatformDesc(m, &oc.Platform)
+						if err != nil {
+							return fmt.Errorf("unable to get base image platform %s: %w", oc.Platform.String(), err)
+						}
+						d = *pd
+					} else {
+						return fmt.Errorf("unsupported base image manifest")
+					}
+				}
+				baseConfig, err := rc.BlobGetOCIConfig(c, optTime.BaseRef, d)
+				if err != nil {
+					return fmt.Errorf("failed to get base image config: %w", err)
+				}
+				// exclude matching history lines from base image
+				for i, history := range baseConfig.GetConfig().History {
+					if len(oc.History) <= i ||
+						oc.History[i].Author != history.Author ||
+						oc.History[i].Comment != history.Comment ||
+						!oc.History[i].Created.Equal(*history.Created) ||
+						oc.History[i].CreatedBy != history.CreatedBy ||
+						oc.History[i].EmptyLayer != history.EmptyLayer {
+						break
+					}
+					startHistory = i + 1
+				}
+			}
+			var changed, cCur bool
+			// adjust created time on created and history fields
+			if oc.Created != nil {
+				*oc.Created, changed = timeModOpt(*oc.Created, optTime)
+			}
+			for i := startHistory; i < len(oc.History); i++ {
+				*oc.History[i].Created, cCur = timeModOpt(*oc.History[i].Created, optTime)
+				changed = changed || cCur
+			}
+			if changed {
+				doc.oc.SetConfig(oc)
+				doc.newDesc = doc.oc.GetDescriptor()
+				doc.modified = true
+			}
+			return nil
+		})
+		return nil
+	}
+}
+
 // WithConfigTimestampFromLabel sets the max timestamp in the config to match a label value
+//
+// Deprecated: replace with WithConfigTimestamp
 func WithConfigTimestampFromLabel(label string) Opts {
 	return func(dc *dagConfig, dm *dagManifest) error {
 		dc.stepsOCIConfig = append(dc.stepsOCIConfig, func(c context.Context, rc *regclient.RegClient, rSrc, rTgt ref.Ref, doc *dagOCIConfig) error {
@@ -90,32 +201,13 @@ func WithConfigTimestampFromLabel(label string) Opts {
 }
 
 // WithConfigTimestampMax sets the max timestamp on any config objects
+//
+// Deprecated: replace with WithConfigTimestamp
 func WithConfigTimestampMax(t time.Time) Opts {
-	return func(dc *dagConfig, dm *dagManifest) error {
-		dc.stepsOCIConfig = append(dc.stepsOCIConfig, func(c context.Context, rc *regclient.RegClient, rSrc, rTgt ref.Ref, doc *dagOCIConfig) error {
-			changed := false
-			oc := doc.oc.GetConfig()
-			if oc.Created != nil && t.Before(*oc.Created) {
-				*oc.Created = t
-				changed = true
-			}
-			if oc.History != nil {
-				for i, h := range oc.History {
-					if h.Created != nil && t.Before(*h.Created) {
-						*oc.History[i].Created = t
-						changed = true
-					}
-				}
-			}
-			if changed {
-				doc.oc.SetConfig(oc)
-				doc.newDesc = doc.oc.GetDescriptor()
-				doc.modified = true
-			}
-			return nil
-		})
-		return nil
-	}
+	return WithConfigTimestamp(OptTime{
+		Set:   t,
+		After: t,
+	})
 }
 
 // WithExposeAdd defines an exposed port in the image config

--- a/mod/dag.go
+++ b/mod/dag.go
@@ -441,14 +441,14 @@ func dagWalkManifests(dm *dagManifest, fn func(*dagManifest) (*dagManifest, erro
 			}
 		}
 	}
-	if dm.referrers != nil {
-		for _, child := range dm.referrers {
-			err := dagWalkManifests(child, fn)
-			if err != nil {
-				return err
-			}
-		}
-	}
+	// if dm.referrers != nil {
+	// 	for _, child := range dm.referrers {
+	// 		err := dagWalkManifests(child, fn)
+	// 		if err != nil {
+	// 			return err
+	// 		}
+	// 	}
+	// }
 	mmNew, err := fn(dm)
 	if err != nil {
 		return err
@@ -466,14 +466,14 @@ func dagWalkOCIConfig(dm *dagManifest, fn func(*dagOCIConfig) (*dagOCIConfig, er
 			}
 		}
 	}
-	if dm.referrers != nil {
-		for _, child := range dm.referrers {
-			err := dagWalkOCIConfig(child, fn)
-			if err != nil {
-				return err
-			}
-		}
-	}
+	// if dm.referrers != nil {
+	// 	for _, child := range dm.referrers {
+	// 		err := dagWalkOCIConfig(child, fn)
+	// 		if err != nil {
+	// 			return err
+	// 		}
+	// 	}
+	// }
 	if dm.config != nil {
 		docNew, err := fn(dm.config)
 		if err != nil {
@@ -494,14 +494,14 @@ func dagWalkLayers(dm *dagManifest, fn func(*dagLayer) (*dagLayer, error)) error
 			}
 		}
 	}
-	if dm.referrers != nil {
-		for _, child := range dm.referrers {
-			err = dagWalkLayers(child, fn)
-			if err != nil {
-				return err
-			}
-		}
-	}
+	// if dm.referrers != nil {
+	// 	for _, child := range dm.referrers {
+	// 		err = dagWalkLayers(child, fn)
+	// 		if err != nil {
+	// 			return err
+	// 		}
+	// 	}
+	// }
 	if dm.layers != nil {
 		for i, layer := range dm.layers {
 			if layer.mod == deleted {

--- a/mod/mod.go
+++ b/mod/mod.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"io"
 	"os"
+	"time"
 
 	"github.com/opencontainers/go-digest"
 	"github.com/regclient/regclient"
@@ -17,6 +18,15 @@ import (
 
 // Opts defines options for Apply
 type Opts func(*dagConfig, *dagManifest) error
+
+// OptTime defines time settings for WithConfigTimestamp and WithLayerTimestamp
+type OptTime struct {
+	Set        time.Time // time to set, this or FromLabel are required
+	FromLabel  string    // label from which to extract set time
+	After      time.Time // only change times that are after this
+	BaseRef    ref.Ref   // define base image, do not alter timestamps from base layers
+	BaseLayers int       // define a number of layers to not modify (count of the layers in a base image)
+}
 
 var (
 	// whitelist of tar media types

--- a/mod/mod_test.go
+++ b/mod/mod_test.go
@@ -236,6 +236,74 @@ func TestMod(t *testing.T) {
 			wantSame: true,
 		},
 		{
+			name: "Config Time Missing Set",
+			opts: []Opts{
+				WithConfigTimestamp(OptTime{}),
+			},
+			ref:     "ocidir://testrepo:v1",
+			wantErr: fmt.Errorf("WithConfigTimestamp requires a time to set"),
+		},
+		{
+			name: "Config Time Set",
+			opts: []Opts{
+				WithConfigTimestamp(OptTime{
+					Set: tTime,
+				}),
+			},
+			ref: "ocidir://testrepo:v1",
+		},
+		{
+			name: "Config Time Base Ref",
+			opts: []Opts{
+				WithConfigTimestamp(OptTime{
+					Set:     tTime,
+					BaseRef: rb1,
+				}),
+			},
+			ref: "ocidir://testrepo:v3",
+		},
+		{
+			name: "Config Time Base Count",
+			opts: []Opts{
+				WithConfigTimestamp(OptTime{
+					Set:        tTime,
+					BaseLayers: 1,
+				}),
+			},
+			ref: "ocidir://testrepo:v3",
+		},
+		{
+			name: "Config Time Label Missing",
+			opts: []Opts{
+				WithConfigTimestamp(OptTime{
+					FromLabel: "org.opencontainers.image.created",
+				}),
+			},
+			ref:     "ocidir://testrepo:v1",
+			wantErr: fmt.Errorf("label not found: org.opencontainers.image.created"),
+		},
+		{
+			name: "Config Time Artifact",
+			opts: []Opts{
+				WithConfigTimestamp(OptTime{
+					Set: tTime,
+				}),
+			},
+			ref:      "ocidir://testrepo:a1",
+			wantSame: true,
+		},
+		{
+			name: "Config Time After Unchanged",
+			opts: []Opts{
+				WithConfigTimestamp(OptTime{
+					Set:   tTime,
+					After: time.Now(),
+				}),
+			},
+			ref:      "ocidir://testrepo:v1",
+			wantSame: true,
+		},
+		{
 			name: "Expose Port",
 			opts: []Opts{
 				WithExposeAdd("8080"),
@@ -303,6 +371,97 @@ func TestMod(t *testing.T) {
 				WithLayerStripFile("/layer2"),
 			},
 			ref: "ocidir://testrepo:v3",
+		},
+		{
+			name: "Layer Timestamp Set Missing",
+			opts: []Opts{
+				WithLayerTimestamp(OptTime{}),
+			},
+			ref:     "ocidir://testrepo:v1",
+			wantErr: fmt.Errorf("WithLayerTimestamp requires a time to set"),
+		},
+		{
+			name: "Layer Timestamp Missing Label",
+			opts: []Opts{
+				WithLayerTimestamp(OptTime{
+					FromLabel: "missing",
+				}),
+			},
+			ref:     "ocidir://testrepo:v1",
+			wantErr: fmt.Errorf("label not found: missing"),
+		},
+		{
+			name: "Layer Timestamp",
+			opts: []Opts{
+				WithLayerTimestamp(OptTime{
+					Set: tTime,
+				}),
+			},
+			ref: "ocidir://testrepo:v1",
+		},
+		{
+			name: "Layer Timestamp After Unchanged",
+			opts: []Opts{
+				WithLayerTimestamp(OptTime{
+					Set:   tTime,
+					After: time.Now(),
+				}),
+			},
+			ref:      "ocidir://testrepo:v1",
+			wantSame: true,
+		},
+		{
+			name: "Layer Timestamp Base Ref",
+			opts: []Opts{
+				WithLayerTimestamp(OptTime{
+					Set:     tTime,
+					BaseRef: rb1,
+				}),
+			},
+			ref: "ocidir://testrepo:v3",
+		},
+		{
+			name: "Layer Timestamp Base Ref Same",
+			opts: []Opts{
+				WithLayerTimestamp(OptTime{
+					Set:     tTime,
+					BaseRef: r3,
+				}),
+			},
+			ref:      "ocidir://testrepo:v3",
+			wantSame: true,
+		},
+		{
+			name: "Layer Timestamp Base Count Same",
+			opts: []Opts{
+				WithLayerTimestamp(OptTime{
+					Set:        tTime,
+					BaseLayers: 99,
+				}),
+			},
+			ref:      "ocidir://testrepo:v3",
+			wantSame: true,
+		},
+		{
+			name: "Layer Timestamp Base Count",
+			opts: []Opts{
+				WithLayerTimestamp(OptTime{
+					Set:        tTime,
+					BaseLayers: 1,
+				}),
+			},
+			ref: "ocidir://testrepo:v3",
+		},
+		{
+			name: "Layer Timestamp Artifact",
+			opts: []Opts{
+				WithLayerTimestamp(OptTime{
+					Set:   tTime,
+					After: tTime,
+				}),
+			},
+			ref:      "ocidir://testrepo:a1",
+			wantSame: true,
 		},
 		{
 			name: "Layer File Tar Timestamp",

--- a/mod/time.go
+++ b/mod/time.go
@@ -33,3 +33,15 @@ func timeEpocEnv() (time.Time, error) {
 	}
 	return time.Unix(secI, 0), nil
 }
+
+// timeModOpt adjusts time t according to the opts.
+// The bool indicates if the time was changed.
+func timeModOpt(t time.Time, opt OptTime) (time.Time, bool) {
+	if !opt.After.IsZero() && !t.After(opt.After) {
+		return t, false
+	}
+	if !t.Equal(opt.Set) {
+		return opt.Set, true
+	}
+	return t, false
+}


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Changing timestamps by a "max time" option is limited. It doesn't allow times to be moved forward. And it could conflict with base images, particularly after rebasing on a newer base image.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Make the image mod timestamp methods aware of base images and allow those to be excluded from updates. Then allow timestamps to be set to a specific value, which can adjust the time either forward or backwards.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Build of regclient reproducible images have been updated.

```shell
regctl image mod --help
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Image mod of timestamps is now aware of base images.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
