### PR TITLE
Add timeouts to http clients

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -94,12 +95,22 @@ type auth struct {
 // NewAuth creates a new Auth
 func NewAuth(opts ...Opts) Auth {
 	a := &auth{
-		httpClient: &http.Client{},
-		clientID:   defaultClientID,
-		credsFn:    DefaultCredsFn,
-		hbs:        map[string]HandlerBuild{},
-		hs:         map[string]map[string]Handler{},
-		authTypes:  []string{},
+		httpClient: &http.Client{
+			Transport: &http.Transport{
+				Dial: (&net.Dialer{
+					Timeout:   30 * time.Second,
+					KeepAlive: 30 * time.Second,
+				}).Dial,
+				TLSHandshakeTimeout:   10 * time.Second,
+				ResponseHeaderTimeout: 10 * time.Second,
+				ExpectContinueTimeout: 1 * time.Second,
+			},
+		},
+		clientID:  defaultClientID,
+		credsFn:   DefaultCredsFn,
+		hbs:       map[string]HandlerBuild{},
+		hs:        map[string]map[string]Handler{},
+		authTypes: []string{},
 	}
 	a.log = &logrus.Logger{
 		Out:       os.Stderr,

--- a/internal/reghttp/http.go
+++ b/internal/reghttp/http.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -120,7 +121,17 @@ type Opts func(*Client)
 // NewClient returns a client for handling requests
 func NewClient(opts ...Opts) *Client {
 	c := Client{
-		httpClient: &http.Client{},
+		httpClient: &http.Client{
+			Transport: &http.Transport{
+				Dial: (&net.Dialer{
+					Timeout:   30 * time.Second,
+					KeepAlive: 30 * time.Second,
+				}).Dial,
+				TLSHandshakeTimeout:   10 * time.Second,
+				ResponseHeaderTimeout: 10 * time.Second,
+				ExpectContinueTimeout: 1 * time.Second,
+			},
+		},
 		host:       map[string]*clientHost{},
 		retryLimit: DefaultRetryLimit,
 		delayInit:  defaultDelayInit,

--- a/internal/retryable/retryable.go
+++ b/internal/retryable/retryable.go
@@ -7,6 +7,7 @@ package retryable
 import (
 	"bytes"
 	"context"
+	"net"
 	"os"
 	"sync"
 
@@ -74,7 +75,17 @@ var defaultLimit = 3
 // NewRetryable returns a retryable interface
 func NewRetryable(opts ...Opts) Retryable {
 	r := &retryable{
-		httpClient: &http.Client{},
+		httpClient: &http.Client{
+			Transport: &http.Transport{
+				Dial: (&net.Dialer{
+					Timeout:   30 * time.Second,
+					KeepAlive: 30 * time.Second,
+				}).Dial,
+				TLSHandshakeTimeout:   10 * time.Second,
+				ResponseHeaderTimeout: 10 * time.Second,
+				ExpectContinueTimeout: 1 * time.Second,
+			},
+		},
 		limit:      defaultLimit,
 		delayInit:  defaultDelayInit,
 		delayMax:   defaultDelayMax,


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Unspecified timeouts on the HTTP client could result in indefinite delays for network issues.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Define HTTP client timeouts following the [guidance from cloudflare](https://blog.cloudflare.com/the-complete-guide-to-golang-net-http-timeouts/).
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Connecting to an IP that doesn't explicitly reject the connection (firewall drops the packets) should result in a few retries but no more than a 30 second delay for each connection attempt.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Configure HTTP client timeouts.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

Tests for connection failures are non-trivial to automate. This has been tested by hand.
<!-- Mark the following with an [X] to verify they are included -->

- [ ] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
