### PR TITLE
Change go.mod version to oldest supported release

### DIFF
--- a/.version-bump.yml
+++ b/.version-bump.yml
@@ -125,7 +125,7 @@ scans:
       repo: "github.com/sigstore/cosign"
   go-mod-golang-release:
     type: "regexp"
-    source: "registry-golang-latest"
+    source: "registry-golang-oldest"
     args:
       regexp: '^go (?P<Version>[0-9\.]+)\s*$'
   makefile-gomajor:
@@ -222,6 +222,17 @@ sources:
       expr: '^\d+\.\d+$'
     sort:
       method: "semver"
+  registry-golang-oldest:
+    type: "registry"
+    key: "golang-oldest"
+    args:
+      repo: "golang"
+      type: "tag"
+    filter:
+      expr: '^\d+\.\d+$'
+    sort:
+      method: "semver"
+    template: '{{ index .VerMap ( index .VerList 2 ) }}'
   registry-golang-matrix:
     type: "registry"
     key: "golang-matrix"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/regclient/regclient
 
-go 1.21
+go 1.19
 
 require (
 	github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7


### PR DESCRIPTION
This project supports the last 3 major Go versions. Go itself only supports the last 2 major releases.

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Projects that depend on this may be forced to upgrade prematurely.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This sets the version in the go.mod to the oldest supported release. The various commands built by the project are still using the latest release of Go.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Chore: go.mod version is now set to oldest supported release.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [x] Tests have been added or not applicable
- [x] Documentation has been added, updated, or not applicable
- [x] Changes have been rebased to main
- [x] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
