### PR TITLE
feat(proxy): add support for host level proxy

### DIFF
--- a/config/host.go
+++ b/config/host.go
@@ -128,6 +128,7 @@ type Host struct {
 	ReqPerSec     float64            `json:"reqPerSec,omitempty" yaml:"reqPerSec"`         // requests per second, default is defaultReqPerSec(10)
 	ReqConcurrent int64              `json:"reqConcurrent,omitempty" yaml:"reqConcurrent"` // concurrent requests, default is defaultConcurrent(3)
 	Scheme        string             `json:"scheme,omitempty" yaml:"scheme"`               // Deprecated: use TLS instead
+	Proxy         string             `json:"proxy,omitempty" yaml:"proxy"`                 // Proxy by host
 	credRefresh   time.Time          `json:"-" yaml:"-"`                                   // internal use, when to refresh credentials
 	throttle      *throttle.Throttle `json:"-" yaml:"-"`                                   // internal use, limit for concurrent requests
 }
@@ -471,6 +472,10 @@ func (host *Host) Merge(newHost Host, log *logrus.Logger) error {
 			}).Warn("Changing reqPerSec settings for registry")
 		}
 		host.ReqConcurrent = newHost.ReqConcurrent
+	}
+
+	if newHost.Proxy != "" {
+		host.Proxy = newHost.Proxy
 	}
 
 	return nil

--- a/config/host_test.go
+++ b/config/host_test.go
@@ -110,7 +110,8 @@ func TestConfig(t *testing.T) {
 		"priority": 42,
 		"apiOpts": {"disableHead": "true"},
 		"blobChunk": 123456,
-		"blobMax": 999999
+		"blobMax": 999999,
+		"proxy": "socks5://127.0.0.1"
 	}
 	`
 	exJSON2 := `
@@ -127,7 +128,8 @@ func TestConfig(t *testing.T) {
 		"priority": 42,
 		"apiOpts": {"disableHead": "false", "unknownOpt": "3"},
 		"blobChunk": 333333,
-		"blobMax": 333333
+		"blobMax": 333333,
+		"proxy": "socks5://127.0.0.1"
 	}
 	`
 	exJSONCredHelper := `
