### PR TITLE
Pin base image digest in scripts

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,6 +27,10 @@ jobs:
         image: ["regctl", "regsync", "regbot"]
         type: ["scratch", "alpine"]
 
+    env:
+      ALPINE_NAME: "alpine:3"
+      ALPINE_DIGEST: "sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b" # 3.19.1
+
     steps:
     - name: Check out code
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -141,8 +145,8 @@ jobs:
         base_name=""
         mkdir -p "output/${{matrix.image}}"
         if [ "${{matrix.type}}" = "alpine" ]; then
-          base_name="alpine:3"
-          base_digest="$(regctl image digest "${base_name}")"
+          base_name="${ALPINE_NAME}"
+          base_digest="${ALPINE_DIGEST}"
         fi
         # mutate the image locally
         local_tag="ocidir://output/${{matrix.image}}:${{matrix.type}}"
@@ -163,6 +167,7 @@ jobs:
             --time "set=${vcs_date}"
         fi
         echo "digest=$(regctl image digest ${local_tag})" >>$GITHUB_OUTPUT
+
     - name: Attach SBOMs
       if: github.event_name != 'pull_request' && github.repository_owner == 'regclient'
       id: sbom

--- a/build/oci-image.sh
+++ b/build/oci-image.sh
@@ -6,6 +6,8 @@ platforms="linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/ppc
 base_name=""
 release="scratch"
 push_tags=""
+ALPINE_NAME="alpine:3"
+ALPINE_DIGEST="sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b" # 3.19.1
 
 # CLI options to override image, platform, base digest, and comma separated list of tags to push
 opt_c=0
@@ -64,7 +66,11 @@ vcs_version="$(echo "${vcs_version}" | sed -r 's#/+#-#g')"
 
 build_opts=""
 if [ -n "$base_name" ] && [ -z "$base_digest" ]; then
-  base_digest="$(regctl image digest "${base_name}")"
+  if [ "$base_name" = "${ALPINE_NAME}" ]; then
+    base_digest="${ALPINE_DIGEST}"
+  else
+    base_digest="$(regctl image digest "${base_name}")"
+  fi
   echo "Base image digest: ${base_digest}"
 elif [ -n "$base_name" ] && [ -n "$base_digest" ]; then
   build_opts=--build-context "${base_name}=docker-image://${base_name}@${base_digest}"


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

The base image annotation may not match the base image digest pinned in the Dockerfiles.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Base image digest is pinned in Dockerfile, so it should not be pulled dynamically in scripts. Version bump scripts will be updated with the weekly version update.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
make oci-image
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Fix: Pin base image digest in build scripts to match Dockerfile pins.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
