### PR TITLE
Refactoring cobra commands to remove globals

### DIFF
--- a/cmd/regbot/main.go
+++ b/cmd/regbot/main.go
@@ -23,7 +23,8 @@ func main() {
 	}()
 	godbg.SignalTrace()
 
-	if err := rootCmd.ExecuteContext(ctx); err != nil {
+	rootTopCmd := NewRootCmd()
+	if err := rootTopCmd.ExecuteContext(ctx); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}

--- a/cmd/regbot/regbot_test.go
+++ b/cmd/regbot/regbot_test.go
@@ -154,8 +154,10 @@ func TestRegbot(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rootOpts.dryRun = tt.dryrun
-			err = tt.script.process(ctx)
+			rootOpts := rootCmd{
+				dryRun: tt.dryrun,
+			}
+			err = rootOpts.process(ctx, tt.script)
 			if tt.expErr != nil {
 				if err == nil {
 					t.Errorf("process did not fail")

--- a/cmd/regbot/root.go
+++ b/cmd/regbot/root.go
@@ -24,7 +24,7 @@ More details at https://github.com/regclient/regclient`
 	UserAgent = "regclient/regbot"
 )
 
-var rootOpts struct {
+type rootCmd struct {
 	confFile  string
 	dryRun    bool
 	verbosity string
@@ -32,43 +32,13 @@ var rootOpts struct {
 	format    string // for Go template formatting of various commands
 }
 
+// TODO: remove these globals
 var (
 	conf      *Config
 	log       *logrus.Logger
 	rc        *regclient.RegClient
 	throttleC *throttle.Throttle
 )
-
-var rootCmd = &cobra.Command{
-	Use:           "regbot <cmd>",
-	Short:         "Utility for automating repository actions",
-	Long:          usageDesc,
-	SilenceUsage:  true,
-	SilenceErrors: true,
-}
-var serverCmd = &cobra.Command{
-	Use:   "server",
-	Short: "run the regbot server",
-	Long:  `Runs the various scripts according to their schedule.`,
-	Args:  cobra.RangeArgs(0, 0),
-	RunE:  runServer,
-}
-var onceCmd = &cobra.Command{
-	Use:   "once",
-	Short: "runs each script once",
-	Long: `Each script is executed once ignoring any scheduling. The command
-returns after the last script completes.`,
-	Args: cobra.RangeArgs(0, 0),
-	RunE: runOnce,
-}
-
-var versionCmd = &cobra.Command{
-	Use:   "version",
-	Short: "Show the version",
-	Long:  `Show the version`,
-	Args:  cobra.RangeArgs(0, 0),
-	RunE:  runVersion,
-}
 
 func init() {
 	log = &logrus.Logger{
@@ -77,24 +47,60 @@ func init() {
 		Hooks:     make(logrus.LevelHooks),
 		Level:     logrus.InfoLevel,
 	}
-	rootCmd.PersistentFlags().StringVarP(&rootOpts.confFile, "config", "c", "", "Config file")
-	rootCmd.PersistentFlags().BoolVarP(&rootOpts.dryRun, "dry-run", "", false, "Dry Run, skip all external actions")
-	rootCmd.PersistentFlags().StringVarP(&rootOpts.verbosity, "verbosity", "v", logrus.InfoLevel.String(), "Log level (debug, info, warn, error, fatal, panic)")
-	rootCmd.PersistentFlags().StringArrayVar(&rootOpts.logopts, "logopt", []string{}, "Log options")
+}
+
+func NewRootCmd() *cobra.Command {
+	rootOpts := rootCmd{}
+	var rootTopCmd = &cobra.Command{
+		Use:           "regbot <cmd>",
+		Short:         "Utility for automating repository actions",
+		Long:          usageDesc,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+	var serverCmd = &cobra.Command{
+		Use:   "server",
+		Short: "run the regbot server",
+		Long:  `Runs the various scripts according to their schedule.`,
+		Args:  cobra.RangeArgs(0, 0),
+		RunE:  rootOpts.runServer,
+	}
+	var onceCmd = &cobra.Command{
+		Use:   "once",
+		Short: "runs each script once",
+		Long: `Each script is executed once ignoring any scheduling. The command
+returns after the last script completes.`,
+		Args: cobra.RangeArgs(0, 0),
+		RunE: rootOpts.runOnce,
+	}
+
+	var versionCmd = &cobra.Command{
+		Use:   "version",
+		Short: "Show the version",
+		Long:  `Show the version`,
+		Args:  cobra.RangeArgs(0, 0),
+		RunE:  rootOpts.runVersion,
+	}
+
+	rootTopCmd.PersistentFlags().StringVarP(&rootOpts.confFile, "config", "c", "", "Config file")
+	rootTopCmd.PersistentFlags().BoolVarP(&rootOpts.dryRun, "dry-run", "", false, "Dry Run, skip all external actions")
+	rootTopCmd.PersistentFlags().StringVarP(&rootOpts.verbosity, "verbosity", "v", logrus.InfoLevel.String(), "Log level (debug, info, warn, error, fatal, panic)")
+	rootTopCmd.PersistentFlags().StringArrayVar(&rootOpts.logopts, "logopt", []string{}, "Log options")
 	versionCmd.Flags().StringVarP(&rootOpts.format, "format", "", "{{printPretty .}}", "Format output with go template syntax")
 
-	_ = rootCmd.MarkPersistentFlagFilename("config")
+	_ = rootTopCmd.MarkPersistentFlagFilename("config")
 	_ = serverCmd.MarkPersistentFlagRequired("config")
 	_ = onceCmd.MarkPersistentFlagRequired("config")
 
-	rootCmd.AddCommand(serverCmd)
-	rootCmd.AddCommand(onceCmd)
-	rootCmd.AddCommand(versionCmd)
+	rootTopCmd.AddCommand(serverCmd)
+	rootTopCmd.AddCommand(onceCmd)
+	rootTopCmd.AddCommand(versionCmd)
 
-	rootCmd.PersistentPreRunE = rootPreRun
+	rootTopCmd.PersistentPreRunE = rootOpts.rootPreRun
+	return rootTopCmd
 }
 
-func rootPreRun(cmd *cobra.Command, args []string) error {
+func (rootOpts *rootCmd) rootPreRun(cmd *cobra.Command, args []string) error {
 	lvl, err := logrus.ParseLevel(rootOpts.verbosity)
 	if err != nil {
 		return err
@@ -109,14 +115,14 @@ func rootPreRun(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func runVersion(cmd *cobra.Command, args []string) error {
+func (rootOpts *rootCmd) runVersion(cmd *cobra.Command, args []string) error {
 	info := version.GetInfo()
 	return template.Writer(os.Stdout, rootOpts.format, info)
 }
 
 // runOnce processes the file in one pass, ignoring cron
-func runOnce(cmd *cobra.Command, args []string) error {
-	err := loadConf()
+func (rootOpts *rootCmd) runOnce(cmd *cobra.Command, args []string) error {
+	err := rootOpts.loadConf()
 	if err != nil {
 		return err
 	}
@@ -129,7 +135,7 @@ func runOnce(cmd *cobra.Command, args []string) error {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				err := s.process(ctx)
+				err := rootOpts.process(ctx, s)
 				if err != nil {
 					if mainErr == nil {
 						mainErr = err
@@ -138,7 +144,7 @@ func runOnce(cmd *cobra.Command, args []string) error {
 				}
 			}()
 		} else {
-			err := s.process(ctx)
+			err := rootOpts.process(ctx, s)
 			if err != nil {
 				if mainErr == nil {
 					mainErr = err
@@ -151,8 +157,8 @@ func runOnce(cmd *cobra.Command, args []string) error {
 }
 
 // runServer stays running with cron scheduled tasks
-func runServer(cmd *cobra.Command, args []string) error {
-	err := loadConf()
+func (rootOpts *rootCmd) runServer(cmd *cobra.Command, args []string) error {
+	err := rootOpts.loadConf()
 	if err != nil {
 		return err
 	}
@@ -179,7 +185,7 @@ func runServer(cmd *cobra.Command, args []string) error {
 				}).Debug("Running task")
 				wg.Add(1)
 				defer wg.Done()
-				err := s.process(ctx)
+				err := rootOpts.process(ctx, s)
 				if mainErr == nil {
 					mainErr = err
 				}
@@ -214,7 +220,7 @@ func runServer(cmd *cobra.Command, args []string) error {
 	return mainErr
 }
 
-func loadConf() error {
+func (rootOpts *rootCmd) loadConf() error {
 	var err error
 	if rootOpts.confFile == "-" {
 		conf, err = ConfigLoadReader(os.Stdin)
@@ -280,7 +286,7 @@ func loadConf() error {
 }
 
 // process a sync step
-func (s ConfigScript) process(ctx context.Context) error {
+func (rootOpts *rootCmd) process(ctx context.Context, s ConfigScript) error {
 	log.WithFields(logrus.Fields{
 		"script": s.Name,
 	}).Debug("Starting script")

--- a/cmd/regctl/artifact_test.go
+++ b/cmd/regctl/artifact_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func TestArtifactGet(t *testing.T) {
-	saveArtifactOpts := artifactOpts
 	tt := []struct {
 		name        string
 		args        []string
@@ -54,8 +53,7 @@ func TestArtifactGet(t *testing.T) {
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			out, err := cobraTest(t, tc.args...)
-			artifactOpts = saveArtifactOpts
+			out, err := cobraTest(t, nil, tc.args...)
 			if tc.expectErr != nil {
 				if err == nil {
 					t.Errorf("did not receive expected error: %v", tc.expectErr)
@@ -76,7 +74,6 @@ func TestArtifactGet(t *testing.T) {
 }
 
 func TestArtifactList(t *testing.T) {
-	saveArtifactOpts := artifactOpts
 	tt := []struct {
 		name        string
 		args        []string
@@ -131,8 +128,7 @@ func TestArtifactList(t *testing.T) {
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			out, err := cobraTest(t, tc.args...)
-			artifactOpts = saveArtifactOpts
+			out, err := cobraTest(t, nil, tc.args...)
 			if tc.expectErr != nil {
 				if err == nil {
 					t.Errorf("did not receive expected error: %v", tc.expectErr)
@@ -161,7 +157,6 @@ func TestArtifactPut(t *testing.T) {
 		t.Errorf("failed creating test conf: %v", err)
 		return
 	}
-	saveArtifactOpts := artifactOpts
 
 	tt := []struct {
 		name        string
@@ -219,13 +214,11 @@ func TestArtifactPut(t *testing.T) {
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
+			cobraOpts := cobraTestOpts{}
 			if tc.in != nil {
-				origIn := rootCmd.InOrStdin()
-				defer rootCmd.SetIn(origIn)
-				rootCmd.SetIn(bytes.NewBuffer(tc.in))
+				cobraOpts.stdin = bytes.NewBuffer(tc.in)
 			}
-			out, err := cobraTest(t, tc.args...)
-			artifactOpts = saveArtifactOpts
+			out, err := cobraTest(t, &cobraOpts, tc.args...)
 			if tc.expectErr != nil {
 				if err == nil {
 					t.Errorf("did not receive expected error: %v", tc.expectErr)
@@ -243,13 +236,9 @@ func TestArtifactPut(t *testing.T) {
 			}
 		})
 	}
-	// reset flags
-	artifactOpts.artifactConfig = ""
-	artifactOpts.subject = ""
 }
 
 func TestArtifactTree(t *testing.T) {
-	saveArtifactOpts := artifactOpts
 	tt := []struct {
 		name        string
 		args        []string
@@ -309,8 +298,7 @@ func TestArtifactTree(t *testing.T) {
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			out, err := cobraTest(t, tc.args...)
-			artifactOpts = saveArtifactOpts
+			out, err := cobraTest(t, nil, tc.args...)
 			if tc.expectErr != nil {
 				if err == nil {
 					t.Errorf("did not receive expected error: %v", tc.expectErr)

--- a/cmd/regctl/blob_test.go
+++ b/cmd/regctl/blob_test.go
@@ -8,31 +8,27 @@ import (
 // TODO: implement tests
 
 func TestBlob(t *testing.T) {
-	saveBlobOpts := blobOpts
-	saveManifestOpts := manifestOpts
 	repo := "ocidir://../../testdata/testrepo"
-	digBaseA, err := cobraTest(t, "manifest", "get", repo+":b1", "--platform", "linux/amd64", "--format", "{{(index .Layers 0).Digest}}")
+	digBaseA, err := cobraTest(t, nil, "manifest", "get", repo+":b1", "--platform", "linux/amd64", "--format", "{{(index .Layers 0).Digest}}")
 	if err != nil {
 		t.Errorf("failed getting layer digest: %v", err)
 	}
-	digBaseB, err := cobraTest(t, "manifest", "get", repo+":b3", "--platform", "linux/amd64", "--format", "{{(index .Layers 0).Digest}}")
+	digBaseB, err := cobraTest(t, nil, "manifest", "get", repo+":b3", "--platform", "linux/amd64", "--format", "{{(index .Layers 0).Digest}}")
 	if err != nil {
 		t.Errorf("failed getting layer digest: %v", err)
 	}
-	digConf1, err := cobraTest(t, "manifest", "get", repo+":b1", "--platform", "linux/amd64", "--format", "{{.Config.Digest}}")
+	digConf1, err := cobraTest(t, nil, "manifest", "get", repo+":b1", "--platform", "linux/amd64", "--format", "{{.Config.Digest}}")
 	if err != nil {
 		t.Errorf("failed getting layer digest: %v", err)
 	}
-	digConf3, err := cobraTest(t, "manifest", "get", repo+":b3", "--platform", "linux/amd64", "--format", "{{.Config.Digest}}")
+	digConf3, err := cobraTest(t, nil, "manifest", "get", repo+":b3", "--platform", "linux/amd64", "--format", "{{.Config.Digest}}")
 	if err != nil {
 		t.Errorf("failed getting layer digest: %v", err)
 	}
-	manifestOpts = saveManifestOpts
 
 	t.Run("Get", func(t *testing.T) {
 		// run a get request
-		out, err := cobraTest(t, "blob", "get", "--format", "{{printPretty .}}", repo, digBaseA)
-		blobOpts = saveBlobOpts
+		out, err := cobraTest(t, nil, "blob", "get", "--format", "{{printPretty .}}", repo, digBaseA)
 		if err != nil {
 			t.Errorf("failed to blob get: %v", err)
 		}
@@ -40,8 +36,7 @@ func TestBlob(t *testing.T) {
 			t.Errorf("no blob output received")
 		}
 		// run a head request
-		out, err = cobraTest(t, "blob", "head", "--format", "{{printPretty .}}", repo, digBaseA)
-		blobOpts = saveBlobOpts
+		out, err = cobraTest(t, nil, "blob", "head", "--format", "{{printPretty .}}", repo, digBaseA)
 		if err != nil {
 			t.Errorf("failed to blob head: %v", err)
 		}
@@ -49,8 +44,7 @@ func TestBlob(t *testing.T) {
 			t.Errorf("no blob output received")
 		}
 		// get a file from the blob
-		out, err = cobraTest(t, "blob", "get-file", repo, digBaseA, "base.txt")
-		blobOpts = saveBlobOpts
+		out, err = cobraTest(t, nil, "blob", "get-file", repo, digBaseA, "base.txt")
 		if err != nil {
 			t.Errorf("failed to blob get-file: %v", err)
 		}
@@ -62,19 +56,16 @@ func TestBlob(t *testing.T) {
 	t.Run("Put", func(t *testing.T) {
 		dir := t.TempDir()
 		bufStr := "hello world"
-		buf := bytes.NewBufferString(bufStr)
-		origIn := rootCmd.InOrStdin()
-		rootCmd.SetIn(buf)
-		defer rootCmd.SetIn(origIn)
+		cobraOpts := cobraTestOpts{
+			stdin: bytes.NewBufferString(bufStr),
+		}
 		// put a blob
-		dig, err := cobraTest(t, "blob", "put", "--format", "{{println .Digest}}", "ocidir://"+dir)
-		blobOpts = saveBlobOpts
+		dig, err := cobraTest(t, &cobraOpts, "blob", "put", "--format", "{{println .Digest}}", "ocidir://"+dir)
 		if err != nil {
 			t.Errorf("failed to blob copy: %v", err)
 		}
 		// get the blob from the tempdir
-		out, err := cobraTest(t, "blob", "get", "--format", "{{printPretty .}}", "ocidir://"+dir, dig)
-		blobOpts = saveBlobOpts
+		out, err := cobraTest(t, nil, "blob", "get", "--format", "{{printPretty .}}", "ocidir://"+dir, dig)
 		if err != nil {
 			t.Errorf("failed to blob get: %v", err)
 		}
@@ -86,14 +77,12 @@ func TestBlob(t *testing.T) {
 	t.Run("Copy", func(t *testing.T) {
 		dir := t.TempDir()
 		// copy the blob to the tempdir
-		_, err := cobraTest(t, "blob", "copy", repo, "ocidir://"+dir, digBaseA)
-		blobOpts = saveBlobOpts
+		_, err := cobraTest(t, nil, "blob", "copy", repo, "ocidir://"+dir, digBaseA)
 		if err != nil {
 			t.Errorf("failed to blob copy: %v", err)
 		}
 		// get the blob from the tempdir
-		out, err := cobraTest(t, "blob", "get", "--format", "{{printPretty .}}", "ocidir://"+dir, digBaseA)
-		blobOpts = saveBlobOpts
+		out, err := cobraTest(t, nil, "blob", "get", "--format", "{{printPretty .}}", "ocidir://"+dir, digBaseA)
 		if err != nil {
 			t.Errorf("failed to blob get: %v", err)
 		}
@@ -104,8 +93,7 @@ func TestBlob(t *testing.T) {
 
 	t.Run("Diff", func(t *testing.T) {
 		// diff the layers between two images
-		out, err := cobraTest(t, "blob", "diff-layer", repo, digBaseA, repo, digBaseB)
-		blobOpts = saveBlobOpts
+		out, err := cobraTest(t, nil, "blob", "diff-layer", repo, digBaseA, repo, digBaseB)
 		if err != nil {
 			t.Errorf("failed to diff layers: %v", err)
 		}
@@ -113,8 +101,7 @@ func TestBlob(t *testing.T) {
 			t.Errorf("no output received from diff-layer")
 		}
 		// diff the config between two images
-		out, err = cobraTest(t, "blob", "diff-config", repo, digConf1, repo, digConf3)
-		blobOpts = saveBlobOpts
+		out, err = cobraTest(t, nil, "blob", "diff-config", repo, digConf1, repo, digConf3)
 		if err != nil {
 			t.Errorf("failed to diff config: %v", err)
 		}

--- a/cmd/regctl/completion.go
+++ b/cmd/regctl/completion.go
@@ -11,10 +11,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var completionCmd = &cobra.Command{
-	Use:   "completion [bash|zsh|fish|powershell]",
-	Short: "Generate completion script",
-	Long: fmt.Sprintf(`To load completions:
+func NewCompletionCmd(rootOpts *rootCmd) *cobra.Command {
+	var completionTopCmd = &cobra.Command{
+		Use:   "completion [bash|zsh|fish|powershell]",
+		Short: "Generate completion script",
+		Long: fmt.Sprintf(`To load completions:
 
 Bash:
 
@@ -52,29 +53,39 @@ PowerShell:
   # To load completions for every new session, run:
   PS> %[1]s completion powershell > %[1]s.ps1
   # and source this file from your PowerShell profile.
-`, rootCmd.Root().Name()),
-	DisableFlagsInUseLine: true,
-	ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
-	Args:                  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
-	Run: func(cmd *cobra.Command, args []string) {
-		switch args[0] {
-		case "bash":
-			_ = cmd.Root().GenBashCompletionV2(os.Stdout, true)
-		case "zsh":
-			_ = cmd.Root().GenZshCompletion(os.Stdout)
-		case "fish":
-			_ = cmd.Root().GenFishCompletion(os.Stdout, true)
-		case "powershell":
-			_ = cmd.Root().GenPowerShellCompletionWithDesc(os.Stdout)
-		}
-	},
-}
+`, rootOpts.name),
+		DisableFlagsInUseLine: true,
+		ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
+		Args:                  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+		Run: func(cmd *cobra.Command, args []string) {
+			switch args[0] {
+			case "bash":
+				_ = cmd.Root().GenBashCompletionV2(os.Stdout, true)
+			case "zsh":
+				_ = cmd.Root().GenZshCompletion(os.Stdout)
+			case "fish":
+				_ = cmd.Root().GenFishCompletion(os.Stdout, true)
+			case "powershell":
+				_ = cmd.Root().GenPowerShellCompletionWithDesc(os.Stdout)
+			}
+		},
+	}
 
-func init() {
-	rootCmd.AddCommand(completionCmd)
+	return completionTopCmd
 }
 
 type completeFunc func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective)
+
+// completeArgList takes a list of completion functions and completes each arg separately
+func completeArgList(funcList []completeFunc) completeFunc {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		pos := len(args)
+		if pos >= len(funcList) {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		return funcList[pos](cmd, args, toComplete)
+	}
+}
 
 func completeArgNone(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	return nil, cobra.ShellCompDirectiveNoFileComp
@@ -104,18 +115,7 @@ func completeArgMediaTypeManifest(cmd *cobra.Command, args []string, toComplete 
 	}, cobra.ShellCompDirectiveNoFileComp
 }
 
-// completeArgList takes a list of completion functions and completes each arg separately
-func completeArgList(funcList []completeFunc) completeFunc {
-	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		pos := len(args)
-		if pos >= len(funcList) {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-		return funcList[pos](cmd, args, toComplete)
-	}
-}
-
-func completeArgTag(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func (rootOpts *rootCmd) completeArgTag(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	result := []string{}
 	// TODO: is it possible to expand registry, then repo, then tag?
 	input := strings.TrimRight(toComplete, ":")
@@ -123,7 +123,7 @@ func completeArgTag(cmd *cobra.Command, args []string, toComplete string) ([]str
 	if err != nil || r.Digest != "" {
 		return result, cobra.ShellCompDirectiveNoFileComp
 	}
-	rc := newRegClient()
+	rc := rootOpts.newRegClient()
 	tl, err := rc.TagList(context.Background(), r)
 	if err != nil {
 		return result, cobra.ShellCompDirectiveNoFileComp

--- a/cmd/regctl/config_test.go
+++ b/cmd/regctl/config_test.go
@@ -14,11 +14,9 @@ func TestConfig(t *testing.T) {
 		defer os.Setenv(ConfigEnv, origEnv)
 	}
 	os.Setenv(ConfigEnv, filepath.Join(tempDir, "config.json"))
-	saveConfigOpts := configOpts
 
 	// test empty config
-	out, err := cobraTest(t, "config", "get", "--format", "{{ json . }}")
-	configOpts = saveConfigOpts
+	out, err := cobraTest(t, nil, "config", "get", "--format", "{{ json . }}")
 	if err != nil {
 		t.Errorf("failed to run config get: %v", err)
 	}
@@ -28,8 +26,7 @@ func TestConfig(t *testing.T) {
 
 	// set options
 	testLimit := "420000000"
-	out, err = cobraTest(t, "config", "set", "--blob-limit", testLimit, "--docker-cert=false", "--docker-cred=false")
-	configOpts = saveConfigOpts
+	out, err = cobraTest(t, nil, "config", "set", "--blob-limit", testLimit, "--docker-cert=false", "--docker-cred=false")
 	if err != nil {
 		t.Errorf("failed to set config: %v", err)
 	}
@@ -38,24 +35,21 @@ func TestConfig(t *testing.T) {
 	}
 
 	// get changes
-	out, err = cobraTest(t, "config", "get", "--format", "{{ .BlobLimit }}")
-	configOpts = saveConfigOpts
+	out, err = cobraTest(t, nil, "config", "get", "--format", "{{ .BlobLimit }}")
 	if err != nil {
 		t.Errorf("failed to run config get on blob-limit: %v", err)
 	}
 	if out != testLimit {
 		t.Errorf("unexpected output for blob-limit, expected: %s, received: %s", testLimit, out)
 	}
-	out, err = cobraTest(t, "config", "get", "--format", "{{ .IncDockerCert }}")
-	configOpts = saveConfigOpts
+	out, err = cobraTest(t, nil, "config", "get", "--format", "{{ .IncDockerCert }}")
 	if err != nil {
 		t.Errorf("failed to run config get on docker-cert: %v", err)
 	}
 	if out != "false" {
 		t.Errorf("unexpected output for docker-cert, expected: false, received: %s", out)
 	}
-	out, err = cobraTest(t, "config", "get", "--format", "{{ .IncDockerCred }}")
-	configOpts = saveConfigOpts
+	out, err = cobraTest(t, nil, "config", "get", "--format", "{{ .IncDockerCred }}")
 	if err != nil {
 		t.Errorf("failed to run config get on docker-cred: %v", err)
 	}
@@ -64,8 +58,7 @@ func TestConfig(t *testing.T) {
 	}
 
 	// reset back to zero values
-	out, err = cobraTest(t, "config", "set", "--blob-limit", "0", "--docker-cert", "--docker-cred")
-	configOpts = saveConfigOpts
+	out, err = cobraTest(t, nil, "config", "set", "--blob-limit", "0", "--docker-cert", "--docker-cred")
 	if err != nil {
 		t.Errorf("failed to set blob-limit: %v", err)
 	}
@@ -74,8 +67,7 @@ func TestConfig(t *testing.T) {
 	}
 
 	// verify config is empty
-	out, err = cobraTest(t, "config", "get", "--format", "{{ json . }}")
-	configOpts = saveConfigOpts
+	out, err = cobraTest(t, nil, "config", "get", "--format", "{{ json . }}")
 	if err != nil {
 		t.Errorf("failed to run config get: %v", err)
 	}

--- a/cmd/regctl/digest.go
+++ b/cmd/regctl/digest.go
@@ -13,20 +13,27 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// TODO: identify a more appropriate location for this command, leave it hidden until then
-var digestCmd = &cobra.Command{
-	Hidden: true,
-	Use:    "digest",
-	Short:  "compute digest on stdin",
-	Args:   cobra.RangeArgs(0, 0),
-	RunE:   runDigest,
+type digestCmd struct {
+	rootOpts *rootCmd
 }
 
-func init() {
-	rootCmd.AddCommand(digestCmd)
+func NewDigestCmd(rootOpts *rootCmd) *cobra.Command {
+	digestOpts := digestCmd{
+		rootOpts: rootOpts,
+	}
+	// TODO: identify a more appropriate location for this command, leave it hidden until then
+	var digestCmd = &cobra.Command{
+		Hidden: true,
+		Use:    "digest",
+		Short:  "compute digest on stdin",
+		Args:   cobra.RangeArgs(0, 0),
+		RunE:   digestOpts.runDigest,
+	}
+
+	return digestCmd
 }
 
-func runDigest(cmd *cobra.Command, args []string) error {
+func (digestOpts *digestCmd) runDigest(cmd *cobra.Command, args []string) error {
 	digester := digest.Canonical.Digester()
 
 	_, err := io.Copy(digester.Hash(), os.Stdin)

--- a/cmd/regctl/image_test.go
+++ b/cmd/regctl/image_test.go
@@ -11,10 +11,8 @@ func TestImageExportImport(t *testing.T) {
 	exportFile := tmpDir + "/export.tar"
 	exportName := "registry.example.com/repo:v2"
 	importRefA := fmt.Sprintf("ocidir://%s/repo:v2", tmpDir)
-	saveOpts := imageOpts
 
-	out, err := cobraTest(t, "image", "export", "--name", exportName, srcRef, exportFile)
-	imageOpts = saveOpts
+	out, err := cobraTest(t, nil, "image", "export", "--name", exportName, srcRef, exportFile)
 	if err != nil {
 		t.Errorf("failed to run image export: %v", err)
 		return
@@ -23,8 +21,7 @@ func TestImageExportImport(t *testing.T) {
 		t.Errorf("unexpected output: %v", out)
 	}
 
-	out, err = cobraTest(t, "image", "import", importRefA, exportFile)
-	imageOpts = saveOpts
+	out, err = cobraTest(t, nil, "image", "import", importRefA, exportFile)
 	if err != nil {
 		t.Errorf("failed to run image import: %v", err)
 		return
@@ -33,8 +30,7 @@ func TestImageExportImport(t *testing.T) {
 		t.Errorf("unexpected output: %v", out)
 	}
 
-	out, err = cobraTest(t, "image", "export", "--name", exportName, "--platform", "linux/amd64", srcRef, exportFile)
-	imageOpts = saveOpts
+	out, err = cobraTest(t, nil, "image", "export", "--name", exportName, "--platform", "linux/amd64", srcRef, exportFile)
 	if err != nil {
 		t.Errorf("failed to run image export: %v", err)
 		return
@@ -49,10 +45,8 @@ func TestImageMod(t *testing.T) {
 	srcRef := "ocidir://../../testdata/testrepo:v3"
 	baseRef := "ocidir://../../testdata/testrepo:b1"
 	modRef := fmt.Sprintf("ocidir://%s/repo:mod", tmpDir)
-	saveOpts := imageOpts
 
-	out, err := cobraTest(t, "image", "mod", srcRef, "--create", modRef, "--time", "set=2000-01-01T00:00:00Z,base-ref="+baseRef)
-	imageOpts = saveOpts
+	out, err := cobraTest(t, nil, "image", "mod", srcRef, "--create", modRef, "--time", "set=2000-01-01T00:00:00Z,base-ref="+baseRef)
 	if err != nil {
 		t.Errorf("failed to run image mod: %v", err)
 		return

--- a/cmd/regctl/index_test.go
+++ b/cmd/regctl/index_test.go
@@ -10,13 +10,9 @@ func TestIndex(t *testing.T) {
 	latestRef := fmt.Sprintf("ocidir://%s/repo:latest", tmpDir)
 	artifactRef := fmt.Sprintf("ocidir://%s/repo:latest", tmpDir)
 	srcRef := "ocidir://../../testdata/testrepo:v2"
-	saveIndexOpts := indexOpts
-	saveManifestOpts := manifestOpts
-	saveArtifactOpts := artifactOpts
 
 	// create index with 2 platforms from test repo
-	out, err := cobraTest(t, "index", "create", "--ref", srcRef, "--platform", "linux/amd64", "--platform", "linux/arm/v7", latestRef)
-	indexOpts = saveIndexOpts
+	out, err := cobraTest(t, nil, "index", "create", "--ref", srcRef, "--platform", "linux/amd64", "--platform", "linux/arm/v7", latestRef)
 	if err != nil {
 		t.Errorf("failed to run index create: %v", err)
 		return
@@ -25,30 +21,25 @@ func TestIndex(t *testing.T) {
 		t.Errorf("unexpected output: %s", out)
 	}
 	// verify content
-	_, err = cobraTest(t, "manifest", "get", "--platform", "linux/amd64", latestRef)
-	manifestOpts = saveManifestOpts
+	_, err = cobraTest(t, nil, "manifest", "get", "--platform", "linux/amd64", latestRef)
 	if err != nil {
 		t.Errorf("failed to get linux/amd64 entry: %v", err)
 	}
-	_, err = cobraTest(t, "manifest", "get", "--platform", "linux/arm/v7", latestRef)
-	manifestOpts = saveManifestOpts
+	_, err = cobraTest(t, nil, "manifest", "get", "--platform", "linux/arm/v7", latestRef)
 	if err != nil {
 		t.Errorf("failed to get linux/arm/v7 entry: %v", err)
 	}
-	_, err = cobraTest(t, "manifest", "get", "--platform", "linux/arm64", latestRef)
-	manifestOpts = saveManifestOpts
+	_, err = cobraTest(t, nil, "manifest", "get", "--platform", "linux/arm64", latestRef)
 	if err == nil {
 		t.Errorf("found linux/arm64 entry")
 	}
-	_, err = cobraTest(t, "artifact", "get", "--subject", latestRef, "--platform", "linux/amd/v7", "--filter-artifact-type", "application/example.arms")
-	artifactOpts = saveArtifactOpts
+	_, err = cobraTest(t, nil, "artifact", "get", "--subject", latestRef, "--platform", "linux/amd/v7", "--filter-artifact-type", "application/example.arms")
 	if err == nil {
 		t.Errorf("found referrers that were not copied")
 	}
 
 	// add artifact with referrers
-	out, err = cobraTest(t, "index", "add", "--ref", srcRef, "--platform", "linux/arm64", "--referrers", "--digest-tags", latestRef)
-	indexOpts = saveIndexOpts
+	out, err = cobraTest(t, nil, "index", "add", "--ref", srcRef, "--platform", "linux/arm64", "--referrers", "--digest-tags", latestRef)
 	if err != nil {
 		t.Errorf("failed to run index add: %v", err)
 		return
@@ -56,13 +47,11 @@ func TestIndex(t *testing.T) {
 	if out != "" {
 		t.Errorf("unexpected output: %s", out)
 	}
-	_, err = cobraTest(t, "manifest", "get", "--platform", "linux/arm64", latestRef)
-	manifestOpts = saveManifestOpts
+	_, err = cobraTest(t, nil, "manifest", "get", "--platform", "linux/arm64", latestRef)
 	if err != nil {
 		t.Errorf("failed to get linux/arm64 entry: %v", err)
 	}
-	out, err = cobraTest(t, "artifact", "get", "--subject", latestRef, "--platform", "linux/arm64", "--filter-artifact-type", "application/example.arms")
-	artifactOpts = saveArtifactOpts
+	out, err = cobraTest(t, nil, "artifact", "get", "--subject", latestRef, "--platform", "linux/arm64", "--filter-artifact-type", "application/example.arms")
 	if err != nil {
 		t.Errorf("artifact not found: %v", err)
 	}
@@ -73,8 +62,7 @@ func TestIndex(t *testing.T) {
 
 	// create an index that itself is an artifact
 	testArtifactType := "application/example.test"
-	out, err = cobraTest(t, "index", "create", artifactRef, "--subject", "latest", "--artifact-type", testArtifactType, "--ref", srcRef)
-	indexOpts = saveIndexOpts
+	out, err = cobraTest(t, nil, "index", "create", artifactRef, "--subject", "latest", "--artifact-type", testArtifactType, "--ref", srcRef)
 	if err != nil {
 		t.Errorf("failed to run index create for artifact: %v", err)
 		return
@@ -82,8 +70,7 @@ func TestIndex(t *testing.T) {
 	if out != "" {
 		t.Errorf("unexpected output: %s", out)
 	}
-	out, err = cobraTest(t, "manifest", "get", artifactRef, "--format", "{{.ArtifactType}}")
-	manifestOpts = saveManifestOpts
+	out, err = cobraTest(t, nil, "manifest", "get", artifactRef, "--format", "{{.ArtifactType}}")
 	if err != nil {
 		t.Errorf("failed to get artifact type from manifest: %v", err)
 	}

--- a/cmd/regctl/main.go
+++ b/cmd/regctl/main.go
@@ -24,7 +24,8 @@ func main() {
 	}()
 	godbg.SignalTrace()
 
-	if err := rootCmd.ExecuteContext(ctx); err != nil {
+	rootTopCmd := NewRootCmd()
+	if err := rootTopCmd.ExecuteContext(ctx); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		// provide tips for common error messages
 		switch {

--- a/cmd/regctl/main_test.go
+++ b/cmd/regctl/main_test.go
@@ -2,18 +2,27 @@ package main
 
 import (
 	"bytes"
+	"io"
 	"strings"
 	"testing"
 )
 
-func cobraTest(t *testing.T, args ...string) (string, error) {
+type cobraTestOpts struct {
+	stdin io.Reader
+}
+
+func cobraTest(t *testing.T, opts *cobraTestOpts, args ...string) (string, error) {
 	t.Helper()
 
 	buf := new(bytes.Buffer)
-	rootCmd.SetOut(buf)
-	rootCmd.SetErr(buf)
-	rootCmd.SetArgs(args)
+	rootTopCmd := NewRootCmd()
+	if opts != nil && opts.stdin != nil {
+		rootTopCmd.SetIn(opts.stdin)
+	}
+	rootTopCmd.SetOut(buf)
+	rootTopCmd.SetErr(buf)
+	rootTopCmd.SetArgs(args)
 
-	err := rootCmd.Execute()
+	err := rootTopCmd.Execute()
 	return strings.TrimSpace(buf.String()), err
 }

--- a/cmd/regctl/manifest_test.go
+++ b/cmd/regctl/manifest_test.go
@@ -10,7 +10,6 @@ import (
 )
 
 func TestManifestHead(t *testing.T) {
-	saveManifestOpts := manifestOpts
 	tt := []struct {
 		name        string
 		args        []string
@@ -53,8 +52,7 @@ func TestManifestHead(t *testing.T) {
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			out, err := cobraTest(t, tc.args...)
-			manifestOpts = saveManifestOpts
+			out, err := cobraTest(t, nil, tc.args...)
 			if tc.expectErr != nil {
 				if err == nil {
 					t.Errorf("did not receive expected error: %v", tc.expectErr)

--- a/cmd/regctl/registry.go
+++ b/cmd/regctl/registry.go
@@ -16,46 +16,8 @@ import (
 	"golang.org/x/term"
 )
 
-var registryCmd = &cobra.Command{
-	Use:   "registry <cmd>",
-	Short: "manage registries",
-}
-var registryConfigCmd = &cobra.Command{
-	Use:   "config [registry]",
-	Short: "show registry config",
-	Long: `Displays the configuration used for a registry. Secrets are not included
-in the output (e.g. passwords, tokens, and TLS keys).`,
-	Args:              cobra.RangeArgs(0, 1),
-	ValidArgsFunction: registryArgListReg,
-	RunE:              runRegistryConfig,
-}
-var registryLoginCmd = &cobra.Command{
-	Use:   "login <registry>",
-	Short: "login to a registry",
-	Long: `Provide login credentials for a registry. This may not be necessary if you
-have already logged in with docker.`,
-	Args:              cobra.RangeArgs(0, 1),
-	ValidArgsFunction: registryArgListReg,
-	RunE:              runRegistryLogin,
-}
-var registryLogoutCmd = &cobra.Command{
-	Use:               "logout <registry>",
-	Short:             "logout of a registry",
-	Long:              `Remove registry credentials from the configuration.`,
-	Args:              cobra.RangeArgs(0, 1),
-	ValidArgsFunction: registryArgListReg,
-	RunE:              runRegistryLogout,
-}
-var registrySetCmd = &cobra.Command{
-	Use:   "set <registry>",
-	Short: "set options on a registry",
-	Long: `Set or modify the configuration of a registry. To pass a certificate, include
-the contents of the file, e.g. --cacert "$(cat reg-ca.crt)"`,
-	Args:              cobra.RangeArgs(0, 1),
-	ValidArgsFunction: registryArgListReg,
-	RunE:              runRegistrySet,
-}
-var registryOpts struct {
+type registryCmd struct {
+	rootOpts             *rootCmd
 	user, pass           string // login opts
 	passStdin            bool
 	credHelper           string
@@ -74,7 +36,50 @@ var registryOpts struct {
 	dns                  []string // TODO: remove
 }
 
-func init() {
+func NewRegistryCmd(rootOpts *rootCmd) *cobra.Command {
+	registryOpts := registryCmd{
+		rootOpts: rootOpts,
+	}
+	var registryTopCmd = &cobra.Command{
+		Use:   "registry <cmd>",
+		Short: "manage registries",
+	}
+	var registryConfigCmd = &cobra.Command{
+		Use:   "config [registry]",
+		Short: "show registry config",
+		Long: `Displays the configuration used for a registry. Secrets are not included
+in the output (e.g. passwords, tokens, and TLS keys).`,
+		Args:              cobra.RangeArgs(0, 1),
+		ValidArgsFunction: registryArgListReg,
+		RunE:              registryOpts.runRegistryConfig,
+	}
+	var registryLoginCmd = &cobra.Command{
+		Use:   "login <registry>",
+		Short: "login to a registry",
+		Long: `Provide login credentials for a registry. This may not be necessary if you
+have already logged in with docker.`,
+		Args:              cobra.RangeArgs(0, 1),
+		ValidArgsFunction: registryArgListReg,
+		RunE:              registryOpts.runRegistryLogin,
+	}
+	var registryLogoutCmd = &cobra.Command{
+		Use:               "logout <registry>",
+		Short:             "logout of a registry",
+		Long:              `Remove registry credentials from the configuration.`,
+		Args:              cobra.RangeArgs(0, 1),
+		ValidArgsFunction: registryArgListReg,
+		RunE:              registryOpts.runRegistryLogout,
+	}
+	var registrySetCmd = &cobra.Command{
+		Use:   "set <registry>",
+		Short: "set options on a registry",
+		Long: `Set or modify the configuration of a registry. To pass a certificate, include
+the contents of the file, e.g. --cacert "$(cat reg-ca.crt)"`,
+		Args:              cobra.RangeArgs(0, 1),
+		ValidArgsFunction: registryArgListReg,
+		RunE:              registryOpts.runRegistrySet,
+	}
+
 	registryLoginCmd.Flags().StringVarP(&registryOpts.user, "user", "u", "", "Username")
 	registryLoginCmd.Flags().StringVarP(&registryOpts.pass, "pass", "p", "", "Password")
 	registryLoginCmd.Flags().BoolVarP(&registryOpts.passStdin, "pass-stdin", "", false, "Read password from stdin")
@@ -117,11 +122,11 @@ func init() {
 	_ = registrySetCmd.Flags().MarkHidden("scheme")
 	_ = registrySetCmd.Flags().MarkHidden("dns")
 
-	registryCmd.AddCommand(registryConfigCmd)
-	registryCmd.AddCommand(registryLoginCmd)
-	registryCmd.AddCommand(registryLogoutCmd)
-	registryCmd.AddCommand(registrySetCmd)
-	rootCmd.AddCommand(registryCmd)
+	registryTopCmd.AddCommand(registryConfigCmd)
+	registryTopCmd.AddCommand(registryLoginCmd)
+	registryTopCmd.AddCommand(registryLogoutCmd)
+	registryTopCmd.AddCommand(registrySetCmd)
+	return registryTopCmd
 }
 
 func registryArgListReg(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
@@ -138,7 +143,7 @@ func registryArgListReg(cmd *cobra.Command, args []string, toComplete string) ([
 	return result, cobra.ShellCompDirectiveNoFileComp
 }
 
-func runRegistryConfig(cmd *cobra.Command, args []string) error {
+func (registryOpts *registryCmd) runRegistryConfig(cmd *cobra.Command, args []string) error {
 	c, err := ConfigLoadDefault()
 	if err != nil {
 		return err
@@ -173,7 +178,7 @@ func runRegistryConfig(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func runRegistryLogin(cmd *cobra.Command, args []string) error {
+func (registryOpts *registryCmd) runRegistryLogin(cmd *cobra.Command, args []string) error {
 	c, err := ConfigLoadDefault()
 	if err != nil {
 		return err
@@ -257,7 +262,7 @@ func runRegistryLogin(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func runRegistryLogout(cmd *cobra.Command, args []string) error {
+func (registryOpts *registryCmd) runRegistryLogout(cmd *cobra.Command, args []string) error {
 	c, err := ConfigLoadDefault()
 	if err != nil {
 		return err
@@ -289,7 +294,7 @@ func runRegistryLogout(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func runRegistrySet(cmd *cobra.Command, args []string) error {
+func (registryOpts *registryCmd) runRegistrySet(cmd *cobra.Command, args []string) error {
 	c, err := ConfigLoadDefault()
 	if err != nil {
 		return err

--- a/cmd/regctl/repo.go
+++ b/cmd/regctl/repo.go
@@ -9,28 +9,32 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var repoCmd = &cobra.Command{
-	Use:   "repo <cmd>",
-	Short: "manage repositories",
+type repoCmd struct {
+	rootOpts *rootCmd
+	last     string
+	limit    int
+	format   string
 }
-var repoLsCmd = &cobra.Command{
-	Use:     "ls <registry>",
-	Aliases: []string{"list"},
-	Short:   "list repositories in a registry",
-	Long: `List repositories in a registry.
+
+func NewRepoCmd(rootOpts *rootCmd) *cobra.Command {
+	repoOpts := repoCmd{
+		rootOpts: rootOpts,
+	}
+	var repoTopCmd = &cobra.Command{
+		Use:   "repo <cmd>",
+		Short: "manage repositories",
+	}
+	var repoLsCmd = &cobra.Command{
+		Use:     "ls <registry>",
+		Aliases: []string{"list"},
+		Short:   "list repositories in a registry",
+		Long: `List repositories in a registry.
 Note: Docker Hub does not support this API request.`,
-	Args:              cobra.ExactArgs(1),
-	ValidArgsFunction: registryArgListReg,
-	RunE:              runRepoLs,
-}
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: registryArgListReg,
+		RunE:              repoOpts.runRepoLs,
+	}
 
-var repoOpts struct {
-	last   string
-	limit  int
-	format string
-}
-
-func init() {
 	repoLsCmd.Flags().StringVarP(&repoOpts.last, "last", "", "", "Specify the last repo from a previous request for pagination")
 	repoLsCmd.Flags().IntVarP(&repoOpts.limit, "limit", "", 0, "Specify the number of repos to retrieve")
 	repoLsCmd.Flags().StringVarP(&repoOpts.format, "format", "", "{{printPretty .}}", "Format output with go template syntax")
@@ -38,11 +42,11 @@ func init() {
 	_ = repoLsCmd.RegisterFlagCompletionFunc("limit", completeArgNone)
 	_ = repoLsCmd.RegisterFlagCompletionFunc("format", completeArgNone)
 
-	repoCmd.AddCommand(repoLsCmd)
-	rootCmd.AddCommand(repoCmd)
+	repoTopCmd.AddCommand(repoLsCmd)
+	return repoTopCmd
 }
 
-func runRepoLs(cmd *cobra.Command, args []string) error {
+func (repoOpts *repoCmd) runRepoLs(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 	host := args[0]
 	// TODO: use regex to validate hostname + port
@@ -53,7 +57,7 @@ func runRepoLs(cmd *cobra.Command, args []string) error {
 		}).Error("Hostname invalid")
 		return ErrInvalidInput
 	}
-	rc := newRegClient()
+	rc := repoOpts.rootOpts.newRegClient()
 	log.WithFields(logrus.Fields{
 		"host":  host,
 		"last":  repoOpts.last,

--- a/cmd/regctl/tag_test.go
+++ b/cmd/regctl/tag_test.go
@@ -11,7 +11,6 @@ import (
 )
 
 func TestTagList(t *testing.T) {
-	saveTagOpts := tagOpts
 	tt := []struct {
 		name        string
 		args        []string
@@ -59,12 +58,9 @@ func TestTagList(t *testing.T) {
 			outContains: true,
 		},
 	}
-	optInit := tagOpts
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			tagOpts = optInit
-			out, err := cobraTest(t, tc.args...)
-			tagOpts = saveTagOpts
+			out, err := cobraTest(t, nil, tc.args...)
 			if tc.expectErr != nil {
 				if err == nil {
 					t.Errorf("did not receive expected error: %v", tc.expectErr)
@@ -82,5 +78,4 @@ func TestTagList(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/cmd/regsync/main.go
+++ b/cmd/regsync/main.go
@@ -23,7 +23,8 @@ func main() {
 	}()
 	godbg.SignalTrace()
 
-	if err := rootCmd.ExecuteContext(ctx); err != nil {
+	rootTopCmd := NewRootCmd()
+	if err := rootTopCmd.ExecuteContext(ctx); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}

--- a/cmd/regsync/regsync_test.go
+++ b/cmd/regsync/regsync_test.go
@@ -632,8 +632,9 @@ func TestProcess(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			// run each test
+			rootOpts := rootCmd{}
 			syncSetDefaults(&tc.sync, conf.Defaults)
-			err = tc.sync.process(ctx, tc.action)
+			err = rootOpts.process(ctx, tc.sync, tc.action)
 			// validate err
 			if tc.expErr != nil {
 				if err == nil {
@@ -732,6 +733,7 @@ func TestProcessRef(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
+			rootOpts := rootCmd{}
 			src, err := ref.New(cs.Source)
 			if err != nil {
 				t.Errorf("failed to create src ref: %v", err)
@@ -744,7 +746,7 @@ func TestProcessRef(t *testing.T) {
 			}
 			src.Tag = tc.src
 			tgt.Tag = tc.tgt
-			err = cs.processRef(ctx, src, tgt, tc.action)
+			err = rootOpts.processRef(ctx, cs, src, tgt, tc.action)
 			// validate err
 			if tc.expErr != nil {
 				if err == nil {


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Testing of cobra CLI's gets a bit complicated and error prone since all options are globals that can be modified by other tests.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Moves all initialization into setup functions that can be directly called.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Hopefully there are no user visible changes, but it's a significant refactoring so no promises.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Chore: refactoring CLIs to remove global state.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
