### PR TITLE
Use http.Client default values

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -97,22 +96,12 @@ type auth struct {
 // NewAuth creates a new Auth
 func NewAuth(opts ...Opts) Auth {
 	a := &auth{
-		httpClient: &http.Client{
-			Transport: &http.Transport{
-				Dial: (&net.Dialer{
-					Timeout:   30 * time.Second,
-					KeepAlive: 30 * time.Second,
-				}).Dial,
-				TLSHandshakeTimeout:   10 * time.Second,
-				ResponseHeaderTimeout: 10 * time.Second,
-				ExpectContinueTimeout: 1 * time.Second,
-			},
-		},
-		clientID:  defaultClientID,
-		credsFn:   DefaultCredsFn,
-		hbs:       map[string]HandlerBuild{},
-		hs:        map[string]map[string]Handler{},
-		authTypes: []string{},
+		httpClient: &http.Client{},
+		clientID:   defaultClientID,
+		credsFn:    DefaultCredsFn,
+		hbs:        map[string]HandlerBuild{},
+		hs:         map[string]map[string]Handler{},
+		authTypes:  []string{},
 	}
 	a.log = &logrus.Logger{
 		Out:       os.Stderr,

--- a/internal/reghttp/http.go
+++ b/internal/reghttp/http.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -121,17 +120,7 @@ type Opts func(*Client)
 // NewClient returns a client for handling requests
 func NewClient(opts ...Opts) *Client {
 	c := Client{
-		httpClient: &http.Client{
-			Transport: &http.Transport{
-				Dial: (&net.Dialer{
-					Timeout:   30 * time.Second,
-					KeepAlive: 30 * time.Second,
-				}).Dial,
-				TLSHandshakeTimeout:   10 * time.Second,
-				ResponseHeaderTimeout: 10 * time.Second,
-				ExpectContinueTimeout: 1 * time.Second,
-			},
-		},
+		httpClient: &http.Client{},
 		host:       map[string]*clientHost{},
 		retryLimit: DefaultRetryLimit,
 		delayInit:  defaultDelayInit,

--- a/internal/retryable/retryable.go
+++ b/internal/retryable/retryable.go
@@ -7,7 +7,6 @@ package retryable
 import (
 	"bytes"
 	"context"
-	"net"
 	"os"
 	"sync"
 
@@ -75,17 +74,7 @@ var defaultLimit = 3
 // NewRetryable returns a retryable interface
 func NewRetryable(opts ...Opts) Retryable {
 	r := &retryable{
-		httpClient: &http.Client{
-			Transport: &http.Transport{
-				Dial: (&net.Dialer{
-					Timeout:   30 * time.Second,
-					KeepAlive: 30 * time.Second,
-				}).Dial,
-				TLSHandshakeTimeout:   10 * time.Second,
-				ResponseHeaderTimeout: 10 * time.Second,
-				ExpectContinueTimeout: 1 * time.Second,
-			},
-		},
+		httpClient: &http.Client{},
 		limit:      defaultLimit,
 		delayInit:  defaultDelayInit,
 		delayMax:   defaultDelayMax,


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

This fixes proxy connections, limits idle connections, and uses HTTP2.
Fixes #614.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Rollback #584. Timeouts were already included in `http.DefaultTransport`:

```golang
var DefaultTransport RoundTripper = &Transport{
	Proxy: ProxyFromEnvironment,
	DialContext: defaultTransportDialContext(&net.Dialer{
		Timeout:   30 * time.Second,
		KeepAlive: 30 * time.Second,
	}),
	ForceAttemptHTTP2:     true,
	MaxIdleConns:          100,
	IdleConnTimeout:       90 * time.Second,
	TLSHandshakeTimeout:   10 * time.Second,
	ExpectContinueTimeout: 1 * time.Second,
}
```

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Proxies defined with `http_proxy` and `https_proxy` should work again.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Fix: HTTP proxy using environment variables.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [ ] Tests have been added or not applicable
- [x] Documentation has been added, updated, or not applicable
- [x] Changes have been rebased to main
- [x] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
