### PR TITLE
Make artifact filename annotation optional

### DIFF
--- a/cmd/regctl/artifact_test.go
+++ b/cmd/regctl/artifact_test.go
@@ -157,6 +157,12 @@ func TestArtifactPut(t *testing.T) {
 		t.Errorf("failed creating test conf: %v", err)
 		return
 	}
+	testFileName := filepath.Join(testDir, "exFile")
+	err = os.WriteFile(testFileName, []byte(`example test file`), 0600)
+	if err != nil {
+		t.Errorf("failed creating test conf: %v", err)
+		return
+	}
 
 	tt := []struct {
 		name        string
@@ -197,18 +203,28 @@ func TestArtifactPut(t *testing.T) {
 			in:   testData,
 		},
 		{
+			name: "Put artifact example conf data and file",
+			args: []string{"artifact", "put", "--artifact-type", "", "--config-type", "application/vnd.example", "--config-file", testConfName, "--file", testFileName, "ocidir://" + testDir + ":put-example-file-data"},
+			in:   testData,
+		},
+		{
+			name: "Put artifact example conf data and file stripped",
+			args: []string{"artifact", "put", "--artifact-type", "", "--config-type", "application/vnd.example", "--config-file", testConfName, "--file", testFileName, "--file-title", "--strip-dirs", "ocidir://" + testDir + ":put-example-file-data"},
+			in:   testData,
+		},
+		{
 			name: "Put subject",
-			args: []string{"artifact", "put", "--artifact-type", "application/vnd.example", "--config-file", "", "--subject", "ocidir://" + testDir + ":put-example-at"},
+			args: []string{"artifact", "put", "--artifact-type", "application/vnd.example", "--subject", "ocidir://" + testDir + ":put-example-at"},
 			in:   testData,
 		},
 		{
 			name: "Put create index",
-			args: []string{"artifact", "put", "--artifact-type", "application/vnd.example", "--config-file", "", "--annotation", "test=a", "--platform", "linux/amd64", "--index", "ocidir://" + testDir + ":index"},
+			args: []string{"artifact", "put", "--artifact-type", "application/vnd.example", "--annotation", "test=a", "--platform", "linux/amd64", "--index", "ocidir://" + testDir + ":index"},
 			in:   testData,
 		},
 		{
 			name: "Put append index",
-			args: []string{"artifact", "put", "--artifact-type", "application/vnd.example", "--config-file", "", "--annotation", "test=b", "--platform", "linux/arm64", "--index", "ocidir://" + testDir + ":index"},
+			args: []string{"artifact", "put", "--artifact-type", "application/vnd.example", "--annotation", "test=b", "--platform", "linux/arm64", "--index", "ocidir://" + testDir + ":index"},
 			in:   testData,
 		},
 	}


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

The title annotation for filenames in artifacts attempted to mirror other projects but is an atypical usage of the annotation and not documented by OCI. It could also be used to accidentally leak data. This stops including it by default but allows it with a `regctl artifact put --file-title` option for those that need it.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
regctl artifact put --artifact-type application/vnd.example --file ./some-file.txt localhost:5000/aritfact:test
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Breaking: `regctl artifact put` no longer includes the filename annotation by default. Use `--file-title` to include.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
