### PR TITLE
Fix regression in formatted output of image config

### DIFF
--- a/cmd/regctl/image.go
+++ b/cmd/regctl/image.go
@@ -20,7 +20,9 @@ import (
 	"github.com/regclient/regclient/mod"
 	"github.com/regclient/regclient/pkg/template"
 	"github.com/regclient/regclient/types"
+	"github.com/regclient/regclient/types/blob"
 	"github.com/regclient/regclient/types/manifest"
+	v1 "github.com/regclient/regclient/types/oci/v1"
 	"github.com/regclient/regclient/types/platform"
 	"github.com/regclient/regclient/types/ref"
 	"github.com/sirupsen/logrus"
@@ -1220,6 +1222,13 @@ func (imageOpts *imageCmd) runImageInspect(cmd *cobra.Command, args []string) er
 	if err != nil {
 		return err
 	}
+	result := struct {
+		*blob.BOCIConfig
+		v1.Image
+	}{
+		BOCIConfig: blobConfig,
+		Image:      blobConfig.GetConfig(),
+	}
 	switch imageOpts.format {
 	case "raw":
 		imageOpts.format = "{{ range $key,$vals := .RawHeaders}}{{range $val := $vals}}{{printf \"%s: %s\\n\" $key $val }}{{end}}{{end}}{{printf \"\\n%s\" .RawBody}}"
@@ -1228,7 +1237,7 @@ func (imageOpts *imageCmd) runImageInspect(cmd *cobra.Command, args []string) er
 	case "rawHeaders", "raw-headers", "headers":
 		imageOpts.format = "{{ range $key,$vals := .RawHeaders}}{{range $val := $vals}}{{printf \"%s: %s\\n\" $key $val }}{{end}}{{end}}"
 	}
-	return template.Writer(cmd.OutOrStdout(), imageOpts.format, blobConfig)
+	return template.Writer(cmd.OutOrStdout(), imageOpts.format, result)
 }
 
 func (imageOpts *imageCmd) runImageMod(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Fixes #551 
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Adds the image config as an anonymous field in the returned struct to allow better formatting options.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
regctl image inspect regclient/regctl:latest --format '{{ jsonPretty .Config.Labels }}'
```

<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Fix formatting variables in `regctl image inspect`.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
