### PR TITLE
Add: Supports multiple image export and import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ bin/
 output/
 vendor/
 .regctl_conf_ci.json
+.idea/

--- a/cmd/regbot/sandbox/image.go
+++ b/cmd/regbot/sandbox/image.go
@@ -251,7 +251,7 @@ func (s *Sandbox) imageExportTar(ls *lua.LState) int {
 	if err != nil {
 		ls.RaiseError("Failed to open \"%s\": %v", file, err)
 	}
-	err = s.rc.ImageExport(s.ctx, src.r, fh)
+	err = s.rc.ImageExport(s.ctx, []ref.Ref{src.r}, "", fh)
 	if err != nil {
 		ls.RaiseError("Failed to export image \"%s\" to \"%s\": %v", src.r.CommonName(), file, err)
 	}
@@ -277,7 +277,7 @@ func (s *Sandbox) imageImportTar(ls *lua.LState) int {
 	if err != nil {
 		ls.RaiseError("Failed to read from \"%s\": %v", file, err)
 	}
-	err = s.rc.ImageImport(s.ctx, tgt.r, rs)
+	err = s.rc.ImageImport(s.ctx, []ref.Ref{tgt.r}, rs.Name(), rs)
 	if err != nil {
 		ls.RaiseError("Failed to import image \"%s\" from \"%s\": %v", tgt.r.CommonName(), file, err)
 	}


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->
https://github.com/regclient/regclient/issues/616

### Describe the change

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

Can you consider supporting downloading multiple images and compressing them into A.AR

### How to verify it

<!-- Include steps that can be taken to verify the change -->

regctl  image export   xxx.xxx/xxx/mysql:5.7,xxx.xxx/xxx/zulu-openjdk:8u345,xxx.xxx/xxx/adoptjdk11:javaGeneralImage a.tar
regctl  image import   xxx.xxx/xxx/mysql:5.7,xxx.xxx/xxx/zulu-openjdk:8u345,xxx.xxx/xxx/adoptjdk11:javaGeneralImage a.tar 
### Changelog text

<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [x] Tests have been added or not applicable
- [x] Documentation has been added, updated, or not applicable
- [x] Changes have been rebased to main
- [x] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
