### PR TITLE
Fixes for image mod to different target registry

### DIFF
--- a/mod/mod.go
+++ b/mod/mod.go
@@ -107,8 +107,12 @@ func Apply(ctx context.Context, rc *regclient.RegClient, rSrc ref.Ref, opts ...O
 			return rTgt, err
 		}
 	}
-	if len(dc.stepsLayerFile) > 0 || !ref.EqualRepository(rSrc, rTgt) {
+	if len(dc.stepsLayerFile) > 0 || !ref.EqualRepository(rSrc, rTgt) || dc.forceLayerWalk {
 		err = dagWalkLayers(dm, func(dl *dagLayer) (*dagLayer, error) {
+			rSrc := rSrc
+			if dl.rSrc.IsSet() {
+				rSrc = dl.rSrc
+			}
 			if dl.mod == deleted || len(dl.desc.URLs) > 0 {
 				// skip deleted or external layers
 				return dl, nil


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Trying to rebase and copy an image with a `regctl image mod --rebase --create $tgt $src` would fail registry validation of the manifests because of missing blobs.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Multiple fixes were applied to the mod:

- Rebase should define a different source repository
- Referrers should only be updated in same repository
- Tests should use olareg for manifest validation
- Pushing manifest by digest should handle unchanged copy

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
regctl image mod --rebase \
  --create localhost:5000/regclient/regctl:v0.5.1-alpine-rebase \
  ghcr.io/regclient/regctl:v0.5.1-alpine
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Fix: Image mod where created image is in a different repository
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
