### PR TITLE
Fix regbot reproducible build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -108,7 +108,7 @@ jobs:
         target: release-${{ matrix.type }}
         outputs: type=oci,dest=output/${{matrix.image}}-${{matrix.type}}.tar
         build-args: |
-          SOURCE_DATE_EPOC=${{ steps.prep.outputs.vcs_sec }}
+          SOURCE_DATE_EPOCH=${{ steps.prep.outputs.vcs_sec }}
         labels: |
           org.opencontainers.image.created=${{ steps.prep.outputs.created }}
           org.opencontainers.image.source=${{ steps.prep.outputs.repo_url }}

--- a/build/Dockerfile.regbot
+++ b/build/Dockerfile.regbot
@@ -57,7 +57,8 @@ RUN apk add curl \
  && curl -fL https://raw.githubusercontent.com/kikito/semver.lua/${SEMVER_COMMIT}/semver.lua > /lua/semver.lua \
  && cd /lua \
  && ln -s lunajson.lua json.lua \
- && SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH}:-$(date +%s)}" find . -exec touch --date="@${SOURCE_DATE_EPOCH}" '{}' \;
+ && SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$(date +%s)}" sh -c 'find . -exec touch --date="@${SOURCE_DATE_EPOCH}" {} \;'
+
 
 FROM ${REGISTRY}/library/alpine:${ALPINE_VER} as release-alpine
 COPY --from=build /etc/passwd /etc/group /etc/

--- a/build/Dockerfile.regbot.buildkit
+++ b/build/Dockerfile.regbot.buildkit
@@ -76,7 +76,7 @@ RUN apk add curl \
  && curl -fL https://raw.githubusercontent.com/kikito/semver.lua/${SEMVER_COMMIT}/semver.lua > /lua/semver.lua \
  && cd /lua \
  && ln -s lunajson.lua json.lua \
- && SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH}:-$(date +%s)}" find . -exec touch --date="@${SOURCE_DATE_EPOCH}" '{}' \;
+ && SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$(date +%s)}" sh -c 'find . -exec touch --date="@${SOURCE_DATE_EPOCH}" {} \;'
 
 FROM ${REGISTRY}/library/alpine:${ALPINE_VER} as release-alpine
 COPY --from=build /etc/passwd /etc/group /etc/


### PR DESCRIPTION
First, `SOURCE_DATE_EPOCH` was misspelled in the workflow file, so the vcs_sec value did not get passed in correctly.

Second, the fallback had a syntax error:

```
    SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH}:-$(date +%s)}"
                                          ^
```

The accidental `}` meant that something like `:-1696222361}` would unconditionally get appended.  If `$SOURCE_DATE_EPOCH` was e.g. `1234567890`, it would get changed to `1234567890:-1696222361}`.

If it wasn't set to begin with, it would become `:-1696222361}`.

Third, the reason it works when `SOURCE_DATE_EPOCH` is passed in correctly is that the shell construct where `SOURCE_DATE_EPOCH` was to be used does not work as expected:

    SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$(date +%s)}" find . -exec touch --date="@${SOURCE_DATE_EPOCH}" '{}' \;

Setting `SOURCE_DATE_EPOCH` in this manner causes it to be passed as an environment variable to `find`. However, it is not `find` that expands `@${SOURCE_DATE_EPOCH}` in the `--date` argument. That is done by the shell. The shell has the original value of `SOURCE_DATE_EPOCH`.