### PR TITLE
Improve error handling of a failed copy

### DIFF
--- a/image.go
+++ b/image.go
@@ -756,7 +756,12 @@ func (rc *RegClient) imageCopyOpt(ctx context.Context, refSrc ref.Ref, refTgt re
 				done = true // happy path
 			}
 		} else {
-			<-waitCh
+			if errors.Is(err, context.Canceled) {
+				// try to find a better error message than context canceled
+				err = <-waitCh
+			} else {
+				<-waitCh
+			}
 		}
 		if !done {
 			waitCount--
@@ -851,7 +856,12 @@ func (rc *RegClient) imageCopyOpt(ctx context.Context, refSrc ref.Ref, refTgt re
 				cancel()
 			}
 		} else {
-			<-waitCh
+			if errors.Is(err, context.Canceled) {
+				// try to find a better error message than context canceled
+				err = <-waitCh
+			} else {
+				<-waitCh
+			}
 		}
 		waitCount--
 	}


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

A failed image copy, e.g. to a repo without write access, often returns a `context.Canceled` error rather than the http or other error.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This prefers errors other than the `context.Canceled` that is generated by stopping goroutines.

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Copy from a source to a destination where you do not have write access:

```shell
regctl image copy busybox noaccess
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Fix: Improve returned errors from `regclient.ImageCopy`.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
