### PR TITLE
Preserve the descriptor on chunked blob put

### DIFF
--- a/scheme/reg/blob.go
+++ b/scheme/reg/blob.go
@@ -24,6 +24,10 @@ import (
 	"github.com/regclient/regclient/types/ref"
 )
 
+var (
+	zeroDig = digest.Canonical.FromBytes([]byte{})
+)
+
 // BlobDelete removes a blob from the repository
 func (reg *Reg) BlobDelete(ctx context.Context, r ref.Ref, d types.Descriptor) error {
 	req := &reghttp.Req{
@@ -180,13 +184,10 @@ func (reg *Reg) BlobMount(ctx context.Context, rSrc ref.Ref, rTgt ref.Ref, d typ
 func (reg *Reg) BlobPut(ctx context.Context, r ref.Ref, d types.Descriptor, rdr io.Reader) (types.Descriptor, error) {
 	var putURL *url.URL
 	var err error
-	// defaults for content-type and length
-	if d.Size == 0 {
-		d.Size = -1
-	}
+	validDesc := (d.Digest != "" && d.Size > 0) || (d.Size == 0 && d.Digest == zeroDig)
 
 	// attempt an anonymous blob mount
-	if d.Digest != "" && d.Size > 0 {
+	if validDesc {
 		putURL, _, err = reg.blobMount(ctx, r, d, ref.Ref{})
 		if err == nil {
 			return d, nil
@@ -202,9 +203,8 @@ func (reg *Reg) BlobPut(ctx context.Context, r ref.Ref, d types.Descriptor, rdr 
 			return d, err
 		}
 	}
-
 	// send upload as one-chunk
-	tryPut := bool(d.Digest != "" && d.Size > 0)
+	tryPut := validDesc
 	if tryPut {
 		host := reg.hostGet(r.Registry)
 		maxPut := host.BlobMax
@@ -230,9 +230,8 @@ func (reg *Reg) BlobPut(ctx context.Context, r ref.Ref, d types.Descriptor, rdr 
 			return d, err
 		}
 	}
-
 	// send a chunked upload if full upload not possible or too large
-	return reg.blobPutUploadChunked(ctx, r, putURL, rdr)
+	return reg.blobPutUploadChunked(ctx, r, d, putURL, rdr)
 }
 
 func (reg *Reg) blobGetUploadURL(ctx context.Context, r ref.Ref) (*url.URL, error) {
@@ -406,6 +405,10 @@ func (reg *Reg) blobPutUploadFull(ctx context.Context, r ref.Ref, d types.Descri
 		readOnce = true
 		return io.NopCloser(rdr), nil
 	}
+	// special case for the empty blob
+	if d.Size == 0 && d.Digest == zeroDig {
+		bodyFunc = nil
+	}
 
 	// build/send request
 	header := http.Header{
@@ -437,7 +440,7 @@ func (reg *Reg) blobPutUploadFull(ctx context.Context, r ref.Ref, d types.Descri
 	return nil
 }
 
-func (reg *Reg) blobPutUploadChunked(ctx context.Context, r ref.Ref, putURL *url.URL, rdr io.Reader) (types.Descriptor, error) {
+func (reg *Reg) blobPutUploadChunked(ctx context.Context, r ref.Ref, d types.Descriptor, putURL *url.URL, rdr io.Reader) (types.Descriptor, error) {
 	host := reg.hostGet(r.Registry)
 	bufSize := host.BlobChunk
 	if bufSize <= 0 {
@@ -481,7 +484,7 @@ func (reg *Reg) blobPutUploadChunked(ctx context.Context, r ref.Ref, putURL *url
 			if err == io.EOF || err == io.ErrUnexpectedEOF {
 				finalChunk = true
 			} else if err != nil {
-				return types.Descriptor{}, fmt.Errorf("failed to send blob chunk, ref %s: %w", r.CommonName(), err)
+				return d, fmt.Errorf("failed to send blob chunk, ref %s: %w", r.CommonName(), err)
 			}
 			// update length on partial read
 			if chunkSize != len(bufBytes) {
@@ -497,7 +500,7 @@ func (reg *Reg) blobPutUploadChunked(ctx context.Context, r ref.Ref, putURL *url
 			bufChange = true
 		}
 		if chunkSize > 0 && chunkStart != bufStart {
-			return types.Descriptor{}, fmt.Errorf("chunkStart (%d) != bufStart (%d)", chunkStart, bufStart)
+			return d, fmt.Errorf("chunkStart (%d) != bufStart (%d)", chunkStart, bufStart)
 		}
 		if bufChange {
 			// need to recreate the reader on a change to the slice length,
@@ -527,11 +530,11 @@ func (reg *Reg) blobPutUploadChunked(ctx context.Context, r ref.Ref, putURL *url
 			}
 			resp, err := reg.reghttp.Do(ctx, req)
 			if err != nil && !errors.Is(err, types.ErrHTTPStatus) && !errors.Is(err, types.ErrNotFound) {
-				return types.Descriptor{}, fmt.Errorf("failed to send blob (chunk), ref %s: http do: %w", r.CommonName(), err)
+				return d, fmt.Errorf("failed to send blob (chunk), ref %s: http do: %w", r.CommonName(), err)
 			}
 			err = resp.Close()
 			if err != nil {
-				return types.Descriptor{}, fmt.Errorf("failed to close request: %w", err)
+				return d, fmt.Errorf("failed to close request: %w", err)
 			}
 			httpResp := resp.HTTPResponse()
 			// distribution-spec is 202, AWS ECR returns a 201 and rejects the put
@@ -555,7 +558,7 @@ func (reg *Reg) blobPutUploadChunked(ctx context.Context, r ref.Ref, putURL *url
 				retryCur++
 				statusResp, statusErr := reg.blobUploadStatus(ctx, r, &chunkURL)
 				if retryCur > retryLimit || statusErr != nil {
-					return types.Descriptor{}, fmt.Errorf("failed to send blob (chunk), ref %s: http status: %w", r.CommonName(), reghttp.HTTPError(resp.HTTPResponse().StatusCode))
+					return d, fmt.Errorf("failed to send blob (chunk), ref %s: http status: %w", r.CommonName(), reghttp.HTTPError(resp.HTTPResponse().StatusCode))
 				}
 				httpResp = statusResp
 			} else {
@@ -578,7 +581,7 @@ func (reg *Reg) blobPutUploadChunked(ctx context.Context, r ref.Ref, putURL *url
 				prevURL := httpResp.Request.URL
 				parseURL, err := prevURL.Parse(location)
 				if err != nil {
-					return types.Descriptor{}, fmt.Errorf("failed to send blob (parse next chunk location), ref %s: %w", r.CommonName(), err)
+					return d, fmt.Errorf("failed to send blob (parse next chunk location), ref %s: %w", r.CommonName(), err)
 				}
 				chunkURL = *parseURL
 			}
@@ -586,14 +589,22 @@ func (reg *Reg) blobPutUploadChunked(ctx context.Context, r ref.Ref, putURL *url
 	}
 
 	// compute digest
-	d := digester.Digest()
+	dOut := digester.Digest()
+	if d.Digest != "" && dOut != d.Digest {
+		return d, fmt.Errorf("%w, expected %s, computed %s", types.ErrDigestMismatch, d.Digest.String(), dOut.String())
+	}
+	if d.Size != 0 && chunkStart != d.Size {
+		return d, fmt.Errorf("blob content size does not match descriptor, expected %d, received %d%.0w", d.Size, chunkStart, types.ErrMismatch)
+	}
+	d.Digest = dOut
+	d.Size = chunkStart
 
 	// send the final put
 	// append digest to request to use the monolithic upload option
 	if chunkURL.RawQuery != "" {
-		chunkURL.RawQuery = chunkURL.RawQuery + "&digest=" + url.QueryEscape(d.String())
+		chunkURL.RawQuery = chunkURL.RawQuery + "&digest=" + url.QueryEscape(dOut.String())
 	} else {
-		chunkURL.RawQuery = "digest=" + url.QueryEscape(d.String())
+		chunkURL.RawQuery = "digest=" + url.QueryEscape(dOut.String())
 	}
 
 	header := http.Header{
@@ -614,15 +625,15 @@ func (reg *Reg) blobPutUploadChunked(ctx context.Context, r ref.Ref, putURL *url
 	}
 	resp, err := reg.reghttp.Do(ctx, req)
 	if err != nil {
-		return types.Descriptor{}, fmt.Errorf("failed to send blob (chunk digest), digest %s, ref %s: %w", d, r.CommonName(), err)
+		return d, fmt.Errorf("failed to send blob (chunk digest), digest %s, ref %s: %w", dOut, r.CommonName(), err)
 	}
 	defer resp.Close()
 	// 201 follows distribution-spec, 204 is listed as possible in the Docker registry spec
 	if resp.HTTPResponse().StatusCode != 201 && resp.HTTPResponse().StatusCode != 204 {
-		return types.Descriptor{}, fmt.Errorf("failed to send blob (chunk digest), digest %s, ref %s: %w", d, r.CommonName(), reghttp.HTTPError(resp.HTTPResponse().StatusCode))
+		return d, fmt.Errorf("failed to send blob (chunk digest), digest %s, ref %s: %w", dOut, r.CommonName(), reghttp.HTTPError(resp.HTTPResponse().StatusCode))
 	}
 
-	return types.Descriptor{Digest: d, Size: chunkStart}, nil
+	return d, nil
 }
 
 // TODO: just take a putURL rather than the uuid and call a delete on that url

--- a/scheme/reg/blob_test.go
+++ b/scheme/reg/blob_test.go
@@ -380,7 +380,9 @@ func TestBlobPut(t *testing.T) {
 	d1, blob1 := reqresp.NewRandomBlob(blobLen, seed)
 	uuid1 := uuid.New()
 	d2, blob2 := reqresp.NewRandomBlob(blobLen, seed+1)
+	d2Bad := digest.Canonical.FromString("digest 2 bad")
 	uuid2 := uuid.New()
+	uuid2Bad := uuid.New()
 	d3, blob3 := reqresp.NewRandomBlob(blobLen3, seed+2)
 	uuid3 := uuid.New()
 	d4, blob4 := reqresp.NewRandomBlob(blobLen4, seed+3)
@@ -615,6 +617,148 @@ func TestBlobPut(t *testing.T) {
 				Path:     "/v2" + blobRepo + "/blobs/uploads/" + uuid2.String(),
 				Query: map[string][]string{
 					"digest": {d2.String()},
+				},
+				Headers: http.Header{
+					"Content-Length": {fmt.Sprintf("%d", len(blob2))},
+					"Content-Type":   {"application/octet-stream"},
+				},
+				Body: blob2,
+			},
+			RespEntry: reqresp.RespEntry{
+				Status: http.StatusGatewayTimeout,
+				Headers: http.Header{
+					"Content-Length": {fmt.Sprintf("%d", 0)},
+				},
+			},
+		},
+		// get upload2 location
+		{
+			ReqEntry: reqresp.ReqEntry{
+				Name:   "POST for d2Bad",
+				Method: "POST",
+				Path:   "/v2" + blobRepo + "/blobs/uploads/",
+				Query: map[string][]string{
+					"mount": {d2Bad.String()},
+				},
+			},
+			RespEntry: reqresp.RespEntry{
+				Status: http.StatusAccepted,
+				Headers: http.Header{
+					"Content-Length": {"0"},
+					"Location":       {uuid2Bad.String()},
+				},
+			},
+		},
+		// upload put for d2Bad
+		{
+			ReqEntry: reqresp.ReqEntry{
+				DelOnUse: false,
+				Name:     "PUT for patched d2Bad",
+				Method:   "PUT",
+				Path:     "/v2" + blobRepo + "/blobs/uploads/" + uuid2Bad.String(),
+				Query: map[string][]string{
+					"digest": {d2Bad.String()},
+					"chunk":  {"3"},
+				},
+				Headers: http.Header{
+					"Content-Length": {"0"},
+					"Content-Type":   {"application/octet-stream"},
+				},
+			},
+			RespEntry: reqresp.RespEntry{
+				Status: http.StatusBadRequest,
+				Headers: http.Header{
+					"Content-Length": {"0"},
+					// "Location":              {"/v2" + blobRepo + "/blobs/" + d2Bad.String()},
+					// "Docker-Content-Digest": {d2Bad.String()},
+				},
+			},
+		},
+		// upload patch 2b for d2
+		{
+			ReqEntry: reqresp.ReqEntry{
+				DelOnUse: false,
+				Name:     "PATCH 2b for d2Bad",
+				Method:   "PATCH",
+				Path:     "/v2" + blobRepo + "/blobs/uploads/" + uuid2Bad.String(),
+				Query: map[string][]string{
+					"chunk": {"2b"},
+				},
+				Headers: http.Header{
+					"Content-Length": {fmt.Sprintf("%d", blobLen-blobChunk-20)},
+					"Content-Range":  {fmt.Sprintf("%d-%d", blobChunk+20, blobLen-1)},
+					"Content-Type":   {"application/octet-stream"},
+				},
+				Body: blob2[blobChunk+20:],
+			},
+			RespEntry: reqresp.RespEntry{
+				Status: http.StatusAccepted,
+				Headers: http.Header{
+					"Content-Length": {fmt.Sprintf("%d", 0)},
+					"Range":          {fmt.Sprintf("bytes=0-%d", blobLen-1)},
+					"Location":       {uuid2Bad.String() + "?chunk=3"},
+				},
+			},
+		},
+		// upload patch 2 for d2
+		{
+			ReqEntry: reqresp.ReqEntry{
+				DelOnUse: false,
+				Name:     "PATCH 2 for d2Bad",
+				Method:   "PATCH",
+				Path:     "/v2" + blobRepo + "/blobs/uploads/" + uuid2Bad.String(),
+				Query: map[string][]string{
+					"chunk": {"2"},
+				},
+				Headers: http.Header{
+					"Content-Length": {fmt.Sprintf("%d", blobLen-blobChunk)},
+					"Content-Range":  {fmt.Sprintf("%d-%d", blobChunk, blobLen-1)},
+					"Content-Type":   {"application/octet-stream"},
+				},
+				Body: blob2[blobChunk:],
+			},
+			RespEntry: reqresp.RespEntry{
+				Status: http.StatusRequestedRangeNotSatisfiable,
+				Headers: http.Header{
+					"Content-Length": {fmt.Sprintf("%d", 0)},
+					"Range":          {fmt.Sprintf("bytes=0-%d", blobChunk+20-1)},
+					"Location":       {uuid2Bad.String() + "?chunk=2b"},
+				},
+			},
+		},
+		// upload patch 1 for d2
+		{
+			ReqEntry: reqresp.ReqEntry{
+				DelOnUse: false,
+				Name:     "PATCH 1 for d2Bad",
+				Method:   "PATCH",
+				Path:     "/v2" + blobRepo + "/blobs/uploads/" + uuid2Bad.String(),
+				Query:    map[string][]string{},
+				Headers: http.Header{
+					"Content-Length": {fmt.Sprintf("%d", blobChunk)},
+					"Content-Range":  {fmt.Sprintf("0-%d", blobChunk-1)},
+					"Content-Type":   {"application/octet-stream"},
+				},
+				Body: blob2[0:blobChunk],
+			},
+			RespEntry: reqresp.RespEntry{
+				Status: http.StatusAccepted,
+				Headers: http.Header{
+					"Content-Length": {fmt.Sprintf("%d", 0)},
+					"Range":          {fmt.Sprintf("bytes=0-%d", blobChunk-1)},
+					"Location":       {uuid2Bad.String() + "?chunk=2"},
+				},
+			},
+		},
+		// upload blob
+		{
+			ReqEntry: reqresp.ReqEntry{
+				DelOnUse: false,
+				Name:     "PUT for d2Bad",
+				Method:   "PUT",
+				Path:     "/v2" + blobRepo + "/blobs/uploads/" + uuid2Bad.String(),
+				Query: map[string][]string{
+					"digest": {d2Bad.String()},
 				},
 				Headers: http.Header{
 					"Content-Length": {fmt.Sprintf("%d", len(blob2))},
@@ -1059,7 +1203,8 @@ func TestBlobPut(t *testing.T) {
 			t.Errorf("Failed creating ref: %v", err)
 		}
 		br := bytes.NewReader(blob2)
-		dp, err := reg.BlobPut(ctx, r, types.Descriptor{Digest: d2, Size: int64(len(blob2))}, br)
+		mt := "application/vnd.example.test"
+		dp, err := reg.BlobPut(ctx, r, types.Descriptor{MediaType: mt, Digest: d2, Size: int64(len(blob2))}, br)
 		if err != nil {
 			t.Errorf("Failed running BlobPut: %v", err)
 			return
@@ -1069,6 +1214,9 @@ func TestBlobPut(t *testing.T) {
 		}
 		if dp.Size != int64(len(blob2)) {
 			t.Errorf("Content length mismatch, expected %d, received %d", len(blob2), dp.Size)
+		}
+		if dp.MediaType != mt {
+			t.Errorf("Blob put did not preserve descriptor media type: expected %s, received %s", mt, dp.MediaType)
 		}
 	})
 
@@ -1085,6 +1233,32 @@ func TestBlobPut(t *testing.T) {
 		}
 		if !errors.Is(err, types.ErrHTTPStatus) {
 			t.Errorf("unexpected err, expected %v, received %v", types.ErrHTTPStatus, err)
+		}
+	})
+
+	t.Run("Invalid digest", func(t *testing.T) {
+		r, err := ref.New("retry." + tsURL.Host + blobRepo)
+		if err != nil {
+			t.Errorf("Failed creating ref: %v", err)
+		}
+		br := bytes.NewReader(blob2)
+		mt := "application/vnd.example.test"
+		_, err = reg.BlobPut(ctx, r, types.Descriptor{MediaType: mt, Digest: d2Bad, Size: int64(len(blob2))}, br)
+		if err == nil || !errors.Is(err, types.ErrDigestMismatch) {
+			t.Errorf("unexpected error, expected %v, received %v", types.ErrDigestMismatch, err)
+		}
+	})
+
+	t.Run("Invalid size", func(t *testing.T) {
+		r, err := ref.New("retry." + tsURL.Host + blobRepo)
+		if err != nil {
+			t.Errorf("Failed creating ref: %v", err)
+		}
+		br := bytes.NewReader(blob2)
+		mt := "application/vnd.example.test"
+		_, err = reg.BlobPut(ctx, r, types.Descriptor{MediaType: mt, Digest: d2, Size: int64(len(blob2) - 2)}, br)
+		if err == nil || !errors.Is(err, types.ErrMismatch) {
+			t.Errorf("unexpected error, expected %v, received %v", types.ErrMismatch, err)
 		}
 	})
 


### PR DESCRIPTION
This also adds special handling for the empty blob, and validates the descriptor.

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Replaces #611
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This both preserves the descriptor, but also validates it and better handles the zero length blob.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Tests have been added:

```
make test
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Fix: Preserve descriptor contents on chunked blob push. (@edigaryev)
- Fix: Validate descriptor contents on chunked blob push.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
