### PR TITLE
Use t.Setenv in tests

### DIFF
--- a/cmd/regctl/config_test.go
+++ b/cmd/regctl/config_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 )
@@ -9,11 +8,7 @@ import (
 func TestConfig(t *testing.T) {
 	// set a temp dir for storing configs
 	tempDir := t.TempDir()
-	origEnv, set := os.LookupEnv(ConfigEnv)
-	if set {
-		defer os.Setenv(ConfigEnv, origEnv)
-	}
-	os.Setenv(ConfigEnv, filepath.Join(tempDir, "config.json"))
+	t.Setenv(ConfigEnv, filepath.Join(tempDir, "config.json"))
 
 	// test empty config
 	out, err := cobraTest(t, nil, "config", "get", "--format", "{{ json . }}")

--- a/config/credhelper_test.go
+++ b/config/credhelper_test.go
@@ -59,8 +59,7 @@ func TestCredHelper(t *testing.T) {
 		return
 	}
 	curPath := os.Getenv("PATH")
-	os.Setenv("PATH", filepath.Join(cwd, "testdata")+string(os.PathListSeparator)+curPath)
-	defer os.Setenv("PATH", curPath)
+	t.Setenv("PATH", filepath.Join(cwd, "testdata")+string(os.PathListSeparator)+curPath)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			h := HostNewName(tt.host)

--- a/config/docker_test.go
+++ b/config/docker_test.go
@@ -10,21 +10,14 @@ import (
 
 func TestDocker(t *testing.T) {
 	// cannot run cred helper in parallel because of OS working directory race conditions
-	curPath := os.Getenv("PATH")
 	pwd, err := os.Getwd()
 	if err != nil {
 		t.Errorf("failed to get working dir: %v", err)
 		return
 	}
-	os.Setenv("PATH", filepath.Join(pwd, "testdata")+string(os.PathListSeparator)+curPath)
-	defer os.Setenv("PATH", curPath)
-	curDockerConf := os.Getenv(dockerEnv)
-	os.Setenv(dockerEnv, "testdata")
-	if curDockerConf != "" {
-		defer os.Setenv(dockerEnv, curDockerConf)
-	} else {
-		defer os.Unsetenv(dockerEnv)
-	}
+	curPath := os.Getenv("PATH")
+	t.Setenv("PATH", filepath.Join(pwd, "testdata")+string(os.PathListSeparator)+curPath)
+	t.Setenv(dockerEnv, "testdata")
 	hosts, err := DockerLoad()
 	if err != nil {
 		t.Errorf("error loading docker credentials: %v", err)

--- a/config/host_test.go
+++ b/config/host_test.go
@@ -19,8 +19,7 @@ func TestConfig(t *testing.T) {
 		return
 	}
 	curPath := os.Getenv("PATH")
-	os.Setenv("PATH", filepath.Join(cwd, "testdata")+string(os.PathListSeparator)+curPath)
-	defer os.Setenv("PATH", curPath)
+	t.Setenv("PATH", filepath.Join(cwd, "testdata")+string(os.PathListSeparator)+curPath)
 
 	// generate new/blank
 	blankHostP := HostNew()

--- a/internal/conffile/conffile_test.go
+++ b/internal/conffile/conffile_test.go
@@ -12,14 +12,15 @@ import (
 
 // test New
 func TestNew(t *testing.T) {
-	t.Parallel()
 	testEnvFileVar, testEnvFileVal := "TEST_CONFFILE_NEW", "./test-filename.json"
-	os.Setenv(testEnvFileVar, testEnvFileVal)
+	t.Setenv(testEnvFileVar, testEnvFileVal)
 	testEnvDirVar, testEnvDirVal := "TEST_CONFDIR_NEW", "./test-dirname"
-	os.Setenv(testEnvFileVar, testEnvFileVal)
-	os.Setenv(testEnvDirVar, testEnvDirVal)
+	t.Setenv(testEnvFileVar, testEnvFileVal)
+	t.Setenv(testEnvDirVar, testEnvDirVal)
 	testEnvUnset := "TEST_CONFFILE_NEW_UNSET"
-	os.Unsetenv(testEnvUnset)
+	if _, ok := os.LookupEnv(testEnvUnset); ok {
+		t.Errorf("environment variable should not be set for tests: %s", testEnvUnset)
+	}
 	hd := homedir()
 	tests := []struct {
 		name       string

--- a/mod/time_test.go
+++ b/mod/time_test.go
@@ -8,21 +8,15 @@ import (
 )
 
 func TestTimeNow(t *testing.T) {
-	t.Parallel()
-	curEnv, envIsSet := os.LookupEnv(epocEnv)
-	defer func() {
-		if envIsSet {
-			os.Setenv(epocEnv, curEnv)
-		} else {
-			os.Unsetenv(epocEnv)
-		}
-	}()
-
 	t.Run("NoEnv", func(t *testing.T) {
-		err := os.Unsetenv(epocEnv)
-		if err != nil {
-			t.Errorf("failed to unset %s", epocEnv)
-			return
+		curEnv, envIsSet := os.LookupEnv(epocEnv)
+		if envIsSet {
+			err := os.Unsetenv(epocEnv)
+			if err != nil {
+				t.Errorf("failed to unset %s", epocEnv)
+				return
+			}
+			defer os.Setenv(epocEnv, curEnv)
 		}
 		curTimeNow := timeNow()
 		if curTimeNow.After(time.Now()) {
@@ -32,11 +26,7 @@ func TestTimeNow(t *testing.T) {
 	t.Run("WithEnv", func(t *testing.T) {
 		timePrev := time.Now().Add(-1 * time.Hour).Round(time.Second)
 		timeSec := fmt.Sprintf("%d", timePrev.Unix())
-		err := os.Setenv(epocEnv, timeSec)
-		if err != nil {
-			t.Errorf("failed to set %s", epocEnv)
-			return
-		}
+		t.Setenv(epocEnv, timeSec)
 		curTimeNow := timeNow()
 		if !curTimeNow.Equal(timePrev) {
 			t.Errorf("timeNow did not use the epoc, expected %d, received %d", timePrev.Unix(), curTimeNow.Unix())


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Tests that modify the environment run in parallel and manually reset values.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Leverage `t.Setenv` where possible.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
make test
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Chore: leverage `t.Setenv` in tests of environment variables.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
