### PR TITLE
regsync: fix tag filter on server first pass

### DIFF
--- a/cmd/regsync/root.go
+++ b/cmd/regsync/root.go
@@ -547,7 +547,7 @@ func (rootOpts *rootCmd) processRepo(ctx context.Context, s ConfigSync, src, tgt
 		for sI >= 0 && tI >= 0 {
 			switch strings.Compare(sTagList[sI], tTagList[tI]) {
 			case 0:
-				sTagList = append(sTagList[:sI], sTagsList[sI+1:]...)
+				sTagList = append(sTagList[:sI], sTagList[sI+1:]...)
 				sI--
 				tI--
 			case -1:


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Fixes #576.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

On the `regsync server` startup, a first pass is run to only copy missing tags before falling back to the scheduled updates. This quickly gets new tags, but in this case, the generation of the tag list to copy had a minor error that caused the unfiltered list to be used.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

See linked issue.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Fix bug in regsync tag filtering when running as a server.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
