### PR TITLE
Add examples to regctl help messages

### DIFF
--- a/cmd/regctl/blob.go
+++ b/cmd/regctl/blob.go
@@ -48,17 +48,27 @@ func NewBlobCmd(rootOpts *rootCmd) *cobra.Command {
 		Short:   "manage image blobs/layers",
 	}
 	var blobDiffConfigCmd = &cobra.Command{
-		Use:       "diff-config <repository> <digest> <repository> <digest>",
-		Short:     "diff two image configs",
-		Long:      `This returns the difference between two configs, comparing the contents of each config json.`,
+		Use:   "diff-config <repository> <digest> <repository> <digest>",
+		Short: "diff two image configs",
+		Long:  `This returns the difference between two configs, comparing the contents of each config json.`,
+		Example: `
+# compare two versions of busybox
+regctl blob diff-config \
+  busybox sha256:0c00acac9c2794adfa8bb7b13ef38504300b505a043bf68dff7a00068dcc732b \
+  busybox sha256:3f57d9401f8d42f986df300f0c69192fc41da28ccc8d797829467780db3dd741`,
 		Args:      cobra.ExactArgs(4),
 		ValidArgs: []string{}, // do not auto complete repository or digest
 		RunE:      blobOpts.runBlobDiffConfig,
 	}
 	var blobDiffLayerCmd = &cobra.Command{
-		Use:       "diff-layer <repository> <digest> <repository> <digest>",
-		Short:     "diff two tar layers",
-		Long:      `This returns the difference between two layers, comparing the contents of each tar.`,
+		Use:   "diff-layer <repository> <digest> <repository> <digest>",
+		Short: "diff two tar layers",
+		Long:  `This returns the difference between two layers, comparing the contents of each tar.`,
+		Example: `
+# compare two versions of busybox, ignoring timestamp changes
+regctl blob diff-layer \
+  busybox sha256:2354422721e449fa3fa83b84465b9d5bb65ac5415ec93c06f598854312e8957e \
+  busybox sha256:9ad63333ebc97e32b987ae66aa3cff81300e4c2e6d2f2395cef8a3ae18b249fe --ignore-timestamp`,
 		Args:      cobra.ExactArgs(4),
 		ValidArgs: []string{}, // do not auto complete repository or digest
 		RunE:      blobOpts.runBlobDiffLayer,
@@ -70,24 +80,38 @@ func NewBlobCmd(rootOpts *rootCmd) *cobra.Command {
 		Long: `Download a blob from the registry. The output is the blob itself which may
 be a compressed tar file, a json config, or any other blob supported by the
 registry. The blob or layer digest can be found in the image manifest.`,
+		Example: `
+# inspect the layer contents of a busybox image
+regctl blob get busybox \
+  sha256:a58ecd4f0c864650a4286c3c2d49c7219a3f2fc8d7a0bf478aa9834acfe14ae7 \
+  | tar -tvzf -`,
 		Args:      cobra.ExactArgs(2),
 		ValidArgs: []string{}, // do not auto complete repository or digest
 		RunE:      blobOpts.runBlobGet,
 	}
 	var blobGetFileCmd = &cobra.Command{
-		Use:       "get-file <repository> <digest> <file> [out-file]",
-		Aliases:   []string{"cat"},
-		Short:     "get a file from a layer",
-		Long:      `This returns a requested file from a layer.`,
+		Use:     "get-file <repository> <digest> <file> [out-file]",
+		Aliases: []string{"cat"},
+		Short:   "get a file from a layer",
+		Long:    `This returns a requested file from a layer.`,
+		Example: `
+# retrieve the contents of /etc/alpine-release
+regctl blob get-file alpine \
+  sha256:9123ac7c32f74759e6283f04dbf571f18246abe5bb2c779efcb32cd50f3ff13c \
+  /etc/alpine-release`,
 		Args:      cobra.RangeArgs(3, 4),
 		ValidArgs: []string{}, // do not auto complete repository, digest, or filenames
 		RunE:      blobOpts.runBlobGetFile,
 	}
 	var blobHeadCmd = &cobra.Command{
-		Use:       "head <repository> <digest>",
-		Aliases:   []string{"digest"},
-		Short:     "http head request for a blob",
-		Long:      `Shows the headers for a blob head request.`,
+		Use:     "head <repository> <digest>",
+		Aliases: []string{"digest"},
+		Short:   "http head request for a blob",
+		Long:    `Shows the headers for a blob head request.`,
+		Example: `
+# verify the existence of a blob
+regctl blob head alpine \
+  sha256:9123ac7c32f74759e6283f04dbf571f18246abe5bb2c779efcb32cd50f3ff13c`,
 		Args:      cobra.ExactArgs(2),
 		ValidArgs: []string{}, // do not auto complete repository or digest
 		RunE:      blobOpts.runBlobHead,
@@ -98,6 +122,9 @@ registry. The blob or layer digest can be found in the image manifest.`,
 		Short:   "upload a blob/layer",
 		Long: `Upload a blob to a repository. Stdin must be the blob contents. The output
 is the digest of the blob.`,
+		Example: `
+# push a blob
+regctl blob put registry.example.org/repo <layer.tgz`,
 		Args:      cobra.ExactArgs(1),
 		ValidArgs: []string{}, // do not auto complete repository
 		RunE:      blobOpts.runBlobPut,
@@ -109,6 +136,10 @@ is the digest of the blob.`,
 		Long: `Copy a blob between repositories. This works in the same registry only. It
 attempts to mount the layers between repositories. And within the same repository
 it only sends the manifest with the new tag.`,
+		Example: `
+# copy a blob
+regctl blob copy alpine registry.example.org/library/alpine \
+  sha256:9123ac7c32f74759e6283f04dbf571f18246abe5bb2c779efcb32cd50f3ff13c`,
 		Args:      cobra.ExactArgs(3),
 		ValidArgs: []string{}, // do not auto complete repository or digest
 		RunE:      blobOpts.runBlobCopy,

--- a/cmd/regctl/config.go
+++ b/cmd/regctl/config.go
@@ -54,15 +54,27 @@ func NewConfigCmd(rootOpts *rootCmd) *cobra.Command {
 		Use:   "get",
 		Short: "show the config",
 		Long:  `Displays the configuration. Passwords are not included in the output.`,
-		Args:  cobra.ExactArgs(0),
-		RunE:  configOpts.runConfigGet,
+		Example: `
+# retrieve the full config
+regctl config get
+
+# display the filename of the config
+regctl config get --format '{{.Filename}}'`,
+		Args: cobra.ExactArgs(0),
+		RunE: configOpts.runConfigGet,
 	}
 	var configSetCmd = &cobra.Command{
 		Use:   "set",
 		Short: "set a configuration option",
 		Long:  `Modifies an option used in future executions.`,
-		Args:  cobra.ExactArgs(0),
-		RunE:  configOpts.runConfigSet,
+		Example: `
+# disable loading credentials from docker
+regctl config set --docker-cred=false
+
+# enable loading credentials from docker
+regctl config set --docker-cred`,
+		Args: cobra.ExactArgs(0),
+		RunE: configOpts.runConfigSet,
 	}
 
 	configGetCmd.Flags().StringVar(&configOpts.format, "format", "{{ printPretty . }}", "format the output with Go template syntax")

--- a/cmd/regctl/image.go
+++ b/cmd/regctl/image.go
@@ -77,6 +77,9 @@ If the digest is not available, layers of each manifest are compared.
 If the layers match, the config (history and roots) are optionally compared.	
 If the base image does not match, the command exits with a non-zero status.
 Use "-v info" to see more details.`,
+		Example: `
+# report if base image has changed using annotations
+regctl image check-base ghcr.io/regclient/regctl:alpine -v info`,
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: rootOpts.completeArgTag,
 		RunE:              imageOpts.runImageCheckBase,
@@ -89,6 +92,25 @@ Use "-v info" to see more details.`,
 that do not exist at the target. In the same registry it attempts to mount
 the layers between repositories. And within the same repository it only
 sends the manifest with the new tag.`,
+		Example: `
+# copy an image
+regctl image copy \
+  ghcr.io/regclient/regctl:edge registry.example.org/regclient/regctl:edge
+
+# copy an image with signatures
+regctl image copy --digest-tags \
+  ghcr.io/regclient/regctl:edge registry.example.org/regclient/regctl:edge
+
+# copy only the local platform image
+regctl image copy --platform local \
+  ghcr.io/regclient/regctl:edge registry.example.org/regclient/regctl:edge
+
+# retag an image
+regctl image copy registry.example.org/repo:v1.2.3 registry.example.org/repo:v1
+
+# copy an image to an OCI Layout including referrers
+regctl image copy --referrers \
+  ghcr.io/regclient/regctl:edge ocidir://regctl:edge`,
 		Args:              cobra.ExactArgs(2),
 		ValidArgsFunction: rootOpts.completeArgTag,
 		RunE:              imageOpts.runImageCopy,
@@ -102,13 +124,23 @@ manifest. You must specify a digest, not a tag on this command (e.g.
 image_name@sha256:1234abc...). It is up to the registry whether the delete
 API is supported. Additionally, registries may garbage collect the filesystem
 layers (blobs) separately or not at all. See also the "tag delete" command.`,
+		Example: `
+# delete a specific image
+regctl image delete registry.example.org/repo@sha256:fab3c890d0480549d05d2ff3d746f42e360b7f0e3fe64bdf39fc572eab94911b
+
+# delete a specific image by tag (including all other tags to the same image)
+regctl image delete --force-tag-dereference registry.example.org/repo:v123`,
 		Args:      cobra.ExactArgs(1),
 		ValidArgs: []string{}, // do not auto complete digests
 		RunE:      manifestOpts.runManifestDelete,
 	}
 	var imageDigestCmd = &cobra.Command{
-		Use:               "digest <image_ref>",
-		Short:             "show digest for pinning, same as \"manifest digest\"",
+		Use:   "digest <image_ref>",
+		Short: "show digest for pinning, same as \"manifest digest\"",
+		Long:  `show digest for pinning, same as "manifest digest"`,
+		Example: `
+# get the digest for the latest regctl image
+regctl image digest ghcr.io/regclient/regctl`,
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: rootOpts.completeArgTag,
 		RunE:              manifestOpts.runManifestHead,
@@ -118,17 +150,22 @@ layers (blobs) separately or not at all. See also the "tag delete" command.`,
 		Short: "export image",
 		Long: `Exports an image into a tar file that can be later loaded into a docker
 engine with "docker load". The tar file is output to stdout by default.
-Compression is typically not useful since layers are already compressed.
-Example usage: regctl image export registry:5000/yourimg:v1 >yourimg-v1.tar`,
+Compression is typically not useful since layers are already compressed.`,
+		Example: `
+# export an image
+regctl image export registry.example.org/repo:v1 >image-v1.tar`,
 		Args:              cobra.RangeArgs(1, 2),
 		ValidArgsFunction: rootOpts.completeArgTag,
 		RunE:              imageOpts.runImageExport,
 	}
 	var imageGetFileCmd = &cobra.Command{
-		Use:               "get-file <image_ref> <filename> [out-file]",
-		Aliases:           []string{"cat"},
-		Short:             "get a file from an image",
-		Long:              `Go through each of the image layers searching for the requested file.`,
+		Use:     "get-file <image_ref> <filename> [out-file]",
+		Aliases: []string{"cat"},
+		Short:   "get a file from an image",
+		Long:    `Go through each of the image layers searching for the requested file.`,
+		Example: `
+# get the alpine-release file from the latest alpine image
+regctl image get-file --platform local alpine /etc/alpine-release`,
 		Args:              cobra.RangeArgs(2, 3),
 		ValidArgsFunction: completeArgList([]completeFunc{rootOpts.completeArgTag, completeArgNone, completeArgNone}),
 		RunE:              imageOpts.runImageGetFile,
@@ -139,6 +176,9 @@ Example usage: regctl image export registry:5000/yourimg:v1 >yourimg-v1.tar`,
 		Long: `Imports an image from a tar file. This must be either a docker formatted tar
 from "docker save" or an OCI Layout compatible tar. The output from
 "regctl image export" can be used. Stdin is not permitted for the tar file.`,
+		Example: `
+# import an image saved from docker
+regctl image import registry.example.org/repo:v1 image-v1.tar`,
 		Args:              cobra.ExactArgs(2),
 		ValidArgsFunction: completeArgList([]completeFunc{rootOpts.completeArgTag, completeArgDefault}),
 		RunE:              imageOpts.runImageImport,
@@ -149,14 +189,20 @@ from "docker save" or an OCI Layout compatible tar. The output from
 		Short:   "inspect image",
 		Long: `Shows the config json for an image and is equivalent to pulling the image
 in docker, and inspecting it, but without pulling any of the image layers.`,
+		Example: `
+# return the image config for the nginx image
+regctl image inspect --platform local nginx`,
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: rootOpts.completeArgTag,
 		RunE:              imageOpts.runImageInspect,
 	}
 	var imageManifestCmd = &cobra.Command{
-		Use:               "manifest <image_ref>",
-		Short:             "show manifest or manifest list, same as \"manifest get\"",
-		Long:              `Shows the manifest or manifest list of the specified image.`,
+		Use:   "manifest <image_ref>",
+		Short: "show manifest or manifest list, same as \"manifest get\"",
+		Long:  `Shows the manifest or manifest list of the specified image.`,
+		Example: `
+# return the manifest of the golang image
+regctl image manifest golang`,
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: rootOpts.completeArgTag,
 		RunE:              manifestOpts.runManifestGet,
@@ -172,18 +218,40 @@ For time options, the value is a comma separated list of key/value pairs:
   after=${time_in_rfc3339}: adjust any time after this
   base-ref=${image}: image to lookup base layers, which are skipped
   base-layers=${count}: number of layers to skip changing (from the base image)
-  * set or from-label is required in the time options
-`,
+  Note: set or from-label is required in the time options`,
+		Example: `
+# add an annotation to all images, replacing the v1 tag with the new image
+regctl image mod registry.example.org/repo:v1 \
+  --replace --annotation '[*]org.opencontainers.image.created=2021-02-03T05:06:07Z
+
+# convert an image to the OCI media types, copying to local registry
+regctl image mod alpine:3.5 --to-oci --create registry.example.org/alpine:3.5
+
+# set the timestamp on the config and layers, ignoring the alpine base image layers
+regctl image mod registry.example.org/repo:v1 --create v1-mod \
+  --time "set=2021-02-03T04:05:06Z,base-ref=alpine:3"
+
+# Rebase an older regctl image, copying to the local registry.
+# This uses annotations that were included in the original image build.
+regctl image mod registry.example.org/regctl:v0.5.1-alpine \
+  --rebase --create v0.5.1-alpine-rebase`,
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: rootOpts.completeArgTag,
 		RunE:              imageOpts.runImageMod,
 	}
 	var imageRateLimitCmd = &cobra.Command{
-		Use:   "ratelimit <image_ref>",
-		Short: "show the current rate limit",
+		Use:     "ratelimit <image_ref>",
+		Aliases: []string{"rate-limit"},
+		Short:   "show the current rate limit",
 		Long: `Shows the rate limit using an http head request against the image manifest.
 If Set is false, the Remain value was not provided.
 The other values may be 0 if not provided by the registry.`,
+		Example: `
+# return the current rate limit for pulling the alpine image
+regctl image ratelimit alpine
+
+# return the number of pulls remaining
+regctl image ratelimit alpine --format '{{.Remain}}'`,
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: rootOpts.completeArgTag,
 		RunE:              imageOpts.runImageRateLimit,
@@ -237,7 +305,7 @@ The other values may be 0 if not provided by the registry.`,
 	_ = imageManifestCmd.RegisterFlagCompletionFunc("format", completeArgNone)
 	_ = imageManifestCmd.Flags().MarkHidden("list")
 
-	imageModCmd.Flags().StringVarP(&imageOpts.create, "create", "", "", "Create tag")
+	imageModCmd.Flags().StringVarP(&imageOpts.create, "create", "", "", "Create image or tag")
 	imageModCmd.Flags().BoolVarP(&imageOpts.replace, "replace", "", false, "Replace tag (ignored when \"create\" is used)")
 	// most image mod flags are order dependent, so they are added using VarP/VarPF to append to modOpts
 	imageModCmd.Flags().VarP(&modFlagFunc{

--- a/cmd/regctl/index.go
+++ b/cmd/regctl/index.go
@@ -50,30 +50,50 @@ func NewIndexCmd(rootOpts *rootCmd) *cobra.Command {
 	}
 
 	var indexAddCmd = &cobra.Command{
-		Use:       "add <image_ref>",
-		Aliases:   []string{"append", "insert"},
-		Short:     "add an index entry",
-		Long:      `Add an entry to a manifest list or OCI Index.`,
+		Use:     "add <image_ref>",
+		Aliases: []string{"append", "insert"},
+		Short:   "add an index entry",
+		Long:    `Add an entry to a manifest list or OCI Index.`,
+		Example: `
+# add arm64 to the v1 image
+regctl index add registry.example.org/repo:v1 --ref registry.example.org/repo:arm64`,
 		Args:      cobra.ExactArgs(1),
 		ValidArgs: []string{}, // do not auto complete digests
 		RunE:      indexOpts.runIndexAdd,
 	}
 
 	var indexCreateCmd = &cobra.Command{
-		Use:       "create <image_ref>",
-		Aliases:   []string{"init", "new"},
-		Short:     "create an index",
-		Long:      `Create a manifest list or OCI Index.`,
+		Use:     "create <image_ref>",
+		Aliases: []string{"init", "new"},
+		Short:   "create an index",
+		Long:    `Create a manifest list or OCI Index.`,
+		Example: `
+# create an empty index
+regctl index create registry.example.org/repo:v1
+
+# create an index from the amd64 and arm64 platforms
+regctl index create registry.example.org/alpine:latest \
+  --ref alpine:latest --platform linux/amd64 --platform linux/arm64
+
+# create a docker manifest list
+regctl index create registry.example.org/busybox:1.34 \
+  --media-type application/vnd.docker.distribution.manifest.list.v2+json \
+  --ref busybox:1.34 --platform linux/amd64 --platform linux/arm64`,
 		Args:      cobra.ExactArgs(1),
 		ValidArgs: []string{}, // do not auto complete digests
 		RunE:      indexOpts.runIndexCreate,
 	}
 
 	var indexDeleteCmd = &cobra.Command{
-		Use:       "delete <image_ref>",
-		Aliases:   []string{"del", "rm", "remove"},
-		Short:     "delete an index entry",
-		Long:      `Delete an entry from a manifest list or OCI Index.`,
+		Use:     "delete <image_ref>",
+		Aliases: []string{"del", "rm", "remove"},
+		Short:   "delete an index entry",
+		Long:    `Delete an entry from a manifest list or OCI Index.`,
+		Example: `
+# remove the several platforms from an image
+regctl index delete registry.example.org/repo:v1 \
+  --platform unknown/unknown --platform linux/s390x \
+  --platform linux/ppc64le --platform linux/mips64le`,
 		Args:      cobra.ExactArgs(1),
 		ValidArgs: []string{}, // do not auto complete digests
 		RunE:      indexOpts.runIndexDelete,

--- a/cmd/regctl/root.go
+++ b/cmd/regctl/root.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"time"
 
@@ -17,8 +18,6 @@ import (
 
 const (
 	progressFreq = time.Millisecond * 250
-	usageDesc    = `Utility for accessing docker registries
-More details at https://github.com/regclient/regclient`
 	// UserAgent sets the header on http requests
 	UserAgent = "regclient/regctl"
 )
@@ -40,9 +39,28 @@ type rootCmd struct {
 func NewRootCmd() *cobra.Command {
 	rootOpts := rootCmd{}
 	var rootTopCmd = &cobra.Command{
-		Use:           "regctl <cmd>",
-		Short:         "Utility for accessing docker registries",
-		Long:          usageDesc,
+		Use:   "regctl <cmd>",
+		Short: "Utility for accessing docker registries",
+		Long: `Utility for accessing docker registries
+More details at https://github.com/regclient/regclient`,
+		Example: `
+# login to ghcr.io
+regctl registry login ghcr.io
+
+# configure a local registry for http
+regctl registry set --tls disabled registry.example.org
+
+# copy an image from ghcr.io to local registry
+regctl image copy ghcr.io/regclient/regctl:latest registry.example.org/regctl:latest
+
+# show debugging output from a command
+regctl tag ls ghcr.io/regclient/regctl -v debug
+
+# format log output in json
+regctl image ratelimit --logopt json alpine
+
+# override registry config for a single command
+regctl image digest --host reg=localhost:5000,tls=disabled localhost:5000/repo:v1`,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
@@ -50,9 +68,15 @@ func NewRootCmd() *cobra.Command {
 	var versionCmd = &cobra.Command{
 		Use:   "version",
 		Short: "Show the version",
-		Long:  `Show the version`,
-		Args:  cobra.ExactArgs(0),
-		RunE:  rootOpts.runVersion,
+		Long:  fmt.Sprintf(`Show the version of %s`, rootOpts.name),
+		Example: `
+# display full version details
+regctl version
+
+# retrieve the version number
+regctl version --format '{{.VCSTag}}'`,
+		Args: cobra.ExactArgs(0),
+		RunE: rootOpts.runVersion,
 	}
 
 	log = &logrus.Logger{

--- a/cmd/regctl/tag.go
+++ b/cmd/regctl/tag.go
@@ -37,8 +37,10 @@ func NewTagCmd(rootOpts *rootCmd) *cobra.Command {
 This avoids deleting the manifest when multiple tags reference the same image.
 For registries that do not support the OCI tag delete API, this is implemented
 by pushing a unique dummy manifest and deleting that by digest.
-If the registry does not support the delete API, the dummy manifest will remain.
-`,
+If the registry does not support the delete API, the dummy manifest will remain.`,
+		Example: `
+# delete a tag
+regctl tag delete registry.example.org/repo:v42`,
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: rootOpts.completeArgTag,
 		RunE:              tagOpts.runTagDelete,
@@ -49,8 +51,13 @@ If the registry does not support the delete API, the dummy manifest will remain.
 		Short:   "list tags in a repo",
 		Long: `List tags in a repository.
 Note: many registries ignore the pagination options.
-For an OCI Layout, the index is available as Index (--format "{{.Index}}").
-`,
+For an OCI Layout, the index is available as Index (--format "{{.Index}}").`,
+		Example: `
+# list all tags in a repository
+regctl tag ls registry.example.org/repo
+
+# exclude tags starting with sha256- from the listing
+regctl tag ls registry.example.org/repo --exclude 'sha256-.*'`,
 		Args:      cobra.ExactArgs(1),
 		ValidArgs: []string{},
 		RunE:      tagOpts.runTagLs,


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Fixes #644
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This adds examples to the help messages of the various `regctl` commands.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
$ regctl --help
Utility for accessing docker registries
More details at https://github.com/regclient/regclient

Usage:
  regctl [command]

Examples:

# login to ghcr.io
regctl registry login ghcr.io

# configure a local registry for http
regctl registry set --tls disabled registry.example.org

# copy an image from ghcr.io to local registry
regctl image copy ghcr.io/regclient/regctl:latest registry.example.org/regctl:latest

# show debugging output from a command
regctl tag ls ghcr.io/regclient/regctl -v debug

# format log output in json
regctl image ratelimit --logopt json alpine

# override registry config for a single command
regctl image digest --host reg=localhost:5000,tls=disabled localhost:5000/repo:v1

Available Commands:
  artifact    manage artifacts
  blob        manage image blobs/layers
  completion  Generate completion script
  config      read/set configuration options
  help        Help about any command
  image       manage images
  index       manage manifest lists and OCI index
  manifest    manage manifests
  registry    manage registries
  repo        manage repositories
  tag         manage tags
  version     Show the version

Flags:
  -h, --help                 help for regctl
      --host stringArray     Registry hosts to add (reg=registry,user=username,pass=password,tls=enabled)
      --logopt stringArray   Log options
      --user-agent string    Override user agent
  -v, --verbosity string     Log level (debug, info, warn, error, fatal, panic) (default "warning")

Use "regctl [command] --help" for more information about a command.

$ regctl image copy --help
Copy or retag an image. This works between registries and only pulls layers
that do not exist at the target. In the same registry it attempts to mount
the layers between repositories. And within the same repository it only
sends the manifest with the new tag.

Usage:
  regctl image copy <src_image_ref> <dst_image_ref> [flags]

Aliases:
  copy, cp

Examples:

# copy an image
regctl image copy \
  ghcr.io/regclient/regctl:edge registry.example.org/regclient/regctl:edge

# copy an image with signatures
regctl image copy --digest-tags \
  ghcr.io/regclient/regctl:edge registry.example.org/regclient/regctl:edge

# copy only the local platform image
regctl image copy --platform local \
  ghcr.io/regclient/regctl:edge registry.example.org/regclient/regctl:edge

# retag an image
regctl image copy registry.example.org/repo:v1.2.3 registry.example.org/repo:v1

# copy an image to an OCI Layout including referrers
regctl image copy --referrers \
  ghcr.io/regclient/regctl:edge ocidir://regctl:edge

Flags:
      --digest-tags        Include digest tags ("sha256-<digest>.*") when copying manifests
      --fast               Fast check, skip referrers and digest tag checks when image exists, overrides force-recursive
      --force-recursive    Force recursive copy of image, repairs missing nested blobs and manifests
      --format string      Format output with go template syntax
  -h, --help               help for copy
      --include-external   Include external layers
  -p, --platform string    Specify platform (e.g. linux/amd64 or local)
      --referrers          Include referrers

Global Flags:
      --host stringArray     Registry hosts to add (reg=registry,user=username,pass=password,tls=enabled)
      --logopt stringArray   Log options
      --user-agent string    Override user agent
  -v, --verbosity string     Log level (debug, info, warn, error, fatal, panic) (default "warning")
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [x] Tests have been added or not applicable
- [x] Documentation has been added, updated, or not applicable
- [x] Changes have been rebased to main
- [x] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
