### PR TITLE
Add image mod annotation promotion

### DIFF
--- a/cmd/regctl/image.go
+++ b/cmd/regctl/image.go
@@ -355,6 +355,20 @@ regctl image ratelimit alpine --format '{{.Remain}}'`,
 			return nil
 		},
 	}, "annotation-base", "", `set base image annotations (image/name:tag,sha256:digest)`)
+	flagAnnotationPromote := imageModCmd.Flags().VarPF(&modFlagFunc{
+		t: "bool",
+		f: func(val string) error {
+			b, err := strconv.ParseBool(val)
+			if err != nil {
+				return fmt.Errorf("unable to parse value %s: %w", val, err)
+			}
+			if b {
+				imageOpts.modOpts = append(imageOpts.modOpts, mod.WithAnnotationPromoteCommon())
+			}
+			return nil
+		},
+	}, "annotation-promote", "", `promote common annotations from child images to index`)
+	flagAnnotationPromote.NoOptDefVal = "true"
 	imageModCmd.Flags().VarP(&modFlagFunc{
 		t: "string",
 		f: func(val string) error {

--- a/mod/mod_test.go
+++ b/mod/mod_test.go
@@ -777,6 +777,26 @@ func TestMod(t *testing.T) {
 			},
 			ref: "ocidir://testrepo:v2",
 		},
+		{
+			name: "Setup Annotations",
+			opts: []Opts{
+				WithAnnotation("[*]common", "annotation on all images"),
+				WithAnnotation("[linux/amd64,linux/arm64,linux/arm/v7]child", "annotation on all child images"),
+				WithAnnotation("[linux/amd64]unique", "amd64"),
+				WithAnnotation("[linux/arm64]unique", "arm64"),
+				WithAnnotation("[linux/arm/v7]unique", "arm/v7"),
+				WithAnnotation("[linux/amd64]amd64only", "value for amd64"),
+				WithRefTgt(rTgt2),
+			},
+			ref: "ocidir://testrepo:v2",
+		},
+		{
+			name: "Pull up common annotations",
+			opts: []Opts{
+				WithAnnotationPromoteCommon(),
+			},
+			ref: rTgt2.CommonName(),
+		},
 	}
 
 	// run tests


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This allows common annotations to be copied to the index. The intended workflow is to individually label each image in the Dockerfile or as part of the build, copy those labels to annotations, and copy the image annotations to an index annotation.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
regctl image mod --annotation-promote $src --create $tgt
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Feature: Add image mod ability to promote common annotations in the child images to the index.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
