### PR TITLE
Adds a WithFileTarTime method

### DIFF
--- a/cmd/regctl/image_test.go
+++ b/cmd/regctl/image_test.go
@@ -54,11 +54,10 @@ func TestImageMod(t *testing.T) {
 	out, err := cobraTest(t, "image", "mod", srcRef, "--create", modRef, "--time", "set=2000-01-01T00:00:00Z,base-ref="+baseRef)
 	imageOpts = saveOpts
 	if err != nil {
-		t.Errorf("failed to run image import: %v", err)
+		t.Errorf("failed to run image mod: %v", err)
 		return
 	}
 	if out == "" {
 		t.Errorf("missing output")
 	}
-
 }

--- a/mod/mod_test.go
+++ b/mod/mod_test.go
@@ -516,16 +516,47 @@ func TestMod(t *testing.T) {
 			wantSame: true,
 		},
 		{
-			name: "Layer File Tar Timestamp",
+			name: "Layer File Tar Time Max",
 			opts: []Opts{
 				WithFileTarTimeMax("/dir/layer.tar", tTime),
 			},
 			ref: "ocidir://testrepo:v3",
 		},
 		{
-			name: "Layer File Tar Timestamp Unchanged",
+			name: "Layer File Tar Time Max Unchanged",
 			opts: []Opts{
 				WithFileTarTimeMax("/dir/layer.tar", time.Now()),
+			},
+			ref:      "ocidir://testrepo:v3",
+			wantSame: true,
+		},
+		{
+			name: "Layer File Tar Time",
+			opts: []Opts{
+				WithFileTarTime("/dir/layer.tar", OptTime{
+					Set:     tTime,
+					BaseRef: rb1,
+				}),
+			},
+			ref: "ocidir://testrepo:v3",
+		},
+		{
+			name: "Layer File Tar Time After",
+			opts: []Opts{
+				WithFileTarTime("/dir/layer.tar", OptTime{
+					Set:   tTime,
+					After: tTime,
+				}),
+			},
+			ref: "ocidir://testrepo:v3",
+		},
+		{
+			name: "Layer File Tar Time Same Base",
+			opts: []Opts{
+				WithFileTarTime("/dir/layer.tar", OptTime{
+					Set:     tTime,
+					BaseRef: r3,
+				}),
 			},
 			ref:      "ocidir://testrepo:v3",
 			wantSame: true,


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This replaces `WithFileTarTimeMax` with a version that recognizes base image layers, and has more options to setting the time.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
regctl image mod --create ocidir:///tmp/regctl-test:mod \
  --file-tar-time filename=dir/layer.tar,set=2020-01-01T12:00:00Z,base-ref=ocidir://testdata/testrepo:b1 \
  ocidir://testdata/testrepo:v3
```

<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Add `WithFileTarTime` method and `regctl image mod --file-tar-time` option to edit timestamps inside tar files.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
