### PR TITLE
Add support for repo filters in regsync

### DIFF
--- a/cmd/regsync/config.go
+++ b/cmd/regsync/config.go
@@ -63,7 +63,8 @@ type ConfigSync struct {
 	Source          string                 `yaml:"source" json:"source"`
 	Target          string                 `yaml:"target" json:"target"`
 	Type            string                 `yaml:"type" json:"type"`
-	Tags            ConfigTags             `yaml:"tags" json:"tags"`
+	Tags            AllowDeny              `yaml:"tags" json:"tags"`
+	Repos           AllowDeny              `yaml:"repos" json:"repos"`
 	DigestTags      *bool                  `yaml:"digestTags" json:"digestTags"`
 	Referrers       *bool                  `yaml:"referrers" json:"referrers"`
 	ReferrerFilters []ConfigReferrerFilter `yaml:"referrerFilters" json:"referrerFilters"`
@@ -80,8 +81,8 @@ type ConfigSync struct {
 	Hooks           ConfigHooks            `yaml:"hooks" json:"hooks"`
 }
 
-// ConfigTags is an allow and deny list of tag regex strings
-type ConfigTags struct {
+// AllowDeny is an allow and deny list of regex strings
+type AllowDeny struct {
 	Allow []string `yaml:"allow" json:"allow"`
 	Deny  []string `yaml:"deny" json:"deny"`
 }

--- a/cmd/regsync/regsync_test.go
+++ b/cmd/regsync/regsync_test.go
@@ -282,7 +282,7 @@ func TestProcess(t *testing.T) {
 				Source: "ocidir://testrepo",
 				Target: "ocidir://test3",
 				Type:   "repository",
-				Tags: ConfigTags{
+				Tags: AllowDeny{
 					Allow: []string{"v1", "v3", "latest"},
 				},
 			},
@@ -305,7 +305,7 @@ func TestProcess(t *testing.T) {
 				Source: "ocidir://testrepo",
 				Target: "ocidir://test4",
 				Type:   "repository",
-				Tags: ConfigTags{
+				Tags: AllowDeny{
 					Deny: []string{"v2", "old"},
 				},
 			},
@@ -379,7 +379,7 @@ func TestProcess(t *testing.T) {
 				Source: "ocidir://testrepo",
 				Target: "ocidir://test-missing",
 				Type:   "repository",
-				Tags: ConfigTags{
+				Tags: AllowDeny{
 					Allow: []string{"v1", "v2", "v3", "latest"},
 				},
 			},

--- a/docs/regsync.md
+++ b/docs/regsync.md
@@ -81,6 +81,11 @@ sync:
   - source: localreg:5000
     target: localcopy:5000
     type: registry
+    repos:
+      allow:
+      - "team-x\/.*"
+      deny:
+      - ".*backup"
 ```
 
 - `version`:
@@ -220,6 +225,12 @@ sync:
     "registry", "repository", or "image".
     "registry" expects a registry name (host:port) and will copy every repository.
     "repository" will copy all tags from the source repository.
+  - `repos`:
+    Implements filters on repositories for "registry" types, regex values are automatically bound to the beginning and ending of each string (`^` and `$`).
+    - `allow`:
+      (array of strings) regex to allow specific repositories.
+    - `deny`:
+      (array of strings) regex to deny specific repositories.
   - `tags`:
     Implements filters on tags for "registry" and "repository" types, regex values are automatically bound to the beginning and ending of each string (`^` and `$`).
     - `allow`:


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Fixes #533
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This adds a `repos` filter similar to the `tags` filter when copying registries with regsync.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

With a registry that supports the `_catalog` API, a regsync config like the following:

```yaml
sync:
  - source: localreg:5000
    target: localcopy:5000
    type: registry
    repos:
      allow:
      - "team-x\\/.*"
      deny:
      - ".*backup"
```

Would copy every repo under `team-x` excluding any repo name that ends in `backup`.

<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Add repo filters to regsync when copying registries
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->
Because `_catalog` is not supported on many registries, and not implemented with `ocidir`, tests are not yet available for this.

- [ ] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