@@ -135,7 +137,8 @@ func TestConfig(t *testing.T) {
 	  "tls": "insecure",
 		"hostname": "testhost.example.com",
 		"credHelper": "docker-credential-test",
-		"credExpire": "1h0m0s"
+		"credExpire": "1h0m0s",
+		"proxy": "socks5://127.0.0.1"
 	}
 	`
 	var exHost, exHost2, exHostCredHelper Host
@@ -192,6 +195,7 @@ func TestConfig(t *testing.T) {
 			hostExpect: Host{
 				TLS:     TLSEnabled,
 				APIOpts: map[string]string{},
+				Proxy:   "socks5://127.0.0.1",
 			},
 			credExpect: Cred{},
 		},
@@ -202,6 +206,7 @@ func TestConfig(t *testing.T) {
 				TLS:      TLSEnabled,
 				Hostname: "host.example.org",
 				APIOpts:  map[string]string{},
+				Proxy:    "socks5://127.0.0.1",
 			},
 			credExpect: Cred{},
 		},
@@ -219,6 +224,7 @@ func TestConfig(t *testing.T) {
 				APIOpts:    map[string]string{"disableHead": "true"},
 				PathPrefix: "hub",
 				Mirrors:    []string{"host1.example.com", "host2.example.com"},
+				Proxy:      "socks5://127.0.0.1",
 			},
 			credExpect: Cred{
 				User:     "user-ex",
@@ -242,6 +248,7 @@ func TestConfig(t *testing.T) {
 				APIOpts:    map[string]string{"disableHead": "false", "unknownOpt": "3"},
 				BlobChunk:  333333,
 				BlobMax:    333333,
+				Proxy:      "socks5://127.0.0.1",
 			},
 			credExpect: Cred{
 				User:     "user-ex3",
@@ -257,6 +264,7 @@ func TestConfig(t *testing.T) {
 				CredHelper: "docker-credential-test",
 				CredExpire: timejson.Duration(time.Hour),
 				APIOpts:    map[string]string{},
+				Proxy:      "socks5://127.0.0.1",
 			},
 			credExpect: Cred{
 				User:     "hello",
@@ -277,6 +285,7 @@ func TestConfig(t *testing.T) {
 				APIOpts:    map[string]string{"disableHead": "true"},
 				PathPrefix: "hub",
 				Mirrors:    []string{"host1.example.com", "host2.example.com"},
+				Proxy:      "socks5://127.0.0.1",
 			},
 			credExpect: Cred{
 				User:     "user-ex",
@@ -300,6 +309,7 @@ func TestConfig(t *testing.T) {
 				APIOpts:    map[string]string{"disableHead": "false", "unknownOpt": "3"},
 				BlobChunk:  333333,
 				BlobMax:    333333,
+				Proxy:      "socks5://127.0.0.1",
 			},
 			credExpect: Cred{
 				User:     "user-ex3",
@@ -315,6 +325,7 @@ func TestConfig(t *testing.T) {
 				CredHelper: "docker-credential-test",
 				CredExpire: timejson.Duration(time.Hour),
 				APIOpts:    map[string]string{},
+				Proxy:      "socks5://127.0.0.1",
 			},
 			credExpect: Cred{
 				User:     "hello",
@@ -335,6 +346,7 @@ func TestConfig(t *testing.T) {
 				APIOpts:    map[string]string{"disableHead": "true"},
 				PathPrefix: "hub",
 				Mirrors:    []string{"host1.example.com", "host2.example.com"},
+				Proxy:      "socks5://127.0.0.1",
 			},
 			credExpect: Cred{
 				User:     "hello",
@@ -355,6 +367,7 @@ func TestConfig(t *testing.T) {
 				APIOpts:    map[string]string{"disableHead": "true"},
 				PathPrefix: "hub",
 				Mirrors:    []string{"host1.example.com", "host2.example.com"},
+				Proxy:      "socks5://127.0.0.1",
 			},
 			credExpect: Cred{
 				User:     "user-ex",
@@ -437,6 +450,9 @@ func TestConfig(t *testing.T) {
 			}
 			if tc.credExpect.Token != cred.Token {
 				t.Errorf("cred token field mismatch, expected %s, found %s", tc.credExpect.Token, cred.Token)
+			}
+			if tc.host.Proxy != tc.hostExpect.Proxy {
+				t.Errorf("host proxy field mismatch, expected %s, found %s", tc.hostExpect.Token, tc.host.Proxy)
 			}
 		})
 	}

--- a/internal/reghttp/http.go
+++ b/internal/reghttp/http.go
@@ -781,6 +781,29 @@ func (c *Client) getHost(host string) *clientHost {
 			}
 			h.httpClient = &httpClient
 		}
+
+	}
+
+	if h.config.Proxy != "" && h.httpClient != nil {
+		t, ok := h.httpClient.Transport.(*http.Transport)
+		if ok {
+			u, err := url.Parse(h.config.Proxy)
+			if nil == err {
+				t.Proxy = http.ProxyURL(u)
+				c.log.WithFields(logrus.Fields{
+					"host":  host,
+					"proxy": h.config.Proxy,
+				}).Info("Using proxy")
+			} else {
+				c.log.WithFields(logrus.Fields{
+					"err": err,
+				}).Warn("failed to configure proxy")
+			}
+		} else {
+			c.log.WithFields(logrus.Fields{
+				"err": "not of type http.Transport",
+			}).Warn("failed to configure proxy")
+		}
 	}
 
 	if h.newAuth == nil {


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

fixes #628 

### Describe the change

Add proxy support on host level to allow user specify a different proxy for different hosts.

### How to verify it

Open `~/.regctl/config.json` and find proper host to add `"proxy": "socks5://host:port"` to make it work. Please make sure to replace `socks5://host:port` as your real proxy server.

### Changelog text

- Add host level proxy support #628 

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [ ] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
