### PR TITLE
mod/layer: avoid allocations with `(*regexp.Regexp).MatchString`

### DIFF
--- a/mod/layer.go
+++ b/mod/layer.go
@@ -60,7 +60,7 @@ func WithLayerRmCreatedBy(re regexp.Regexp) Opts {
 				if ch.EmptyLayer {
 					continue
 				}
-				if re.Match([]byte(ch.CreatedBy)) {
+				if re.MatchString(ch.CreatedBy) {
 					delLayers = append(delLayers, i)
 				}
 				i++
@@ -132,7 +132,7 @@ func WithLayerStripFile(file string) Opts {
 	fileRE := regexp.MustCompile("^/?" + regexp.QuoteMeta(file) + "(/.*)?$")
 	return func(dc *dagConfig, dm *dagManifest) error {
 		dc.stepsLayerFile = append(dc.stepsLayerFile, func(c context.Context, rc *regclient.RegClient, rSrc, rTgt ref.Ref, dl *dagLayer, th *tar.Header, tr io.Reader) (*tar.Header, io.Reader, changes, error) {
-			if fileRE.Match([]byte(th.Name)) {
+			if fileRE.MatchString(th.Name) {
 				return th, tr, deleted, nil
 			}
 			return th, tr, unchanged, nil


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

### Describe the change

We should use `(*regexp.Regexp).MatchString` instead of `(*regexp.Regexp).Match([]byte(...))` when matching string to avoid unnecessary `[]byte` conversions and reduce allocations.

Example benchmark:

```go
var re = regexp.MustCompile("^COPY layer2.txt /layer2")

func BenchmarkMatch(b *testing.B) {
	for i := 0; i < b.N; i++ {
		if match := re.Match([]byte("COPY layer2.txt /layer2")); !match {
			b.Fail()
		}
	}
}

func BenchmarkMatchString(b *testing.B) {
	for i := 0; i < b.N; i++ {
		if match := re.MatchString("COPY layer2.txt /layer2"); !match {
			b.Fail()
		}
	}
}
```

Result:

```
goos: linux
goarch: amd64
pkg: github.com/regclient/regclient/mod
cpu: AMD Ryzen 7 PRO 4750U with Radeon Graphics
BenchmarkMatch-16          	 3593138	       487.0 ns/op	      24 B/op	       1 allocs/op
BenchmarkMatchString-16    	 5626380	       212.5 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/regclient/regclient/mod	4.553s
```

### How to verify it

```
go test ./mod
```

### Changelog text

<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [x] Tests have been added or not applicable
- [x] Documentation has been added, updated, or not applicable
- [x] Changes have been rebased to main
- [x] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
