### PR TITLE
Image mod: set labels for specific platforms

### DIFF
--- a/cmd/regctl/image.go
+++ b/cmd/regctl/image.go
@@ -400,7 +400,7 @@ func init() {
 			}
 			return nil
 		},
-	}, "label", "", `set an label (name=value)`)
+	}, "label", "", `set an label (name=value, omit value to delete, prefix with platform list [p1,p2] for subset of images)`)
 	flagLabelAnnot := imageModCmd.Flags().VarPF(&modFlagFunc{
 		t: "bool",
 		f: func(val string) error {

--- a/mod/mod_test.go
+++ b/mod/mod_test.go
@@ -198,6 +198,51 @@ func TestMod(t *testing.T) {
 			ref: "ocidir://testrepo:v1",
 		},
 		{
+			name: "Add Label to All",
+			opts: []Opts{
+				WithLabel("[*]test", "hello"),
+			},
+			ref: "ocidir://testrepo:v1",
+		},
+		{
+			name: "Add Label AMD64/ARM64",
+			opts: []Opts{
+				WithLabel("[linux/amd64,linux/arm64]test", "hello"),
+			},
+			ref: "ocidir://testrepo:v1",
+		},
+		{
+			name: "Add Label Missing",
+			opts: []Opts{
+				WithLabel("[linux/i386,linux/s390x]test", "hello"),
+			},
+			ref:      "ocidir://testrepo:v1",
+			wantSame: true,
+		},
+		{
+			name: "Add Label Platform Parse Error",
+			opts: []Opts{
+				WithLabel("[linux/invalid.arch!]test", "hello"),
+			},
+			ref:     "ocidir://testrepo:v1",
+			wantErr: fmt.Errorf("failed to parse label platform linux/invalid.arch!: invalid platform component invalid.arch! in linux/invalid.arch!"),
+		},
+		{
+			name: "Delete Label",
+			opts: []Opts{
+				WithLabel("version", ""),
+			},
+			ref: "ocidir://testrepo:v1",
+		},
+		{
+			name: "Delete Missing Label",
+			opts: []Opts{
+				WithLabel("[*]missing", ""),
+			},
+			ref:      "ocidir://testrepo:v1",
+			wantSame: true,
+		},
+		{
 			name: "Label to Annotation",
 			opts: []Opts{
 				WithLabelToAnnotation(),


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This allows labels to be set for specific platforms with `regctl image mod` by prefixing the label name with an array of platforms.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
regctl image mod --label '[linux/amd64]key=value' $image --create mod
```

<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Support setting labels on specific platforms with image mod.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
