### PR TITLE
Add regctl --host flag

### DIFF
--- a/docs/regctl.md
+++ b/docs/regctl.md
@@ -34,11 +34,19 @@ Available Commands:
 
 Flags:
   -h, --help                 help for regctl
+      --host stringArray     Registry hosts to add (reg=registry,user=username,pass=password,tls=enabled)
       --logopt stringArray   Log options
   -v, --verbosity string     Log level (debug, info, warn, error, fatal, panic) (default "warning")
 
 Use "regctl [command] --help" for more information about a command.
 ```
+
+`--host` allows registry access to be configured for the current command.
+The arguments are a comma separated list of key/value pairs.
+`reg` specifies the registry, using `docker.io` for Docker Hub.
+`user` specifies the username and `pass` specifies the password.
+`tls` is used to configure TLS with the values `enabled` (default), `disabled` (http), or `insecure` to trust unknown certificates.
+The option `--host reg=localhost:5000,tls=disabled` would adjust the command to access `localhost:5000` using http.
 
 `--logopt` currently accepts `json` to format all logs as json instead of text.
 This is useful for parsing in external tools like Elastic/Splunk.

--- a/internal/strparse/strparse.go
+++ b/internal/strparse/strparse.go
@@ -1,0 +1,91 @@
+// Package strparse is used to parse strings
+package strparse
+
+import (
+	"fmt"
+
+	"github.com/regclient/regclient/types"
+)
+
+// SplitCSKV splits a comma separated key=value list into a map
+func SplitCSKV(s string) (map[string]string, error) {
+	state := "key"
+	key := ""
+	val := ""
+	result := map[string]string{}
+	procKV := func() {
+		if key != "" {
+			result[key] = val
+		}
+		state = "key"
+		key = ""
+		val = ""
+	}
+	for _, c := range s {
+		switch state {
+		case "key":
+			switch c {
+			case '"':
+				state = "keyQuote"
+			case '\\':
+				state = "keyEscape"
+			case '=':
+				state = "val"
+			case ',':
+				procKV()
+			default:
+				key = key + string(c)
+			}
+		case "keyQuote":
+			switch c {
+			case '"':
+				state = "key"
+			case '\\':
+				state = "keyEscapeQuote"
+			default:
+				key = key + string(c)
+			}
+		case "keyEscape":
+			key = key + string(c)
+			state = "key"
+		case "keyEscapeQuote":
+			key = key + string(c)
+			state = "keyQuote"
+		case "val":
+			switch c {
+			case '"':
+				state = "valQuote"
+			case ',':
+				procKV()
+			case '\\':
+				state = "valEscape"
+			default:
+				val = val + string(c)
+			}
+		case "valQuote":
+			switch c {
+			case '"':
+				state = "val"
+			case '\\':
+				state = "valEscapeQuote"
+			default:
+				val = val + string(c)
+			}
+		case "valEscape":
+			val = val + string(c)
+			state = "val"
+		case "valEscapeQuote":
+			val = val + string(c)
+			state = "valQuote"
+		default:
+			return nil, fmt.Errorf("unhandled state: %s", state)
+		}
+	}
+	switch state {
+	case "val", "key":
+		procKV()
+	default:
+		return nil, fmt.Errorf("string parsing failed, end state: %s%.0w", state, types.ErrParsingFailed)
+	}
+	return result, nil
+}

--- a/internal/strparse/strparse_test.go
+++ b/internal/strparse/strparse_test.go
@@ -1,0 +1,107 @@
+package strparse
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/regclient/regclient/types"
+)
+
+func TestSplitCSKV(t *testing.T) {
+	tt := []struct {
+		name   string
+		str    string
+		result map[string]string
+		err    error
+	}{
+		{
+			name:   "empty",
+			result: map[string]string{},
+		},
+		{
+			name: "single",
+			str:  "key=value",
+			result: map[string]string{
+				"key": "value",
+			},
+		},
+		{
+			name: "multiple",
+			str:  "a=123,bcd=456",
+			result: map[string]string{
+				"a":   "123",
+				"bcd": "456",
+			},
+		},
+		{
+			name: "quote",
+			str:  `a="123,456",b=789`,
+			result: map[string]string{
+				"a": "123,456",
+				"b": "789",
+			},
+		},
+		{
+			name: "escape",
+			str:  `a\\d=123\,\"\\456,"b\\,=c"="7\\,89"`,
+			result: map[string]string{
+				"a\\d":   `123,"\456`,
+				"b\\,=c": "7\\,89",
+			},
+		},
+		{
+			name: "noValue",
+			str:  "a,b",
+			result: map[string]string{
+				"a": "",
+				"b": "",
+			},
+		},
+		{
+			name: "errEscapeKey",
+			str:  "a\\",
+			err:  types.ErrParsingFailed,
+		},
+		{
+			name: "errEscapeVal",
+			str:  "a=x\\",
+			err:  types.ErrParsingFailed,
+		},
+		{
+			name: "errQuoteKey",
+			str:  "a\"",
+			err:  types.ErrParsingFailed,
+		},
+		{
+			name: "errQuoteVal",
+			str:  "a=b\"",
+			err:  types.ErrParsingFailed,
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := SplitCSKV(tc.str)
+			if tc.err != nil {
+				if err == nil {
+					t.Errorf("did not fail")
+				} else if err.Error() != tc.err.Error() && !errors.Is(err, tc.err) {
+					t.Errorf("unexpected error, expected %v, received %v", tc.err, err)
+				}
+				return
+			} else if err != nil {
+				t.Errorf("unexpected error, received %v", err)
+				return
+			}
+			for k, v := range tc.result {
+				if result[k] != v {
+					t.Errorf("unexpected result for key %s, expected %s, received %s", k, v, result[k])
+				}
+			}
+			for k, v := range result {
+				if _, ok := tc.result[k]; !ok {
+					t.Errorf("unexpected key, %s = %s", k, v)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Fixes #552.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This adds a `regctl --host` flag allowing credentials to be passed for a single command.
E.g. `regctl --host 'reg=registry.example.org,user=joe,pass=Pa$$w0rd' image inspect registry.example.org/secret-project:tag`.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
regctl --host 'reg=localhost:5000,tls=disabled repo ls localhost:5000
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Add `regctl --host` flag to configure registries for a single command.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

Note: Tests were added for the contained `strparse` package, but not for `regctl` since that would require setting up a registry with authentication.
<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
