### PR TITLE
Reorder Go imports to move local packages last

### DIFF
--- a/blob.go
+++ b/blob.go
@@ -6,12 +6,13 @@ import (
 	"io"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/regclient/regclient/internal/throttle"
 	"github.com/regclient/regclient/scheme"
 	"github.com/regclient/regclient/types"
 	"github.com/regclient/regclient/types/blob"
 	"github.com/regclient/regclient/types/ref"
-	"github.com/sirupsen/logrus"
 )
 
 const blobCBFreq = time.Millisecond * 100

--- a/blob_test.go
+++ b/blob_test.go
@@ -15,11 +15,12 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/opencontainers/go-digest"
+	"github.com/sirupsen/logrus"
+
 	"github.com/regclient/regclient/config"
 	"github.com/regclient/regclient/internal/reqresp"
 	"github.com/regclient/regclient/types"
 	"github.com/regclient/regclient/types/ref"
-	"github.com/sirupsen/logrus"
 )
 
 func TestBlobGet(t *testing.T) {

--- a/cmd/regbot/config.go
+++ b/cmd/regbot/config.go
@@ -6,9 +6,10 @@ import (
 	"os"
 	"time"
 
+	"gopkg.in/yaml.v3"
+
 	"github.com/regclient/regclient/config"
 	"github.com/regclient/regclient/pkg/template"
-	"gopkg.in/yaml.v3"
 )
 
 // Config is parsed configuration file for regsync

--- a/cmd/regbot/main.go
+++ b/cmd/regbot/main.go
@@ -7,8 +7,9 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/regclient/regclient/internal/godbg"
 	"github.com/sirupsen/logrus"
+
+	"github.com/regclient/regclient/internal/godbg"
 )
 
 func main() {

--- a/cmd/regbot/root.go
+++ b/cmd/regbot/root.go
@@ -5,6 +5,10 @@ import (
 	"os"
 	"sync"
 
+	"github.com/robfig/cron/v3"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
 	"github.com/regclient/regclient"
 	"github.com/regclient/regclient/cmd/regbot/sandbox"
 	"github.com/regclient/regclient/config"
@@ -12,9 +16,6 @@ import (
 	"github.com/regclient/regclient/internal/version"
 	"github.com/regclient/regclient/pkg/template"
 	"github.com/regclient/regclient/scheme/reg"
-	"github.com/robfig/cron/v3"
-	"github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
 )
 
 const (

--- a/cmd/regbot/sandbox/blob.go
+++ b/cmd/regbot/sandbox/blob.go
@@ -11,11 +11,12 @@ import (
 	_ "crypto/sha512"
 
 	"github.com/opencontainers/go-digest"
+	"github.com/sirupsen/logrus"
+	lua "github.com/yuin/gopher-lua"
+
 	"github.com/regclient/regclient/types"
 	"github.com/regclient/regclient/types/blob"
 	"github.com/regclient/regclient/types/ref"
-	"github.com/sirupsen/logrus"
-	lua "github.com/yuin/gopher-lua"
 )
 
 type sbBlob struct {

--- a/cmd/regbot/sandbox/image.go
+++ b/cmd/regbot/sandbox/image.go
@@ -6,14 +6,15 @@ import (
 	"os"
 	"time"
 
+	"github.com/sirupsen/logrus"
+	lua "github.com/yuin/gopher-lua"
+
 	"github.com/regclient/regclient"
 	"github.com/regclient/regclient/cmd/regbot/internal/go2lua"
 	"github.com/regclient/regclient/types/blob"
 	"github.com/regclient/regclient/types/manifest"
 	v1 "github.com/regclient/regclient/types/oci/v1"
 	"github.com/regclient/regclient/types/ref"
-	"github.com/sirupsen/logrus"
-	lua "github.com/yuin/gopher-lua"
 )
 
 type config struct {

--- a/cmd/regbot/sandbox/manifest.go
+++ b/cmd/regbot/sandbox/manifest.go
@@ -4,12 +4,13 @@ import (
 	"encoding/json"
 	"reflect"
 
+	"github.com/sirupsen/logrus"
+	lua "github.com/yuin/gopher-lua"
+
 	"github.com/regclient/regclient/cmd/regbot/internal/go2lua"
 	"github.com/regclient/regclient/types/manifest"
 	"github.com/regclient/regclient/types/platform"
 	"github.com/regclient/regclient/types/ref"
-	"github.com/sirupsen/logrus"
-	lua "github.com/yuin/gopher-lua"
 )
 
 type sbManifest struct {

--- a/cmd/regbot/sandbox/reference.go
+++ b/cmd/regbot/sandbox/reference.go
@@ -1,8 +1,9 @@
 package sandbox
 
 import (
-	"github.com/regclient/regclient/types/ref"
 	lua "github.com/yuin/gopher-lua"
+
+	"github.com/regclient/regclient/types/ref"
 )
 
 func setupReference(s *Sandbox) {

--- a/cmd/regbot/sandbox/repo.go
+++ b/cmd/regbot/sandbox/repo.go
@@ -3,10 +3,11 @@ package sandbox
 import (
 	"fmt"
 
-	"github.com/regclient/regclient/cmd/regbot/internal/go2lua"
-	"github.com/regclient/regclient/scheme"
 	"github.com/sirupsen/logrus"
 	lua "github.com/yuin/gopher-lua"
+
+	"github.com/regclient/regclient/cmd/regbot/internal/go2lua"
+	"github.com/regclient/regclient/scheme"
 )
 
 func setupRepo(s *Sandbox) {

--- a/cmd/regbot/sandbox/sandbox.go
+++ b/cmd/regbot/sandbox/sandbox.go
@@ -4,11 +4,12 @@ package sandbox
 import (
 	"context"
 
+	"github.com/sirupsen/logrus"
+	lua "github.com/yuin/gopher-lua"
+
 	"github.com/regclient/regclient"
 	"github.com/regclient/regclient/cmd/regbot/internal/go2lua"
 	"github.com/regclient/regclient/internal/throttle"
-	"github.com/sirupsen/logrus"
-	lua "github.com/yuin/gopher-lua"
 )
 
 const (

--- a/cmd/regctl/artifact.go
+++ b/cmd/regctl/artifact.go
@@ -15,6 +15,8 @@ import (
 	_ "crypto/sha512"
 
 	"github.com/opencontainers/go-digest"
+	"github.com/spf13/cobra"
+
 	"github.com/regclient/regclient"
 	"github.com/regclient/regclient/pkg/archive"
 	"github.com/regclient/regclient/pkg/template"
@@ -25,7 +27,6 @@ import (
 	"github.com/regclient/regclient/types/platform"
 	"github.com/regclient/regclient/types/ref"
 	"github.com/regclient/regclient/types/referrer"
-	"github.com/spf13/cobra"
 )
 
 const (

--- a/cmd/regctl/blob.go
+++ b/cmd/regctl/blob.go
@@ -15,12 +15,13 @@ import (
 	_ "crypto/sha512"
 
 	"github.com/opencontainers/go-digest"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
 	"github.com/regclient/regclient/internal/diff"
 	"github.com/regclient/regclient/pkg/template"
 	"github.com/regclient/regclient/types"
 	"github.com/regclient/regclient/types/ref"
-	"github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
 )
 
 type blobCmd struct {

--- a/cmd/regctl/completion.go
+++ b/cmd/regctl/completion.go
@@ -6,9 +6,10 @@ import (
 	"os"
 	"strings"
 
+	"github.com/spf13/cobra"
+
 	"github.com/regclient/regclient/types"
 	"github.com/regclient/regclient/types/ref"
-	"github.com/spf13/cobra"
 )
 
 func NewCompletionCmd(rootOpts *rootCmd) *cobra.Command {

--- a/cmd/regctl/config.go
+++ b/cmd/regctl/config.go
@@ -8,10 +8,11 @@ import (
 	"io"
 	"io/fs"
 
+	"github.com/spf13/cobra"
+
 	"github.com/regclient/regclient/config"
 	"github.com/regclient/regclient/internal/conffile"
 	"github.com/regclient/regclient/pkg/template"
-	"github.com/spf13/cobra"
 )
 
 var (

--- a/cmd/regctl/image.go
+++ b/cmd/regctl/image.go
@@ -14,6 +14,9 @@ import (
 	"time"
 
 	"github.com/opencontainers/go-digest"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
 	"github.com/regclient/regclient"
 	"github.com/regclient/regclient/internal/ascii"
 	"github.com/regclient/regclient/internal/units"
@@ -25,8 +28,6 @@ import (
 	v1 "github.com/regclient/regclient/types/oci/v1"
 	"github.com/regclient/regclient/types/platform"
 	"github.com/regclient/regclient/types/ref"
-	"github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
 )
 
 type imageCmd struct {

--- a/cmd/regctl/index.go
+++ b/cmd/regctl/index.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 
 	"github.com/opencontainers/go-digest"
+	"github.com/spf13/cobra"
+
 	"github.com/regclient/regclient"
 	"github.com/regclient/regclient/pkg/template"
 	"github.com/regclient/regclient/types"
@@ -14,7 +16,6 @@ import (
 	v1 "github.com/regclient/regclient/types/oci/v1"
 	"github.com/regclient/regclient/types/platform"
 	"github.com/regclient/regclient/types/ref"
-	"github.com/spf13/cobra"
 )
 
 var indexKnownTypes = []string{

--- a/cmd/regctl/main.go
+++ b/cmd/regctl/main.go
@@ -8,8 +8,9 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/regclient/regclient/internal/godbg"
 	"github.com/sirupsen/logrus"
+
+	"github.com/regclient/regclient/internal/godbg"
 )
 
 func main() {

--- a/cmd/regctl/manifest.go
+++ b/cmd/regctl/manifest.go
@@ -8,6 +8,9 @@ import (
 	"os"
 	"strings"
 
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
 	"github.com/regclient/regclient"
 	"github.com/regclient/regclient/internal/diff"
 	"github.com/regclient/regclient/pkg/template"
@@ -15,8 +18,6 @@ import (
 	"github.com/regclient/regclient/types/manifest"
 	"github.com/regclient/regclient/types/platform"
 	"github.com/regclient/regclient/types/ref"
-	"github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
 )
 
 type manifestCmd struct {

--- a/cmd/regctl/registry.go
+++ b/cmd/regctl/registry.go
@@ -9,11 +9,12 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/regclient/regclient"
-	"github.com/regclient/regclient/config"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
+
+	"github.com/regclient/regclient"
+	"github.com/regclient/regclient/config"
 )
 
 type registryCmd struct {

--- a/cmd/regctl/repo.go
+++ b/cmd/regctl/repo.go
@@ -3,10 +3,11 @@ package main
 import (
 	"strings"
 
-	"github.com/regclient/regclient/pkg/template"
-	"github.com/regclient/regclient/scheme"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+
+	"github.com/regclient/regclient/pkg/template"
+	"github.com/regclient/regclient/scheme"
 )
 
 type repoCmd struct {

--- a/cmd/regctl/root.go
+++ b/cmd/regctl/root.go
@@ -4,13 +4,14 @@ import (
 	"os"
 	"time"
 
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
 	"github.com/regclient/regclient"
 	"github.com/regclient/regclient/config"
 	"github.com/regclient/regclient/internal/version"
 	"github.com/regclient/regclient/pkg/template"
 	"github.com/regclient/regclient/scheme/reg"
-	"github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
 )
 
 const (

--- a/cmd/regctl/tag.go
+++ b/cmd/regctl/tag.go
@@ -4,11 +4,12 @@ import (
 	"fmt"
 	"regexp"
 
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
 	"github.com/regclient/regclient/pkg/template"
 	"github.com/regclient/regclient/scheme"
 	"github.com/regclient/regclient/types/ref"
-	"github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
 )
 
 type tagCmd struct {

--- a/cmd/regsync/config.go
+++ b/cmd/regsync/config.go
@@ -6,10 +6,11 @@ import (
 	"os"
 	"time"
 
+	"gopkg.in/yaml.v3"
+
 	"github.com/regclient/regclient/config"
 	"github.com/regclient/regclient/pkg/template"
 	"github.com/regclient/regclient/types"
-	"gopkg.in/yaml.v3"
 )
 
 // delay checking for at least 5 minutes when rate limit is exceeded

--- a/cmd/regsync/main.go
+++ b/cmd/regsync/main.go
@@ -7,8 +7,9 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/regclient/regclient/internal/godbg"
 	"github.com/sirupsen/logrus"
+
+	"github.com/regclient/regclient/internal/godbg"
 )
 
 func main() {

--- a/cmd/regsync/root.go
+++ b/cmd/regsync/root.go
@@ -15,6 +15,10 @@ import (
 	_ "crypto/sha512"
 
 	"github.com/opencontainers/go-digest"
+	"github.com/robfig/cron/v3"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
 	"github.com/regclient/regclient"
 	"github.com/regclient/regclient/config"
 	"github.com/regclient/regclient/internal/throttle"
@@ -26,9 +30,6 @@ import (
 	"github.com/regclient/regclient/types/manifest"
 	"github.com/regclient/regclient/types/platform"
 	"github.com/regclient/regclient/types/ref"
-	"github.com/robfig/cron/v3"
-	"github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
 )
 
 const (

--- a/config/host.go
+++ b/config/host.go
@@ -9,9 +9,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/regclient/regclient/internal/throttle"
 	"github.com/regclient/regclient/internal/timejson"
-	"github.com/sirupsen/logrus"
 )
 
 // TLSConf specifies whether TLS is enabled for a host

--- a/image.go
+++ b/image.go
@@ -19,6 +19,8 @@ import (
 	_ "crypto/sha512"
 
 	digest "github.com/opencontainers/go-digest"
+	"github.com/sirupsen/logrus"
+
 	"github.com/regclient/regclient/pkg/archive"
 	"github.com/regclient/regclient/scheme"
 	"github.com/regclient/regclient/types"
@@ -28,7 +30,6 @@ import (
 	"github.com/regclient/regclient/types/platform"
 	"github.com/regclient/regclient/types/ref"
 	"github.com/regclient/regclient/types/warning"
-	"github.com/sirupsen/logrus"
 )
 
 const (

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -9,8 +9,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/regclient/regclient/internal/reqresp"
 	"github.com/sirupsen/logrus"
+
+	"github.com/regclient/regclient/internal/reqresp"
 )
 
 func TestParseAuthHeader(t *testing.T) {

--- a/internal/reghttp/http.go
+++ b/internal/reghttp/http.go
@@ -26,12 +26,13 @@ import (
 	_ "crypto/sha512"
 
 	"github.com/opencontainers/go-digest"
+	"github.com/sirupsen/logrus"
+
 	"github.com/regclient/regclient/config"
 	"github.com/regclient/regclient/internal/auth"
 	"github.com/regclient/regclient/internal/throttle"
 	"github.com/regclient/regclient/types"
 	"github.com/regclient/regclient/types/warning"
-	"github.com/sirupsen/logrus"
 )
 
 var defaultDelayInit, _ = time.ParseDuration("1s")

--- a/internal/reghttp/http_test.go
+++ b/internal/reghttp/http_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/opencontainers/go-digest"
+
 	"github.com/regclient/regclient/config"
 	"github.com/regclient/regclient/internal/auth"
 	"github.com/regclient/regclient/internal/reqresp"

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -14,13 +14,14 @@ import (
 	"time"
 
 	"github.com/opencontainers/go-digest"
+	"github.com/sirupsen/logrus"
+
 	"github.com/regclient/regclient/config"
 	"github.com/regclient/regclient/internal/reqresp"
 	"github.com/regclient/regclient/types"
 	"github.com/regclient/regclient/types/docker/schema2"
 	"github.com/regclient/regclient/types/manifest"
 	"github.com/regclient/regclient/types/ref"
-	"github.com/sirupsen/logrus"
 )
 
 func TestManifest(t *testing.T) {

--- a/mod/dag.go
+++ b/mod/dag.go
@@ -9,6 +9,7 @@ import (
 	"io"
 
 	"github.com/opencontainers/go-digest"
+
 	"github.com/regclient/regclient"
 	"github.com/regclient/regclient/types"
 	"github.com/regclient/regclient/types/blob"

--- a/mod/layer.go
+++ b/mod/layer.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/opencontainers/go-digest"
+
 	"github.com/regclient/regclient"
 	"github.com/regclient/regclient/types/manifest"
 	"github.com/regclient/regclient/types/ref"

--- a/mod/manifest.go
+++ b/mod/manifest.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/opencontainers/go-digest"
+
 	"github.com/regclient/regclient"
 	"github.com/regclient/regclient/types"
 	"github.com/regclient/regclient/types/docker/schema2"

--- a/mod/mod.go
+++ b/mod/mod.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/opencontainers/go-digest"
+
 	"github.com/regclient/regclient"
 	"github.com/regclient/regclient/pkg/archive"
 	"github.com/regclient/regclient/types"

--- a/mod/mod_test.go
+++ b/mod/mod_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/opencontainers/go-digest"
+
 	"github.com/regclient/regclient"
 	"github.com/regclient/regclient/internal/rwfs"
 	"github.com/regclient/regclient/types"

--- a/regclient.go
+++ b/regclient.go
@@ -7,13 +7,14 @@ import (
 
 	"fmt"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/regclient/regclient/config"
 	"github.com/regclient/regclient/internal/rwfs"
 	"github.com/regclient/regclient/internal/version"
 	"github.com/regclient/regclient/scheme"
 	"github.com/regclient/regclient/scheme/ocidir"
 	"github.com/regclient/regclient/scheme/reg"
-	"github.com/sirupsen/logrus"
 )
 
 const (

--- a/regclient_test.go
+++ b/regclient_test.go
@@ -3,8 +3,9 @@ package regclient
 import (
 	"testing"
 
-	"github.com/regclient/regclient/scheme/reg"
 	"github.com/sirupsen/logrus"
+
+	"github.com/regclient/regclient/scheme/reg"
 )
 
 func TestNew(t *testing.T) {

--- a/scheme/ocidir/blob.go
+++ b/scheme/ocidir/blob.go
@@ -13,11 +13,12 @@ import (
 	_ "crypto/sha512"
 
 	"github.com/opencontainers/go-digest"
+	"github.com/sirupsen/logrus"
+
 	"github.com/regclient/regclient/internal/rwfs"
 	"github.com/regclient/regclient/types"
 	"github.com/regclient/regclient/types/blob"
 	"github.com/regclient/regclient/types/ref"
-	"github.com/sirupsen/logrus"
 )
 
 // BlobDelete removes a blob from the repository

--- a/scheme/ocidir/close.go
+++ b/scheme/ocidir/close.go
@@ -6,9 +6,10 @@ import (
 	"io/fs"
 	"path"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/regclient/regclient/types/manifest"
 	"github.com/regclient/regclient/types/ref"
-	"github.com/sirupsen/logrus"
 )
 
 // Close triggers a garbage collection if the underlying path has been modified

--- a/scheme/ocidir/close_test.go
+++ b/scheme/ocidir/close_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/opencontainers/go-digest"
+
 	"github.com/regclient/regclient/internal/rwfs"
 	"github.com/regclient/regclient/types/ref"
 )

--- a/scheme/ocidir/manifest.go
+++ b/scheme/ocidir/manifest.go
@@ -14,13 +14,14 @@ import (
 	_ "crypto/sha512"
 
 	"github.com/opencontainers/go-digest"
+	"github.com/sirupsen/logrus"
+
 	"github.com/regclient/regclient/internal/rwfs"
 	"github.com/regclient/regclient/internal/wraperr"
 	"github.com/regclient/regclient/scheme"
 	"github.com/regclient/regclient/types"
 	"github.com/regclient/regclient/types/manifest"
 	"github.com/regclient/regclient/types/ref"
-	"github.com/sirupsen/logrus"
 )
 
 // ManifestDelete removes a manifest, including all tags that point to that manifest

--- a/scheme/ocidir/manifest_test.go
+++ b/scheme/ocidir/manifest_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/opencontainers/go-digest"
+
 	"github.com/regclient/regclient/internal/rwfs"
 	"github.com/regclient/regclient/types"
 	"github.com/regclient/regclient/types/manifest"

--- a/scheme/ocidir/ocidir.go
+++ b/scheme/ocidir/ocidir.go
@@ -11,12 +11,13 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/regclient/regclient/internal/rwfs"
 	"github.com/regclient/regclient/internal/throttle"
 	"github.com/regclient/regclient/types"
 	v1 "github.com/regclient/regclient/types/oci/v1"
 	"github.com/regclient/regclient/types/ref"
-	"github.com/sirupsen/logrus"
 )
 
 const (

--- a/scheme/ocidir/ocidir_test.go
+++ b/scheme/ocidir/ocidir_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/opencontainers/go-digest"
+
 	"github.com/regclient/regclient/internal/rwfs"
 	"github.com/regclient/regclient/scheme"
 	"github.com/regclient/regclient/types"

--- a/scheme/ocidir/referrer_test.go
+++ b/scheme/ocidir/referrer_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"github.com/opencontainers/go-digest"
+	"github.com/sirupsen/logrus"
+
 	"github.com/regclient/regclient/internal/rwfs"
 	"github.com/regclient/regclient/scheme"
 	"github.com/regclient/regclient/types"
@@ -14,7 +16,6 @@ import (
 	v1 "github.com/regclient/regclient/types/oci/v1"
 	"github.com/regclient/regclient/types/platform"
 	"github.com/regclient/regclient/types/ref"
-	"github.com/sirupsen/logrus"
 )
 
 func TestReferrer(t *testing.T) {

--- a/scheme/reg/blob.go
+++ b/scheme/reg/blob.go
@@ -16,11 +16,12 @@ import (
 	_ "crypto/sha512"
 
 	"github.com/opencontainers/go-digest"
+	"github.com/sirupsen/logrus"
+
 	"github.com/regclient/regclient/internal/reghttp"
 	"github.com/regclient/regclient/types"
 	"github.com/regclient/regclient/types/blob"
 	"github.com/regclient/regclient/types/ref"
-	"github.com/sirupsen/logrus"
 )
 
 // BlobDelete removes a blob from the repository

--- a/scheme/reg/blob_test.go
+++ b/scheme/reg/blob_test.go
@@ -16,11 +16,12 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/opencontainers/go-digest"
+	"github.com/sirupsen/logrus"
+
 	"github.com/regclient/regclient/config"
 	"github.com/regclient/regclient/internal/reqresp"
 	"github.com/regclient/regclient/types"
 	"github.com/regclient/regclient/types/ref"
-	"github.com/sirupsen/logrus"
 )
 
 func TestBlobGet(t *testing.T) {

--- a/scheme/reg/manifest.go
+++ b/scheme/reg/manifest.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/regclient/regclient/internal/limitread"
 	"github.com/regclient/regclient/internal/reghttp"
 	"github.com/regclient/regclient/internal/wraperr"
@@ -15,7 +17,6 @@ import (
 	"github.com/regclient/regclient/types"
 	"github.com/regclient/regclient/types/manifest"
 	"github.com/regclient/regclient/types/ref"
-	"github.com/sirupsen/logrus"
 )
 
 // ManifestDelete removes a manifest by reference (digest) from a registry.

--- a/scheme/reg/manifest_test.go
+++ b/scheme/reg/manifest_test.go
@@ -14,13 +14,14 @@ import (
 	"time"
 
 	"github.com/opencontainers/go-digest"
+	"github.com/sirupsen/logrus"
+
 	"github.com/regclient/regclient/config"
 	"github.com/regclient/regclient/internal/reqresp"
 	"github.com/regclient/regclient/types"
 	"github.com/regclient/regclient/types/docker/schema2"
 	"github.com/regclient/regclient/types/manifest"
 	"github.com/regclient/regclient/types/ref"
-	"github.com/sirupsen/logrus"
 )
 
 func TestManifest(t *testing.T) {

--- a/scheme/reg/referrer_test.go
+++ b/scheme/reg/referrer_test.go
@@ -12,6 +12,8 @@ import (
 	"time"
 
 	"github.com/opencontainers/go-digest"
+	"github.com/sirupsen/logrus"
+
 	"github.com/regclient/regclient/config"
 	"github.com/regclient/regclient/internal/reqresp"
 	"github.com/regclient/regclient/scheme"
@@ -21,7 +23,6 @@ import (
 	v1 "github.com/regclient/regclient/types/oci/v1"
 	"github.com/regclient/regclient/types/platform"
 	"github.com/regclient/regclient/types/ref"
-	"github.com/sirupsen/logrus"
 )
 
 func TestReferrer(t *testing.T) {

--- a/scheme/reg/reg.go
+++ b/scheme/reg/reg.go
@@ -6,6 +6,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/regclient/regclient/config"
 	"github.com/regclient/regclient/internal/cache"
 	"github.com/regclient/regclient/internal/reghttp"
@@ -13,7 +15,6 @@ import (
 	"github.com/regclient/regclient/types/manifest"
 	"github.com/regclient/regclient/types/ref"
 	"github.com/regclient/regclient/types/referrer"
-	"github.com/sirupsen/logrus"
 )
 
 const (

--- a/scheme/reg/repo.go
+++ b/scheme/reg/repo.go
@@ -8,11 +8,12 @@ import (
 	"net/url"
 	"strconv"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/regclient/regclient/internal/reghttp"
 	"github.com/regclient/regclient/scheme"
 	"github.com/regclient/regclient/types"
 	"github.com/regclient/regclient/types/repo"
-	"github.com/sirupsen/logrus"
 )
 
 // RepoList returns a list of repositories on a registry

--- a/scheme/reg/repo_test.go
+++ b/scheme/reg/repo_test.go
@@ -12,11 +12,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/regclient/regclient/config"
 	"github.com/regclient/regclient/internal/reqresp"
 	"github.com/regclient/regclient/scheme"
 	"github.com/regclient/regclient/types"
-	"github.com/sirupsen/logrus"
 )
 
 func TestRepo(t *testing.T) {

--- a/scheme/reg/tag.go
+++ b/scheme/reg/tag.go
@@ -17,6 +17,8 @@ import (
 	_ "crypto/sha512"
 
 	"github.com/opencontainers/go-digest"
+	"github.com/sirupsen/logrus"
+
 	"github.com/regclient/regclient/internal/httplink"
 	"github.com/regclient/regclient/internal/reghttp"
 	"github.com/regclient/regclient/scheme"
@@ -27,7 +29,6 @@ import (
 	"github.com/regclient/regclient/types/platform"
 	"github.com/regclient/regclient/types/ref"
 	"github.com/regclient/regclient/types/tag"
-	"github.com/sirupsen/logrus"
 )
 
 // TagDelete removes a tag from a repository.

--- a/scheme/reg/tag_test.go
+++ b/scheme/reg/tag_test.go
@@ -15,12 +15,13 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/opencontainers/go-digest"
+	"github.com/sirupsen/logrus"
+
 	"github.com/regclient/regclient/config"
 	"github.com/regclient/regclient/internal/reqresp"
 	"github.com/regclient/regclient/scheme"
 	"github.com/regclient/regclient/types"
 	"github.com/regclient/regclient/types/ref"
-	"github.com/sirupsen/logrus"
 )
 
 func TestTag(t *testing.T) {

--- a/types/blob/blob.go
+++ b/types/blob/blob.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/opencontainers/go-digest"
+
 	"github.com/regclient/regclient/types"
 	v1 "github.com/regclient/regclient/types/oci/v1"
 	"github.com/regclient/regclient/types/ref"

--- a/types/blob/blob_test.go
+++ b/types/blob/blob_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/opencontainers/go-digest"
+
 	"github.com/regclient/regclient/types"
 	v1 "github.com/regclient/regclient/types/oci/v1"
 	"github.com/regclient/regclient/types/ref"

--- a/types/blob/common.go
+++ b/types/blob/common.go
@@ -8,6 +8,7 @@ import (
 	_ "crypto/sha512"
 
 	"github.com/opencontainers/go-digest"
+
 	"github.com/regclient/regclient/types"
 	"github.com/regclient/regclient/types/ref"
 )

--- a/types/blob/ociconfig.go
+++ b/types/blob/ociconfig.go
@@ -9,6 +9,7 @@ import (
 	_ "crypto/sha512"
 
 	"github.com/opencontainers/go-digest"
+
 	"github.com/regclient/regclient/types"
 	v1 "github.com/regclient/regclient/types/oci/v1"
 )

--- a/types/blob/reader.go
+++ b/types/blob/reader.go
@@ -10,6 +10,7 @@ import (
 	_ "crypto/sha512"
 
 	"github.com/opencontainers/go-digest"
+
 	"github.com/regclient/regclient/internal/limitread"
 	"github.com/regclient/regclient/types"
 )

--- a/types/blob/tar.go
+++ b/types/blob/tar.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/opencontainers/go-digest"
+
 	"github.com/regclient/regclient/internal/limitread"
 	"github.com/regclient/regclient/pkg/archive"
 	"github.com/regclient/regclient/types"

--- a/types/descriptor.go
+++ b/types/descriptor.go
@@ -11,6 +11,7 @@ import (
 	_ "crypto/sha512"
 
 	"github.com/opencontainers/go-digest"
+
 	"github.com/regclient/regclient/internal/units"
 	"github.com/regclient/regclient/types/platform"
 )

--- a/types/descriptor_test.go
+++ b/types/descriptor_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/opencontainers/go-digest"
+
 	"github.com/regclient/regclient/types/platform"
 )
 

--- a/types/docker/schema1/manifest.go
+++ b/types/docker/schema1/manifest.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/docker/libtrust"
 	"github.com/opencontainers/go-digest"
+
 	"github.com/regclient/regclient/types"
 	"github.com/regclient/regclient/types/docker"
 )

--- a/types/manifest/common.go
+++ b/types/manifest/common.go
@@ -10,6 +10,7 @@ import (
 	_ "crypto/sha512"
 
 	digest "github.com/opencontainers/go-digest"
+
 	"github.com/regclient/regclient/types"
 	"github.com/regclient/regclient/types/ref"
 )

--- a/types/manifest/docker1.go
+++ b/types/manifest/docker1.go
@@ -11,6 +11,7 @@ import (
 	_ "crypto/sha512"
 
 	digest "github.com/opencontainers/go-digest"
+
 	"github.com/regclient/regclient/types"
 	"github.com/regclient/regclient/types/docker/schema1"
 	"github.com/regclient/regclient/types/platform"

--- a/types/manifest/docker2.go
+++ b/types/manifest/docker2.go
@@ -12,6 +12,7 @@ import (
 	_ "crypto/sha512"
 
 	digest "github.com/opencontainers/go-digest"
+
 	"github.com/regclient/regclient/internal/units"
 	"github.com/regclient/regclient/types"
 	"github.com/regclient/regclient/types/docker/schema2"

--- a/types/manifest/manifest.go
+++ b/types/manifest/manifest.go
@@ -15,6 +15,7 @@ import (
 	_ "crypto/sha512"
 
 	digest "github.com/opencontainers/go-digest"
+
 	"github.com/regclient/regclient/types"
 	"github.com/regclient/regclient/types/docker/schema1"
 	"github.com/regclient/regclient/types/docker/schema2"

--- a/types/manifest/manifest_test.go
+++ b/types/manifest/manifest_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/opencontainers/go-digest"
+
 	"github.com/regclient/regclient/types"
 	"github.com/regclient/regclient/types/docker/schema1"
 	"github.com/regclient/regclient/types/docker/schema2"

--- a/types/manifest/oci1.go
+++ b/types/manifest/oci1.go
@@ -12,6 +12,7 @@ import (
 	_ "crypto/sha512"
 
 	digest "github.com/opencontainers/go-digest"
+
 	"github.com/regclient/regclient/internal/units"
 	"github.com/regclient/regclient/types"
 	v1 "github.com/regclient/regclient/types/oci/v1"

--- a/types/oci/v1/config.go
+++ b/types/oci/v1/config.go
@@ -10,6 +10,7 @@ import (
 	_ "crypto/sha512"
 
 	digest "github.com/opencontainers/go-digest"
+
 	"github.com/regclient/regclient/types/platform"
 )
 

--- a/types/referrer/referrer.go
+++ b/types/referrer/referrer.go
@@ -8,6 +8,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/opencontainers/go-digest"
+
 	"github.com/regclient/regclient/types"
 	"github.com/regclient/regclient/types/manifest"
 	v1 "github.com/regclient/regclient/types/oci/v1"

--- a/types/referrer/referrer_test.go
+++ b/types/referrer/referrer_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/opencontainers/go-digest"
+
 	"github.com/regclient/regclient/types"
 	"github.com/regclient/regclient/types/manifest"
 	v1 "github.com/regclient/regclient/types/oci/v1"


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

The recommended ordering of Go imports is the standard library, then 3rd party imports, and last the local imports. This uses goimport to implement that.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
make # build everything including gofmt and goimport
make goimport # cleanup imports
make lint-goimport # fail if go imports are in the wrong order
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Chore: reorder Go imports to move local packages last.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
