### PR TITLE
Allow registry check to be skipped on set and login

### DIFF
--- a/cmd/regctl/registry_test.go
+++ b/cmd/regctl/registry_test.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/olareg/olareg"
+	oConfig "github.com/olareg/olareg/config"
+)
+
+func TestRegistry(t *testing.T) {
+	// t.Parallel() // this is not parallel due to environment variable settings
+	regHandler := olareg.New(oConfig.Config{
+		Storage: oConfig.ConfigStorage{
+			StoreType: oConfig.StoreMem,
+			RootDir:   "./testdata",
+		},
+	})
+	tsGood := httptest.NewServer(regHandler)
+	tsGoodURL, _ := url.Parse(tsGood.URL)
+	tsGoodHost := tsGoodURL.Host
+	tsBad := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("request was made to the bad host")
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	tsBadURL, _ := url.Parse(tsBad.URL)
+	tsBadHost := tsBadURL.Host
+	tempDir := t.TempDir()
+	t.Setenv(ConfigEnv, filepath.Join(tempDir, "config.json"))
+	tt := []struct {
+		name        string
+		args        []string
+		expectErr   error
+		expectOut   string
+		outContains bool
+	}{
+		// set a good host
+		{
+			name:        "set no TLS",
+			args:        []string{"registry", "set", tsGoodHost, "--tls", "disabled"},
+			expectOut:   "",
+			outContains: false,
+		},
+		// set a bad host but skip the check
+		{
+			name:        "set without check",
+			args:        []string{"registry", "set", tsBadHost, "--tls", "disabled", "--skip-check"},
+			expectOut:   "",
+			outContains: false,
+		},
+		// query the good host
+		{
+			name:        "query good host",
+			args:        []string{"registry", "config", tsGoodHost},
+			expectOut:   `"tls": "disabled",`,
+			outContains: true,
+		},
+		// query the bad host
+		{
+			name:        "query bad host",
+			args:        []string{"registry", "config", tsBadHost},
+			expectOut:   `"tls": "disabled",`,
+			outContains: true,
+		},
+		// login to good and bad hosts
+		{
+			name:        "login good host",
+			args:        []string{"registry", "login", tsGoodHost, "-u", "testgooduser", "-p", "testpass"},
+			expectOut:   "",
+			outContains: false,
+		},
+		{
+			name:        "login bad host",
+			args:        []string{"registry", "login", tsBadHost, "-u", "testbaduser", "-p", "testpass", "--skip-check"},
+			expectOut:   "",
+			outContains: false,
+		},
+		// query good and bad to ensure user is set
+		{
+			name:        "query good host",
+			args:        []string{"registry", "config", tsGoodHost},
+			expectOut:   `"user": "testgooduser",`,
+			outContains: true,
+		},
+		{
+			name:        "query bad host",
+			args:        []string{"registry", "config", tsBadHost},
+			expectOut:   `"user": "testbaduser",`,
+			outContains: true,
+		},
+		// logout
+		{
+			name:        "logout good host",
+			args:        []string{"registry", "logout", tsGoodHost},
+			expectOut:   "",
+			outContains: false,
+		},
+		{
+			name:        "logout bad host",
+			args:        []string{"registry", "logout", tsBadHost},
+			expectOut:   "",
+			outContains: false,
+		},
+		// verify logout
+		{
+			name: "check logout on good host",
+			args: []string{"registry", "config", tsGoodHost},
+			expectOut: fmt.Sprintf(`"hostname": "%s",
+  "credHost": "",`, tsGoodHost),
+			outContains: true,
+		},
+		{
+			name: "check logout on bad host",
+			args: []string{"registry", "config", tsBadHost},
+			expectOut: fmt.Sprintf(`"hostname": "%s",
+  "credHost": "",`, tsBadHost),
+			outContains: true,
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := cobraTest(t, nil, tc.args...)
+			if tc.expectErr != nil {
+				if err == nil {
+					t.Errorf("did not receive expected error: %v", tc.expectErr)
+				} else if !errors.Is(err, tc.expectErr) && err.Error() != tc.expectErr.Error() {
+					t.Errorf("unexpected error, received %v, expected %v", err, tc.expectErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("returned unexpected error: %v", err)
+				return
+			}
+			if (!tc.outContains && out != tc.expectOut) || (tc.outContains && !strings.Contains(out, tc.expectOut)) {
+				t.Errorf("unexpected output, expected %s, received %s", tc.expectOut, out)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Fixes #643 
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This adds a `--skip-check` flag to `regctl registry set` and `regctl registry login` commands.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
regctl registry set ... --skip-check
regctl registry logini ... --skip-check
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Add a `--skip-check` option to `regctl registry set` and `regctl registry login`.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
