### PR TITLE
Support formatted output on regctl registry config

### DIFF
--- a/cmd/regctl/registry_test.go
+++ b/cmd/regctl/registry_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -88,16 +87,14 @@ func TestRegistry(t *testing.T) {
 		},
 		// query good and bad to ensure user is set
 		{
-			name:        "query good host",
-			args:        []string{"registry", "config", tsGoodHost},
-			expectOut:   `"user": "testgooduser",`,
-			outContains: true,
+			name:      "query good host",
+			args:      []string{"registry", "config", tsGoodHost, "--format", "{{.User}}"},
+			expectOut: `testgooduser`,
 		},
 		{
-			name:        "query bad host",
-			args:        []string{"registry", "config", tsBadHost},
-			expectOut:   `"user": "testbaduser",`,
-			outContains: true,
+			name:      "query bad host",
+			args:      []string{"registry", "config", tsBadHost, "--format", "{{.User}}"},
+			expectOut: `testbaduser`,
 		},
 		// logout
 		{
@@ -114,18 +111,14 @@ func TestRegistry(t *testing.T) {
 		},
 		// verify logout
 		{
-			name: "check logout on good host",
-			args: []string{"registry", "config", tsGoodHost},
-			expectOut: fmt.Sprintf(`"hostname": "%s",
-  "credHost": "",`, tsGoodHost),
-			outContains: true,
+			name:      "check logout on good host",
+			args:      []string{"registry", "config", tsGoodHost, "--format", "{{.User}}"},
+			expectOut: ``,
 		},
 		{
-			name: "check logout on bad host",
-			args: []string{"registry", "config", tsBadHost},
-			expectOut: fmt.Sprintf(`"hostname": "%s",
-  "credHost": "",`, tsBadHost),
-			outContains: true,
+			name:      "check logout on bad host",
+			args:      []string{"registry", "config", tsBadHost, "--format", "{{.User}}"},
+			expectOut: ``,
 		},
 	}
 	for _, tc := range tt {


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This adds the ability to format output from the `regctl registry config` command.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
regctl registry config docker.io --format '{{.User}}'
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Feature: Support formatting output on `regctl registry config`.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
