### PR TITLE
Refactoring mod of Docker to OCI referrers

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -152,7 +152,8 @@ jobs:
         regctl image import "${local_tag}" "output/${{matrix.image}}-${{matrix.type}}.tar"
         echo "Modifying image for reproducibility"
         regctl image mod "${local_tag}" --replace \
-          --to-oci-referrers \
+          --to-oci-referrers
+        regctl image mod "${local_tag}" --replace \
           --annotation "[*]org.opencontainers.image.created=${vcs_date}" \
           --annotation "[*]org.opencontainers.image.source=${{ steps.prep.outputs.repo_url }}" \
           --annotation "[*]org.opencontainers.image.version=${{ steps.prep.outputs.version }}" \

--- a/build/oci-image.sh
+++ b/build/oci-image.sh
@@ -87,7 +87,9 @@ regctl image import "ocidir://output/${image}:${release}" "output/${image}-${rel
 echo "Modding image"
 regctl image mod \
   "ocidir://output/${image}:${release}" --replace \
-  --to-oci-referrers \
+  --to-oci-referrers
+regctl image mod \
+  "ocidir://output/${image}:${release}" --replace \
   --annotation "[*]org.opencontainers.image.created=${vcs_date}" \
   --annotation "[*]org.opencontainers.image.source=${vcs_repo}" \
   --annotation "[*]org.opencontainers.image.version=${vcs_version}" \


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

The image mod is changing the contents of the Docker build attestation.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This refactors the process to use the embedded DAG. This also changes the image build to separate out the conversion since changes are made depth first and conversion of referrers runs on the parent node, so referrers will always be converted after the referrer manifest is changed.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
make oci-image
```

<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Avoid changing docker build attestations when converting to referrers
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
