### PR TITLE
Add a layer mod for reproducibility

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -161,9 +161,11 @@ jobs:
           regctl image mod "${local_tag}" --replace \
             --annotation "[*]org.opencontainers.image.base.name=${base_name}" \
             --annotation "[*]org.opencontainers.image.base.digest=${base_digest}" \
+            --reproducible \
             --time "set=${vcs_date},base-ref=${base_name}@${base_digest}"
         else
           regctl image mod "${local_tag}" --replace \
+            --reproducible \
             --time "set=${vcs_date}"
         fi
         echo "digest=$(regctl image digest ${local_tag})" >>$GITHUB_OUTPUT

--- a/build/oci-image.sh
+++ b/build/oci-image.sh
@@ -99,11 +99,13 @@ if [ -n "$base_name" ] && [ -n "$base_digest" ]; then
     "ocidir://output/${image}:${release}" --replace \
     --annotation "[*]org.opencontainers.image.base.name=${base_name}" \
     --annotation "[*]org.opencontainers.image.base.digest=${base_digest}" \
+    --reproducible \
     --time "set=${vcs_date},base-ref=${base_name}@${base_digest}" \
     >/dev/null
 else
   regctl image mod \
     "ocidir://output/${image}:${release}" --replace \
+    --reproducible \
     --time "set=${vcs_date}" \
     >/dev/null
 fi

--- a/cmd/regctl/image.go
+++ b/cmd/regctl/image.go
@@ -510,6 +510,20 @@ func init() {
 			return nil
 		},
 	}, "rebase-ref", "", `rebase an image with base references (base:old,base:new)`)
+	flagReproducible := imageModCmd.Flags().VarPF(&modFlagFunc{
+		t: "bool",
+		f: func(val string) error {
+			b, err := strconv.ParseBool(val)
+			if err != nil {
+				return fmt.Errorf("unable to parse value %s: %w", val, err)
+			}
+			if b {
+				imageOpts.modOpts = append(imageOpts.modOpts, mod.WithLayerReproducible())
+			}
+			return nil
+		},
+	}, "reproducible", "", `fix tar headers for reproducibility`)
+	flagReproducible.NoOptDefVal = "true"
 	imageModCmd.Flags().VarP(&modFlagFunc{
 		t: "string",
 		f: func(val string) error {

--- a/mod/layer.go
+++ b/mod/layer.go
@@ -17,6 +17,30 @@ import (
 	"github.com/regclient/regclient/types/ref"
 )
 
+// WithLayerReproducible modifies the layer with reproducible options.
+// This currently configures users and groups with numeric ids.
+func WithLayerReproducible() Opts {
+	return func(dc *dagConfig, dm *dagManifest) error {
+		dc.stepsLayerFile = append(dc.stepsLayerFile,
+			func(c context.Context, rc *regclient.RegClient, rSrc, rTgt ref.Ref, dl *dagLayer, th *tar.Header, tr io.Reader) (*tar.Header, io.Reader, changes, error) {
+				changed := false
+				if th.Uname != "" {
+					th.Uname = ""
+					changed = true
+				}
+				if th.Gname != "" {
+					th.Gname = ""
+					changed = true
+				}
+				if changed {
+					return th, tr, replaced, nil
+				}
+				return th, tr, unchanged, nil
+			})
+		return nil
+	}
+}
+
 // WithLayerRmCreatedBy deletes a layer based on a regex of the created by field
 // in the config history for that layer
 func WithLayerRmCreatedBy(re regexp.Regexp) Opts {

--- a/mod/mod_test.go
+++ b/mod/mod_test.go
@@ -335,6 +335,13 @@ func TestMod(t *testing.T) {
 			wantSame: true,
 		},
 		{
+			name: "Layer Reproducible",
+			opts: []Opts{
+				WithLayerReproducible(),
+			},
+			ref: "ocidir://testrepo:v3",
+		},
+		{
 			name: "Layer Timestamp Missing Label",
 			opts: []Opts{
 				WithLayerTimestampFromLabel("missing"),


### PR DESCRIPTION
This currently reverts files back to numeric ids, fixing an issue seen in some image builders.

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

The reproducible build is broken depending on the local version of buildkit.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This adds a method to remove the username/groupname from the image layers, reverting to numeric ids.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
make oci-image
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Add reproducible method / option to image mod.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
