### PR TITLE
Support digest-tags in artifact list and tree

### DIFF
--- a/cmd/regctl/artifact_test.go
+++ b/cmd/regctl/artifact_test.go
@@ -12,6 +12,83 @@ import (
 	"github.com/regclient/regclient/types"
 )
 
+func TestArtifactList(t *testing.T) {
+	saveArtifactOpts := artifactOpts
+	tt := []struct {
+		name        string
+		args        []string
+		expectErr   error
+		expectOut   string
+		outContains bool
+	}{
+		{
+			name:      "Missing arg",
+			args:      []string{"artifact", "list"},
+			expectErr: fmt.Errorf("accepts 1 arg(s), received 0"),
+		},
+		{
+			name:      "Invalid ref",
+			args:      []string{"artifact", "list", "invalid*ref"},
+			expectErr: types.ErrInvalidReference,
+		},
+		{
+			name:      "Missing manifest",
+			args:      []string{"artifact", "list", "ocidir://../../testdata/testrepo:missing"},
+			expectErr: types.ErrNotFound,
+		},
+		{
+			name:        "No referrers",
+			args:        []string{"artifact", "list", "ocidir://../../testdata/testrepo:v1"},
+			expectOut:   "Referrers:",
+			outContains: true,
+		},
+		{
+			name:        "Referrers",
+			args:        []string{"artifact", "list", "ocidir://../../testdata/testrepo:v2"},
+			expectOut:   "Referrers:",
+			outContains: true,
+		},
+		{
+			name:        "With Digest Tags",
+			args:        []string{"artifact", "list", "ocidir://../../testdata/testrepo:v2", "--digest-tags"},
+			expectOut:   "Referrers:",
+			outContains: true,
+		},
+		{
+			name:        "Filter",
+			args:        []string{"artifact", "list", "ocidir://../../testdata/testrepo:v2", "--filter-artifact-type", "application/example.sbom"},
+			expectOut:   "application/example.sbom",
+			outContains: true,
+		},
+		{
+			name:      "Filter and Format",
+			args:      []string{"artifact", "list", "ocidir://../../testdata/testrepo:v2", "--filter-artifact-type", "application/example.sbom", "--format", "{{ ( index .Descriptors 0 ).ArtifactType }}"},
+			expectOut: "application/example.sbom",
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := cobraTest(t, tc.args...)
+			artifactOpts = saveArtifactOpts
+			if tc.expectErr != nil {
+				if err == nil {
+					t.Errorf("did not receive expected error: %v", tc.expectErr)
+				} else if !errors.Is(err, tc.expectErr) && err.Error() != tc.expectErr.Error() {
+					t.Errorf("unexpected error, received %v, expected %v", err, tc.expectErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("returned unexpected error: %v", err)
+				return
+			}
+			if (!tc.outContains && out != tc.expectOut) || (tc.outContains && !strings.Contains(out, tc.expectOut)) {
+				t.Errorf("unexpected output, expected %s, received %s", tc.expectOut, out)
+			}
+		})
+	}
+}
+
 func TestArtifactPut(t *testing.T) {
 	testDir := t.TempDir()
 	testData := []byte("hello world")
@@ -136,6 +213,12 @@ func TestArtifactTree(t *testing.T) {
 		{
 			name:        "Referrers",
 			args:        []string{"artifact", "tree", "ocidir://../../testdata/testrepo:v2"},
+			expectOut:   "Referrers",
+			outContains: true,
+		},
+		{
+			name:        "With Digest Tags",
+			args:        []string{"artifact", "tree", "ocidir://../../testdata/testrepo:v2", "--digest-tags"},
 			expectOut:   "Referrers",
 			outContains: true,
 		},


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Describe the change

This adds support for showing digest-tags (i.e. those used by sigstore) in the `regctl artifact list` and `regctl artifact tree` output.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
regctl artifact list --platform local --digest-tags ghcr.io/regclient/regctl:edge
regctl artifact tree --digest-tags ghcr.io/regclient/regctl:edge
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Support digest-tags in artifact list and tree output
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
