### PR TITLE
Cancel failed blob uploads to a registry

### DIFF
--- a/blob_test.go
+++ b/blob_test.go
@@ -846,6 +846,16 @@ func TestBlobCopy(t *testing.T) {
 				},
 			},
 		},
+		{
+			ReqEntry: reqresp.ReqEntry{
+				Name:   "DELETE for repo b - d1",
+				Method: "DELETE",
+				Path:   "/v2" + blobRepoB + "/blobs/uploads/" + uuid1.String(),
+			},
+			RespEntry: reqresp.RespEntry{
+				Status: http.StatusAccepted,
+			},
+		},
 		// head
 		{
 			ReqEntry: reqresp.ReqEntry{
@@ -964,6 +974,16 @@ func TestBlobCopy(t *testing.T) {
 				},
 			},
 		},
+		{
+			ReqEntry: reqresp.ReqEntry{
+				Name:   "DELETE for repo b - d2",
+				Method: "DELETE",
+				Path:   "/v2" + blobRepoB + "/blobs/uploads/" + uuid2.String(),
+			},
+			RespEntry: reqresp.RespEntry{
+				Status: http.StatusAccepted,
+			},
+		},
 		// upload blob
 		{
 			ReqEntry: reqresp.ReqEntry{
@@ -1050,6 +1070,16 @@ func TestBlobCopy(t *testing.T) {
 					"Content-Length": {"0"},
 					"Location":       {uuid3.String()},
 				},
+			},
+		},
+		{
+			ReqEntry: reqresp.ReqEntry{
+				Name:   "DELETE for repo b - d3",
+				Method: "DELETE",
+				Path:   "/v2" + blobRepoB + "/blobs/uploads/" + uuid3.String(),
+			},
+			RespEntry: reqresp.RespEntry{
+				Status: http.StatusAccepted,
 			},
 		},
 		// upload blob

--- a/scheme/reg/blob_test.go
+++ b/scheme/reg/blob_test.go
@@ -631,6 +631,18 @@ func TestBlobPut(t *testing.T) {
 				},
 			},
 		},
+		// cancel the d2 upload
+		{
+			ReqEntry: reqresp.ReqEntry{
+				DelOnUse: false,
+				Name:     "DELETE for d2",
+				Method:   "DELETE",
+				Path:     "/v2" + blobRepo + "/blobs/uploads/" + uuid2.String(),
+			},
+			RespEntry: reqresp.RespEntry{
+				Status: http.StatusAccepted,
+			},
+		},
 		// get upload2 location
 		{
 			ReqEntry: reqresp.ReqEntry{
@@ -771,6 +783,17 @@ func TestBlobPut(t *testing.T) {
 				Headers: http.Header{
 					"Content-Length": {fmt.Sprintf("%d", 0)},
 				},
+			},
+		},
+		{
+			ReqEntry: reqresp.ReqEntry{
+				DelOnUse: false,
+				Name:     "DELETE for d2Bad",
+				Method:   "DELETE",
+				Path:     "/v2" + blobRepo + "/blobs/uploads/" + uuid2Bad.String(),
+			},
+			RespEntry: reqresp.RespEntry{
+				Status: http.StatusAccepted,
 			},
 		},
 


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Failed blob uploads leave the in progress upload on the registry.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

On a blob upload failure, this attempts to cancel the upload, ignoring any additional errors.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
echo "hello" | regctl blob put localhost:5002/x --digest sha256:a8e1571c8aece39aa60cd64b3da4694b936887b620ad7e370b270fbdcca9afec -v debug
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Fix: Cancel blob uploads on failures.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
