### PR TITLE
BlobPut: improve the code readability a bit

### DIFF
--- a/scheme/reg/blob.go
+++ b/scheme/reg/blob.go
@@ -177,10 +177,6 @@ func (reg *Reg) BlobMount(ctx context.Context, rSrc ref.Ref, rTgt ref.Ref, d typ
 func (reg *Reg) BlobPut(ctx context.Context, r ref.Ref, d types.Descriptor, rdr io.Reader) (types.Descriptor, error) {
 	var putURL *url.URL
 	var err error
-	// defaults for content-type and length
-	if d.Size == 0 {
-		d.Size = -1
-	}
 
 	// attempt an anonymous blob mount
 	if d.Digest != "" && d.Size > 0 {

--- a/scheme/reg/blob.go
+++ b/scheme/reg/blob.go
@@ -197,7 +197,7 @@ func (reg *Reg) BlobPut(ctx context.Context, r ref.Ref, d types.Descriptor, rdr 
 	}
 
 	// send upload as one-chunk
-	tryPut := bool(d.Digest != "" && d.Size > 0)
+	tryPut := d.Digest != "" && d.Size > 0
 	if tryPut {
 		host := reg.hostGet(r.Registry)
 		maxPut := host.BlobMax


### PR DESCRIPTION
~~It makes no sense to perform a chunked upload of zero-byte blobs.~~ 

~~@sudo-bmitch I also don't understand why should `BlobPut()` mess with the descriptor's size when it's zero, perhaps you could clarify this.~~

Remaining code readability changes after a review.