### PR TITLE
Align descriptor field order with OCI spec

### DIFF
--- a/types/descriptor.go
+++ b/types/descriptor.go
@@ -21,11 +21,11 @@ type Descriptor struct {
 	// MediaType describe the type of the content.
 	MediaType string `json:"mediaType"`
 
-	// Size in bytes of content.
-	Size int64 `json:"size"`
-
 	// Digest uniquely identifies the content.
 	Digest digest.Digest `json:"digest"`
+
+	// Size in bytes of content.
+	Size int64 `json:"size"`
 
 	// URLs contains the source URLs of this content.
 	URLs []string `json:"urls,omitempty"`

--- a/types/descriptor_test.go
+++ b/types/descriptor_test.go
@@ -460,8 +460,8 @@ func TestDataJSON(t *testing.T) {
 			name: "No Data",
 			dJSON: []byte(`{
 				"mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
-				"size":      941,
-				"digest":    "sha256:f6e2d7fa40092cf3d9817bf6ff54183d68d108a47fdf5a5e476c612626c80e14"
+				"digest":    "sha256:f6e2d7fa40092cf3d9817bf6ff54183d68d108a47fdf5a5e476c612626c80e14",
+				"size":      941
 			}`),
 			wantErr: ErrParsingFailed,
 		},
@@ -469,8 +469,8 @@ func TestDataJSON(t *testing.T) {
 			name: "Bad Data",
 			dJSON: []byte(`{
 				"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
-				"size":      1234,
 				"digest":    "sha256:f6e2d7fa40092cf3d9817bf6ff54183d68d108a47fdf5a5e476c612626c80e14",
+				"size":      1234,
 				"data":      "Invalid data string"
 			}`),
 			wantErr: fmt.Errorf("illegal base64 data at input byte 7"),
@@ -479,8 +479,8 @@ func TestDataJSON(t *testing.T) {
 			name: "Bad Digest",
 			dJSON: []byte(`{
 				"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
-				"size":      10,
 				"digest":    "sha256:e4a380728755139f156563e8b795581d5915dcc947fe937c524c6d52fd604b99",
+				"size":      10,
 				"data":      "ZXhhbXBsZSBkYXRh"
 			}`),
 			wantErr: ErrParsingFailed,
@@ -489,8 +489,8 @@ func TestDataJSON(t *testing.T) {
 			name: "Bad Size",
 			dJSON: []byte(`{
 				"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
-				"size":      1000,
 				"digest":    "sha256:44752f37272e944fd2c913a35342eaccdd1aaf189bae50676b301ab213fc5061",
+				"size":      1000,
 				"data":      "ZXhhbXBsZSBkYXRh"
 			}`),
 			wantErr: ErrParsingFailed,
@@ -499,8 +499,8 @@ func TestDataJSON(t *testing.T) {
 			name: "Good data",
 			dJSON: []byte(`{
 				"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
-				"size":      12,
 				"digest":    "sha256:44752f37272e944fd2c913a35342eaccdd1aaf189bae50676b301ab213fc5061",
+				"size":      12,
 				"data":      "ZXhhbXBsZSBkYXRh"
 			}`),
 			wantData: []byte("example data"),


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Fixes #593.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Adjust the field order to match the upstream OCI types.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Generating new JSON content will have digest before the size field. Note that JSON rendering of existing content is frequently passed through from the original source.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Chore: reorder descriptor fields.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
