### PR TITLE
Handle deleted child manifests when promoting annotations

### DIFF
--- a/mod/manifest.go
+++ b/mod/manifest.go
@@ -173,8 +173,11 @@ func WithAnnotationPromoteCommon() Opts {
 			if err != nil {
 				return err
 			}
-			common := map[string]string{}
-			for i, child := range dm.manifests {
+			var common map[string]string
+			for _, child := range dm.manifests {
+				if child.mod == deleted {
+					continue
+				}
 				mAnnot, ok := child.m.(manifest.Annotator)
 				if !ok {
 					return fmt.Errorf("manifest does not support annotations: %s%.0w", child.m.GetDescriptor().Digest.String(), types.ErrUnsupportedMediaType)
@@ -183,7 +186,7 @@ func WithAnnotationPromoteCommon() Opts {
 				if err != nil {
 					return err
 				}
-				if i == 0 {
+				if common == nil {
 					common = cur
 				} else {
 					for k, v := range common {
@@ -191,6 +194,9 @@ func WithAnnotationPromoteCommon() Opts {
 							delete(common, k)
 						}
 					}
+				}
+				if len(common) == 0 {
+					return nil
 				}
 			}
 			if len(common) == 0 {

--- a/mod/mod_test.go
+++ b/mod/mod_test.go
@@ -778,7 +778,16 @@ func TestMod(t *testing.T) {
 			ref: "ocidir://testrepo:v2",
 		},
 		{
-			name: "Setup Annotations",
+			name: "Pull up labels and common annotations v1",
+			opts: []Opts{
+				WithManifestToOCIReferrers(),
+				WithLabelToAnnotation(),
+				WithAnnotationPromoteCommon(),
+			},
+			ref: "ocidir://testrepo:v1",
+		},
+		{
+			name: "Setup Annotations v2",
 			opts: []Opts{
 				WithAnnotation("[*]common", "annotation on all images"),
 				WithAnnotation("[linux/amd64,linux/arm64,linux/arm/v7]child", "annotation on all child images"),
@@ -791,7 +800,7 @@ func TestMod(t *testing.T) {
 			ref: "ocidir://testrepo:v2",
 		},
 		{
-			name: "Pull up common annotations",
+			name: "Pull up common annotations v2",
 			opts: []Opts{
 				WithAnnotationPromoteCommon(),
 			},


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Promoting annotations doesn't work when also copying labels to annotations and converting docker referrers to OCI referrers. This is because the docker referrers do not have labels converted to annotations.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Ignore deleted child manifests when promoting annotations.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Scripts to build regclient images will be updated in a PR shortly that depend on this. This can be reproduced by building docker images for multiple platforms, with common labels, and Docker build provenance, and then running:

```shell
regctl image mod $image \
  --to-oci-referrers --label-to-annotation --annotation-promote
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Fix: Promoting annotations should ignore child manifests that have been removed from the tree.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
