### PR TITLE
Add xz format support to compression.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.7.0
+	github.com/ulikunitz/xz v0.5.11
 	github.com/yuin/gopher-lua v1.1.0
 	golang.org/x/sys v0.12.0
 	golang.org/x/term v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/ulikunitz/xz v0.5.11 h1:kpFauv27b6ynzBNT/Xy+1k+fK4WswhN/6PN5WhFAGw8=
+github.com/ulikunitz/xz v0.5.11/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/yuin/gopher-lua v1.1.0 h1:BojcDhfyDWgU2f2TOzYK/g5p2gxMrku8oupLDqlnSqE=
 github.com/yuin/gopher-lua v1.1.0/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/pkg/archive/compress.go
+++ b/pkg/archive/compress.go
@@ -6,6 +6,8 @@ import (
 	"compress/bzip2"
 	"compress/gzip"
 	"io"
+
+	"github.com/ulikunitz/xz"
 )
 
 // CompressType identifies the detected compression type
@@ -46,6 +48,9 @@ func Compress(r io.Reader, oComp CompressType) (io.Reader, error) {
 			return compressGzip(br)
 		case CompressBzip2:
 			return compressGzip(bzip2.NewReader(br))
+		case CompressXz:
+			cbr, _ := xz.NewReader(br)
+			return compressGzip(cbr)
 		}
 	}
 	// No other types currently supported
@@ -79,7 +84,7 @@ func Decompress(r io.Reader) (io.Reader, error) {
 	case CompressGzip:
 		return gzip.NewReader(br)
 	case CompressXz:
-		return br, ErrXzUnsupported
+		return xz.NewReader(br)
 	default:
 		return br, nil
 	}


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Add xz support for compression module, allowing import xz compressed tar file.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Add support for decompressing xz layers
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [ ] Tests have been added or not applicable
- [x] Documentation has been added, updated, or not applicable
- [x] Changes have been rebased to main
- [x] Multiple commits to the same code have been squashed
