### PR TITLE
Handle unretryable failures in http requests

### DIFF
--- a/scheme/reg/blob_test.go
+++ b/scheme/reg/blob_test.go
@@ -1072,6 +1072,22 @@ func TestBlobPut(t *testing.T) {
 		}
 	})
 
+	t.Run("Not retryable", func(t *testing.T) {
+		r, err := ref.New("retry." + tsURL.Host + blobRepo)
+		if err != nil {
+			t.Errorf("Failed creating ref: %v", err)
+		}
+		br := bytes.NewReader(blob2)
+		_, err = reg.BlobPut(ctx, r, types.Descriptor{Digest: d2, Size: int64(len(blob2))}, io.NopCloser(br))
+		if err == nil {
+			t.Errorf("Blob put succeeded on a gateway timeout")
+			return
+		}
+		if !errors.Is(err, types.ErrHTTPStatus) {
+			t.Errorf("unexpected err, expected %v, received %v", types.ErrHTTPStatus, err)
+		}
+	})
+
 	t.Run("PartialChunk", func(t *testing.T) {
 		r, err := ref.New(tsURL.Host + blobRepo)
 		if err != nil {

--- a/types/error.go
+++ b/types/error.go
@@ -55,6 +55,8 @@ var (
 	ErrNotFound = errors.New("not found")
 	// ErrNotImplemented returned when method has not been implemented yet
 	ErrNotImplemented = errors.New("not implemented")
+	// ErrNotRetryable indicates the process cannot be retried
+	ErrNotRetryable = errors.New("not retryable")
 	// ErrParsingFailed when a string cannot be parsed
 	ErrParsingFailed = errors.New("parsing failed")
 	// ErrRetryNeeded indicates a request needs to be retried


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Fixes #621.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

The blob put method depends on the input being an io.Seeker for retries. If that is not the case, abort and return the previous error.

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Fix: Improve error handling on blob put retries when source is not an io.Seeker.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [x] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
