### PR TITLE
Fix crash on RepoList from invalid hostname

### DIFF
--- a/internal/reghttp/http.go
+++ b/internal/reghttp/http.go
@@ -707,6 +707,14 @@ func (c *Client) getHost(host string) *clientHost {
 		} else {
 			h.config = config.HostNewName(host)
 		}
+		// check for normalized hostname
+		if h.config.Name != host {
+			host = h.config.Name
+			hNormal, ok := c.host[host]
+			if ok && hNormal.initialized {
+				return hNormal
+			}
+		}
 	}
 	if h.auth == nil {
 		h.auth = map[string]auth.Auth{}

--- a/internal/reghttp/http_test.go
+++ b/internal/reghttp/http_test.go
@@ -1654,5 +1654,38 @@ func TestRegHttp(t *testing.T) {
 			t.Errorf("error closing request: %v", err)
 		}
 	})
+	t.Run("Host Normalized", func(t *testing.T) {
+		apiGet := map[string]ReqAPI{
+			"": {
+				Method:     "GET",
+				Repository: "project",
+				Path:       "manifests/tag-get",
+				Headers:    headers,
+				Digest:     getDigest,
+			},
+		}
+		getReq := &Req{
+			Host: tsHost + "/path",
+			APIs: apiGet,
+		}
+		resp, err := hc.Do(ctx, getReq)
+		if err != nil {
+			t.Errorf("failed to run get: %v", err)
+			return
+		}
+		if resp.HTTPResponse().StatusCode != 200 {
+			t.Errorf("invalid status code, expected 200, received %d", resp.HTTPResponse().StatusCode)
+		}
+		body, err := io.ReadAll(resp)
+		if err != nil {
+			t.Errorf("body read failure: %v", err)
+		} else if !bytes.Equal(body, getBody) {
+			t.Errorf("body read mismatch, expected %s, received %s", getBody, body)
+		}
+		err = resp.Close()
+		if err != nil {
+			t.Errorf("error closing request: %v", err)
+		}
+	})
 	// TODO: test various TLS configs (custom root for all hosts, custom root for one host, insecure)
 }

--- a/repo.go
+++ b/repo.go
@@ -2,6 +2,8 @@ package regclient
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/regclient/regclient/scheme"
 	"github.com/regclient/regclient/types"
@@ -15,6 +17,10 @@ type repoLister interface {
 // RepoList returns a list of repositories on a registry.
 // Note the underlying "_catalog" API is not supported on many cloud registries.
 func (rc *RegClient) RepoList(ctx context.Context, hostname string, opts ...scheme.RepoOpts) (*repo.RepoList, error) {
+	i := strings.Index(hostname, "/")
+	if i > 0 {
+		return nil, fmt.Errorf("invalid hostname: %s%.0w", hostname, types.ErrParsingFailed)
+	}
 	schemeAPI, err := rc.schemeGet("reg")
 	if err != nil {
 		return nil, err
@@ -24,5 +30,4 @@ func (rc *RegClient) RepoList(ctx context.Context, hostname string, opts ...sche
 		return nil, types.ErrNotImplemented
 	}
 	return rl.RepoList(ctx, hostname, opts...)
-
 }

--- a/repo_test.go
+++ b/repo_test.go
@@ -1,0 +1,33 @@
+package regclient
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/regclient/regclient/types"
+)
+
+func TestRepoList(t *testing.T) {
+	ctx := context.Background()
+	log := &logrus.Logger{
+		Out:       os.Stderr,
+		Formatter: new(logrus.TextFormatter),
+		Hooks:     make(logrus.LevelHooks),
+		Level:     logrus.WarnLevel,
+	}
+	delayInit, _ := time.ParseDuration("0.05s")
+	delayMax, _ := time.ParseDuration("0.10s")
+	rc := New(
+		WithLog(log),
+		WithRetryDelay(delayInit, delayMax),
+	)
+	_, err := rc.RepoList(ctx, "registry.example.com/path")
+	if !errors.Is(err, types.ErrParsingFailed) {
+		t.Errorf("RepoList unexpected error on hostname with a path: expected %v, received %v", types.ErrParsingFailed, err)
+	}
+}

--- a/scheme/reg/reg.go
+++ b/scheme/reg/reg.go
@@ -108,7 +108,15 @@ func (reg *Reg) hostGet(hostname string) *config.Host {
 	reg.muHost.Lock()
 	defer reg.muHost.Unlock()
 	if _, ok := reg.hosts[hostname]; !ok {
-		reg.hosts[hostname] = config.HostNewName(hostname)
+		newHost := config.HostNewName(hostname)
+		// check for normalized hostname
+		if newHost.Name != hostname {
+			hostname = newHost.Name
+			if h, ok := reg.hosts[hostname]; ok {
+				return h
+			}
+		}
+		reg.hosts[hostname] = newHost
 	}
 	return reg.hosts[hostname]
 }

--- a/scheme/reg/repo_test.go
+++ b/scheme/reg/repo_test.go
@@ -256,4 +256,20 @@ func TestRepo(t *testing.T) {
 		}
 		// error is a json error, no custom error type was made for this yet
 	})
+	t.Run("Normalize host", func(t *testing.T) {
+		u, _ := url.Parse(tss["registry"].URL)
+		host := u.Host
+		rl, err := reg.RepoList(ctx, host+"/path")
+		if err != nil {
+			t.Errorf("error listing repos: %v", err)
+			return
+		}
+		rlRepos, err := rl.GetRepos()
+		if err != nil {
+			t.Errorf("error retrieving repos: %v", err)
+		} else if stringSliceCmp(listRegistry, rlRepos) == false {
+			t.Errorf("repositories do not match: expected %v, received %v", listRegistry, rlRepos)
+		}
+	})
+
 }


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Fixes #575
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

The `regclient.RepoList` method does not validate inputs which could result in a crash. This resolves the underlying crash and adds a minimal sanity check on the RepoList hostname value.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Regsync with a config:

```yaml
sync:
  - source: registry.example.org/path
    target: destination.example.org/path
    type: registry
```

Should now fail gracefully.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Fix handling of invalid hostname in `regclient.RepoList`.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
