### PR TITLE
Support pushing artifact as index entry

### DIFF
--- a/cmd/regctl/artifact_test.go
+++ b/cmd/regctl/artifact_test.go
@@ -206,6 +206,16 @@ func TestArtifactPut(t *testing.T) {
 			args: []string{"artifact", "put", "--artifact-type", "application/vnd.example", "--config-file", "", "--subject", "ocidir://" + testDir + ":put-example-at"},
 			in:   testData,
 		},
+		{
+			name: "Put create index",
+			args: []string{"artifact", "put", "--artifact-type", "application/vnd.example", "--config-file", "", "--annotation", "test=a", "--platform", "linux/amd64", "--index", "ocidir://" + testDir + ":index"},
+			in:   testData,
+		},
+		{
+			name: "Put append index",
+			args: []string{"artifact", "put", "--artifact-type", "application/vnd.example", "--config-file", "", "--annotation", "test=b", "--platform", "linux/arm64", "--index", "ocidir://" + testDir + ":index"},
+			in:   testData,
+		},
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This allows artifacts to be pushed as entries to an index using the `regctl artifact put --index` flag.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
$ echo oatmeal and orange juice \
  | regctl artifact put --annotation meal=breakfast --platform linux/amd64 \
    --artifact-type application/example.fbom --index ocidir://test/fbom:index

$ echo turkey sandwitch, bananna, and water \
  | regctl artifact put --annotation meal=lunch --platform linux/arm64 \
    --artifact-type application/example.fbom --index ocidir://test/fbom:index

$ regctl manifest get ocidir://test/fbom:index
Name:           ocidir://test/fbom:index
MediaType:      application/vnd.oci.image.index.v1+json
Digest:         sha256:95cb8dbe5267ac9ce1ea40dd2398771c46b6777a6981577e38a211fdfdb03c02
                
Manifests:      
                
  Name:         ocidir://test/fbom:index@sha256:6902eff9fb77c9f8247d7ee6615756e986ac305ced37b07bb6f37eaf495193d5
  Digest:       sha256:6902eff9fb77c9f8247d7ee6615756e986ac305ced37b07bb6f37eaf495193d5
  MediaType:    application/vnd.oci.image.manifest.v1+json
  ArtifactType: application/example.fbom
  Platform:     linux/amd64
  Annotations:  
    meal:       breakfast
                
  Name:         ocidir://test/fbom:index@sha256:5eaf4cb75485a03cdfcc90c5ddfbcd63d1381dac35e55cce19c13b4a1d624430
  Digest:       sha256:5eaf4cb75485a03cdfcc90c5ddfbcd63d1381dac35e55cce19c13b4a1d624430
  MediaType:    application/vnd.oci.image.manifest.v1+json
  ArtifactType: application/example.fbom
  Platform:     linux/arm64
  Annotations:  
    meal:       lunch

$ regctl artifact get --filter-artifact-type application/example.fbom --filter-annotation meal=breakfast ocidir://test/fbom:index
oatmeal and orange juice
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Support pushing artifact to an index entry with `regctl artifact put --index`
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
