### PR TITLE
Update olareg to leverage mem backed by dir

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7
 	github.com/google/uuid v1.5.0
-	github.com/olareg/olareg v0.0.0-20231225221553-ba40df6e30a2
+	github.com/olareg/olareg v0.0.0-20240101214633-f0c6086d9abe
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/olareg/olareg v0.0.0-20231225214909-54343bba2bca h1:tnbLoYvxTyGWL2pZO
 github.com/olareg/olareg v0.0.0-20231225214909-54343bba2bca/go.mod h1:YazBF7Kwb7UGtorlfDOqMv4cxPXERX55H0xbiIYFzow=
 github.com/olareg/olareg v0.0.0-20231225221553-ba40df6e30a2 h1:1l8kbkgiONU9HYm3Fi3rZS3GmM9tNK8TH+05UXrceyU=
 github.com/olareg/olareg v0.0.0-20231225221553-ba40df6e30a2/go.mod h1:YazBF7Kwb7UGtorlfDOqMv4cxPXERX55H0xbiIYFzow=
+github.com/olareg/olareg v0.0.0-20240101214633-f0c6086d9abe h1:WAVUQu4Dp/F0EQA+IV1urZA6tapYF8EDXxgZ/IAyz6E=
+github.com/olareg/olareg v0.0.0-20240101214633-f0c6086d9abe/go.mod h1:YazBF7Kwb7UGtorlfDOqMv4cxPXERX55H0xbiIYFzow=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/image_test.go
+++ b/image_test.go
@@ -144,9 +144,11 @@ func TestCopy(t *testing.T) {
 	t.Parallel()
 	godbg.SignalTrace()
 	ctx := context.Background()
-	// TODO: if/when olareg supports initializing memory from disk, add that instead of the setup loop below
 	regHandler := olareg.New(oConfig.Config{
-		Storage: oConfig.ConfigStorage{StoreType: oConfig.StoreMem},
+		Storage: oConfig.ConfigStorage{
+			StoreType: oConfig.StoreMem,
+			RootDir:   "./testdata",
+		},
 	})
 	ts := httptest.NewServer(regHandler)
 	t.Cleanup(func() { ts.Close() })
@@ -173,23 +175,6 @@ func TestCopy(t *testing.T) {
 		WithLog(log),
 		WithRetryDelay(delayInit, delayMax),
 	)
-	for _, tag := range []string{"v1", "v2", "v3", "child"} {
-		rTestData1, err := ref.New("ocidir://./testdata/testrepo:" + tag)
-		if err != nil {
-			t.Errorf("failed to parse ref %s: %v", "ocidir://./testdata/testrepo:"+tag, err)
-			return
-		}
-		rReg1v1, err := ref.New(tsHost + "/testrepo:" + tag)
-		if err != nil {
-			t.Errorf("failed to parse ref %s: %v", tsHost+"/testrepo:"+tag, err)
-			return
-		}
-		err = rc.ImageCopy(ctx, rTestData1, rReg1v1, ImageWithDigestTags(), ImageWithReferrers())
-		if err != nil {
-			t.Errorf("failed to run setup copy: %v", err)
-			return
-		}
-	}
 	tempDir := t.TempDir()
 	tt := []struct {
 		name      string


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

The `ImageCopy` tests previously depended on a setup that used `ImageCopy`. This leverages the capability of olareg to run a registry in memory that is backed by a directory for the initial content.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
make test
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Chore: Update `ImageCopy` test to not depend on `ImageCopy` for setup.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
