### PR TITLE
Makefile: $(BINARIES) depends on "vendor"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,9 +100,9 @@ vendor: ## Vendor Go modules
 	go mod vendor
 
 .PHONY: binaries
-binaries: vendor $(BINARIES) ## Build Go binaries
+binaries: $(BINARIES) ## Build Go binaries
 
-bin/%: .FORCE
+bin/%: .FORCE vendor
 	CGO_ENABLED=0 go build ${GO_BUILD_FLAGS} -o bin/$* ./cmd/$*
 
 .PHONY: docker


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Properly state the dependence between the binaries targets and vendor.

It prevent make parallel builds of the  "binaries" target (i.e. `make -j binaries`) to fail with errors `... is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt`

Re https://github.com/Homebrew/homebrew-core/pull/153571

### How to verify it

`make -j binaries`

### Changelog text

Enable parallel builds of the make "binaries" target.

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [ ] Tests have been added or not applicable
- [ ] Documentation has been added, updated, or not applicable
- [x] Changes have been rebased to main
- [x] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
