### PR TITLE
RegClient: implement Ping() method

### DIFF
--- a/ping.go
+++ b/ping.go
@@ -2,31 +2,27 @@ package regclient
 
 import (
 	"context"
-	"fmt"
-	"strings"
-
 	"github.com/regclient/regclient/types"
+	"github.com/regclient/regclient/types/ref"
 )
 
 type repoPinger interface {
-	Ping(ctx context.Context, hostname string) error
+	Ping(ctx context.Context, r ref.Ref) error
 }
 
 // Ping accesses the registry's root endpoint, which allows to determine whether
 // the registry implements the OCI Distribution Specification and whether the
 // registry accepts the supplied credentials.
-func (rc *RegClient) Ping(ctx context.Context, hostname string) error {
-	i := strings.Index(hostname, "/")
-	if i > 0 {
-		return fmt.Errorf("invalid hostname: %s%.0w", hostname, types.ErrParsingFailed)
-	}
-	schemeAPI, err := rc.schemeGet("reg")
+func (rc *RegClient) Ping(ctx context.Context, r ref.Ref) error {
+	schemeAPI, err := rc.schemeGet(r.Scheme)
 	if err != nil {
 		return err
 	}
+
 	rp, ok := schemeAPI.(repoPinger)
 	if !ok {
 		return types.ErrNotImplemented
 	}
-	return rp.Ping(ctx, hostname)
+
+	return rp.Ping(ctx, r)
 }

--- a/ping.go
+++ b/ping.go
@@ -1,0 +1,32 @@
+package regclient
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/regclient/regclient/types"
+)
+
+type repoPinger interface {
+	Ping(ctx context.Context, hostname string) error
+}
+
+// Ping accesses the registry's root endpoint, which allows to determine whether
+// the registry implements the OCI Distribution Specification and whether the
+// registry accepts the supplied credentials.
+func (rc *RegClient) Ping(ctx context.Context, hostname string) error {
+	i := strings.Index(hostname, "/")
+	if i > 0 {
+		return fmt.Errorf("invalid hostname: %s%.0w", hostname, types.ErrParsingFailed)
+	}
+	schemeAPI, err := rc.schemeGet("reg")
+	if err != nil {
+		return err
+	}
+	rp, ok := schemeAPI.(repoPinger)
+	if !ok {
+		return types.ErrNotImplemented
+	}
+	return rp.Ping(ctx, hostname)
+}

--- a/scheme/reg/ping.go
+++ b/scheme/reg/ping.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"fmt"
 	"github.com/regclient/regclient/internal/reghttp"
+	"github.com/regclient/regclient/types/ref"
 )
 
-func (reg *Reg) Ping(ctx context.Context, hostname string) error {
+func (reg *Reg) Ping(ctx context.Context, r ref.Ref) error {
 	req := &reghttp.Req{
-		Host:      hostname,
+		Host:      r.Registry,
 		NoMirrors: true,
 		APIs: map[string]reghttp.ReqAPI{
 			"": {
@@ -17,13 +18,16 @@ func (reg *Reg) Ping(ctx context.Context, hostname string) error {
 			},
 		},
 	}
+
 	resp, err := reg.reghttp.Do(ctx, req)
 	if err != nil {
-		return fmt.Errorf("failed to ping registry %s: %w", hostname, err)
+		return fmt.Errorf("failed to ping registry %s: %w", r.Registry, err)
 	}
 	defer resp.Close()
+
 	if resp.HTTPResponse().StatusCode != 200 {
-		return fmt.Errorf("failed to ping registry %s: %w", hostname, reghttp.HTTPError(resp.HTTPResponse().StatusCode))
+		return fmt.Errorf("failed to ping registry %s: %w",
+			r.Registry, reghttp.HTTPError(resp.HTTPResponse().StatusCode))
 	}
 
 	return nil

--- a/scheme/reg/ping.go
+++ b/scheme/reg/ping.go
@@ -1,0 +1,30 @@
+package reg
+
+import (
+	"context"
+	"fmt"
+	"github.com/regclient/regclient/internal/reghttp"
+)
+
+func (reg *Reg) Ping(ctx context.Context, hostname string) error {
+	req := &reghttp.Req{
+		Host:      hostname,
+		NoMirrors: true,
+		APIs: map[string]reghttp.ReqAPI{
+			"": {
+				Method: "GET",
+				Path:   "",
+			},
+		},
+	}
+	resp, err := reg.reghttp.Do(ctx, req)
+	if err != nil {
+		return fmt.Errorf("failed to ping registry %s: %w", hostname, err)
+	}
+	defer resp.Close()
+	if resp.HTTPResponse().StatusCode != 200 {
+		return fmt.Errorf("failed to ping registry %s: %w", hostname, reghttp.HTTPError(resp.HTTPResponse().StatusCode))
+	}
+
+	return nil
+}


### PR DESCRIPTION
Problem: it's not possible to validate whether the credentials provided to the `RegClient` will work for a given repository without doing some operation on a manifest or a blob, which is not possible for CLI utilities using `github.com/regclient/regclient` providing a functionality similar to `docker login`, where we won't know the reference and a tag (or content digest) yet.

Solution: provide a `Ping()` method that will fail (see `end-1` [here](https://github.com/opencontainers/distribution-spec/blob/main/spec.md#endpoints)) when authentication is not valid or OCI Distribution Specification is not supported.