### PR TITLE
chore: remove vendor build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,7 +9,6 @@
 !regclient/
 !scheme/
 !types/
-!vendor/
 !go.*
 !*.go
 !Makefile

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 artifacts/
 bin/
 output/
-vendor/
 .regctl_conf_ci.json

--- a/Makefile
+++ b/Makefile
@@ -95,14 +95,10 @@ osv-scanner: $(GOPATH)/bin/osv-scanner .FORCE ## Run OSV Scanner
 vulncheck-go: $(GOPATH)/bin/govulncheck .FORCE ## Run govulncheck
 	$(GOPATH)/bin/govulncheck ./...
 
-.PHONY: vendor
-vendor: ## Vendor Go modules
-	go mod vendor
-
 .PHONY: binaries
 binaries: $(BINARIES) ## Build Go binaries
 
-bin/%: .FORCE vendor
+bin/%:
 	CGO_ENABLED=0 go build ${GO_BUILD_FLAGS} -o bin/$* ./cmd/$*
 
 .PHONY: docker
@@ -179,8 +175,7 @@ plugin-host:
 util-golang-update: ## update go module versions
 	go get -u -t ./...
 	go mod tidy
-	go mod vendor
-	
+
 .PHONY: util-version-check
 util-version-check: ## check all dependencies for updates
 	$(VER_BUMP) check

--- a/build/Dockerfile.regbot
+++ b/build/Dockerfile.regbot
@@ -20,7 +20,7 @@ FROM golang as build
 COPY go.* /src/
 RUN go mod download
 COPY . /src/
-RUN make vendor bin/regbot
+RUN make bin/regbot
 USER appuser
 CMD [ "/src/bin/regbot" ]
 

--- a/build/Dockerfile.regbot.buildkit
+++ b/build/Dockerfile.regbot.buildkit
@@ -31,7 +31,7 @@ COPY . /src/
 RUN --mount=type=cache,id=gomod,target=/go/pkg/mod/cache \
     --mount=type=cache,id=goroot,target=/root/.cache/go-build \
     GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
-    make vendor bin/regbot
+    make bin/regbot
 USER appuser
 CMD [ "bin/regbot" ]
 

--- a/build/Dockerfile.regctl
+++ b/build/Dockerfile.regctl
@@ -18,7 +18,7 @@ FROM golang as build
 COPY go.* /src/
 RUN go mod download
 COPY . /src/
-RUN make vendor bin/regctl
+RUN make bin/regctl
 USER appuser
 CMD [ "bin/regctl" ]
 

--- a/build/Dockerfile.regctl.buildkit
+++ b/build/Dockerfile.regctl.buildkit
@@ -29,7 +29,7 @@ COPY . /src/
 RUN --mount=type=cache,id=gomod,target=/go/pkg/mod/cache \
     --mount=type=cache,id=goroot,target=/root/.cache/go-build \
     GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
-    make vendor bin/regctl
+    make bin/regctl
 USER appuser
 CMD [ "bin/regctl" ]
 

--- a/build/Dockerfile.regsync
+++ b/build/Dockerfile.regsync
@@ -18,7 +18,7 @@ FROM golang as build
 COPY go.* /src/
 RUN go mod download
 COPY . /src/
-RUN make vendor bin/regsync
+RUN make bin/regsync
 USER appuser
 CMD [ "bin/regsync" ]
 

--- a/build/Dockerfile.regsync.buildkit
+++ b/build/Dockerfile.regsync.buildkit
@@ -29,7 +29,7 @@ COPY . /src/
 RUN --mount=type=cache,id=gomod,target=/go/pkg/mod/cache \
     --mount=type=cache,id=goroot,target=/root/.cache/go-build \
     GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
-    make vendor bin/regsync
+    make bin/regsync
 USER appuser
 CMD [ "bin/regsync" ]
 


### PR DESCRIPTION
### Describe the change

`go mod vendor` build got introduced in #2 (not sure about the context as it is already have the go module build setup), based on my go build experience, there is no need to have `go mod vendor`, especially the vendor folder is not checked in for this project either. 


### How to verify it

`go build` would verify the PR.

### Changelog text

- remove `go mod vendor` setup

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [ ] Tests have been added or not applicable
- [ ] Documentation has been added, updated, or not applicable
- [x] Changes have been rebased to main
- [x] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->

----

relates to https://github.com/Homebrew/homebrew-core/pull/153571