### PR TITLE
Add GetSize method on images

### DIFF
--- a/types/manifest/docker1.go
+++ b/types/manifest/docker1.go
@@ -101,6 +101,14 @@ func (m *docker1SignedManifest) GetPlatformList() ([]*platform.Platform, error) 
 	return nil, fmt.Errorf("platform list not available for media type %s%.0w", m.desc.MediaType, types.ErrUnsupportedMediaType)
 }
 
+func (m *docker1Manifest) GetSize() (int64, error) {
+	return 0, fmt.Errorf("GetSize is not available for media type %s%.0w", m.desc.MediaType, types.ErrUnsupportedMediaType)
+}
+
+func (m *docker1SignedManifest) GetSize() (int64, error) {
+	return 0, fmt.Errorf("GetSize is not available for media type %s%.0w", m.desc.MediaType, types.ErrUnsupportedMediaType)
+}
+
 func (m *docker1Manifest) MarshalJSON() ([]byte, error) {
 	if !m.manifSet {
 		return []byte{}, types.ErrManifestNotSet

--- a/types/manifest/docker2.go
+++ b/types/manifest/docker2.go
@@ -121,6 +121,18 @@ func (m *docker2ManifestList) GetPlatformList() ([]*platform.Platform, error) {
 	return getPlatformList(dl)
 }
 
+// GetSize returns the size in bytes of all layers
+func (m *docker2Manifest) GetSize() (int64, error) {
+	if !m.manifSet {
+		return 0, types.ErrManifestNotSet
+	}
+	var total int64
+	for _, d := range m.Layers {
+		total += d.Size
+	}
+	return total, nil
+}
+
 func (m *docker2Manifest) MarshalJSON() ([]byte, error) {
 	if !m.manifSet {
 		return []byte{}, types.ErrManifestNotSet

--- a/types/manifest/manifest.go
+++ b/types/manifest/manifest.go
@@ -80,6 +80,7 @@ type Imager interface {
 	GetLayers() ([]types.Descriptor, error)
 	SetConfig(d types.Descriptor) error
 	SetLayers(dl []types.Descriptor) error
+	GetSize() (int64, error)
 }
 
 // Subjecter is used by manifests that may have a subject field.

--- a/types/manifest/manifest_test.go
+++ b/types/manifest/manifest_test.go
@@ -423,7 +423,7 @@ func TestNew(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to unmarshal docker schema1 signed json: %v", err)
 	}
-	var tests = []struct {
+	var tt = []struct {
 		name        string
 		opts        []Opts
 		wantR       ref.Ref
@@ -434,6 +434,7 @@ func TestNew(t *testing.T) {
 		hasAnnot    bool
 		testPlat    string
 		wantPlat    types.Descriptor
+		wantSize    int64
 		testSubject bool
 		hasSubject  bool
 	}{
@@ -456,6 +457,7 @@ func TestNew(t *testing.T) {
 			wantE:       nil,
 			isSet:       true,
 			testAnnot:   true,
+			wantSize:    3659443,
 			testSubject: true,
 			hasAnnot:    true,
 		},
@@ -475,6 +477,7 @@ func TestNew(t *testing.T) {
 				Digest:    digestDockerSchema2,
 			},
 			testAnnot:   true,
+			wantSize:    3659443,
 			testSubject: true,
 			wantE:       nil,
 			isSet:       true,
@@ -535,6 +538,7 @@ func TestNew(t *testing.T) {
 			testAnnot:   true,
 			testSubject: true,
 			hasAnnot:    true,
+			wantSize:    657823,
 			hasSubject:  true,
 		},
 		{
@@ -555,6 +559,7 @@ func TestNew(t *testing.T) {
 			testSubject: true,
 			hasAnnot:    true,
 			hasSubject:  true,
+			wantSize:    1794499,
 		},
 		{
 			name: "OCI 1 Manifest List",
@@ -895,14 +900,14 @@ func TestNew(t *testing.T) {
 		Size:      1234,
 		Digest:    digest.FromString("test referrer"),
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			m, err := New(tt.opts...)
-			if tt.wantE != nil {
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			m, err := New(tc.opts...)
+			if tc.wantE != nil {
 				if err == nil {
-					t.Errorf("did not receive expected error %v", tt.wantE)
-				} else if !errors.Is(err, tt.wantE) && err.Error() != tt.wantE.Error() {
-					t.Errorf("expected error not received, expected %v, received %v", tt.wantE, err)
+					t.Errorf("did not receive expected error %v", tc.wantE)
+				} else if !errors.Is(err, tc.wantE) && err.Error() != tc.wantE.Error() {
+					t.Errorf("expected error not received, expected %v, received %v", tc.wantE, err)
 				}
 				return
 			}
@@ -921,16 +926,16 @@ func TestNew(t *testing.T) {
 			} else {
 				t.Errorf("MarshalPretty not available")
 			}
-			if tt.wantR.Scheme != "" && m.GetRef().CommonName() != tt.wantR.CommonName() {
-				t.Errorf("ref mismatch, expected %s, received %s", tt.wantR.CommonName(), m.GetRef().CommonName())
+			if tc.wantR.Scheme != "" && m.GetRef().CommonName() != tc.wantR.CommonName() {
+				t.Errorf("ref mismatch, expected %s, received %s", tc.wantR.CommonName(), m.GetRef().CommonName())
 			}
-			if tt.wantDesc.Digest != "" && GetDigest(m) != tt.wantDesc.Digest {
-				t.Errorf("digest mismatch, expected %s, received %s", tt.wantDesc.Digest, GetDigest(m))
+			if tc.wantDesc.Digest != "" && GetDigest(m) != tc.wantDesc.Digest {
+				t.Errorf("digest mismatch, expected %s, received %s", tc.wantDesc.Digest, GetDigest(m))
 			}
-			if tt.wantDesc.MediaType != "" && GetMediaType(m) != tt.wantDesc.MediaType {
-				t.Errorf("media type mismatch, expected %s, received %s", tt.wantDesc.MediaType, GetMediaType(m))
+			if tc.wantDesc.MediaType != "" && GetMediaType(m) != tc.wantDesc.MediaType {
+				t.Errorf("media type mismatch, expected %s, received %s", tc.wantDesc.MediaType, GetMediaType(m))
 			}
-			if !tt.isSet {
+			if !tc.isSet {
 				// test methods on unset manifest
 				if m.IsSet() {
 					t.Errorf("manifest reports it is set")
@@ -999,9 +1004,9 @@ func TestNew(t *testing.T) {
 					}
 				}
 			}
-			if tt.testAnnot {
+			if tc.testAnnot {
 				mr, ok := m.(Annotator)
-				if tt.hasAnnot {
+				if tc.hasAnnot {
 					if !ok {
 						t.Errorf("manifest does not support annotations")
 					}
@@ -1020,9 +1025,21 @@ func TestNew(t *testing.T) {
 					t.Errorf("manifest supports annotations")
 				}
 			}
-			if tt.testSubject {
+			if tc.wantSize > 0 {
+				if mi, ok := m.(Imager); ok {
+					size, err := mi.GetSize()
+					if err != nil {
+						t.Errorf("get size failed: %v", err)
+					} else if size != tc.wantSize {
+						t.Errorf("unexpected size, expected %d, received %d", tc.wantSize, size)
+					}
+				} else {
+					t.Errorf("manifest is not an imager")
+				}
+			}
+			if tc.testSubject {
 				mr, ok := m.(Subjecter)
-				if tt.hasSubject {
+				if tc.hasSubject {
 					if !ok {
 						t.Errorf("manifest does not support subject")
 					} else {
@@ -1042,17 +1059,17 @@ func TestNew(t *testing.T) {
 					t.Errorf("manifest supports subject")
 				}
 			}
-			if tt.testPlat != "" {
-				p, err := platform.Parse(tt.testPlat)
+			if tc.testPlat != "" {
+				p, err := platform.Parse(tc.testPlat)
 				if err != nil {
-					t.Errorf("failed to parse platform %s: %v", tt.testPlat, err)
+					t.Errorf("failed to parse platform %s: %v", tc.testPlat, err)
 					return
 				}
 				d, err := GetPlatformDesc(m, &p)
 				if err != nil {
 					t.Errorf("failed to get descriptor: %v", err)
-				} else if !tt.wantPlat.Same(*d) {
-					t.Errorf("received platform mismatch, expected %v, received %v", tt.wantPlat, *d)
+				} else if !tc.wantPlat.Same(*d) {
+					t.Errorf("received platform mismatch, expected %v, received %v", tc.wantPlat, *d)
 				}
 			}
 		})

--- a/types/manifest/oci1.go
+++ b/types/manifest/oci1.go
@@ -431,6 +431,30 @@ func (m *oci1Artifact) SetLayers(dl []types.Descriptor) error {
 	return m.updateDesc()
 }
 
+// GetSize returns the size in bytes of all layers
+func (m *oci1Manifest) GetSize() (int64, error) {
+	if !m.manifSet {
+		return 0, types.ErrManifestNotSet
+	}
+	var total int64
+	for _, d := range m.Layers {
+		total += d.Size
+	}
+	return total, nil
+}
+
+// GetSize returns the size in bytes of all layers
+func (m *oci1Artifact) GetSize() (int64, error) {
+	if !m.manifSet {
+		return 0, types.ErrManifestNotSet
+	}
+	var total int64
+	for _, d := range m.Blobs {
+		total += d.Size
+	}
+	return total, nil
+}
+
 func (m *oci1Manifest) SetLayers(dl []types.Descriptor) error {
 	if !m.manifSet {
 		return types.ErrManifestNotSet


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Fixes #562 
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This adds a `GetSize` method on the `Imager` interface used by images.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
$ regctl manifest get --platform local regclient/regctl:alpine --format '{{.GetSize}}'
15674121
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Feature: Add a `GetSize` method to image manifests (OCI and Docker2 manifests).
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
