### PR TITLE
Replace t.Error and return with t.Fatal

### DIFF
--- a/blob_test.go
+++ b/blob_test.go
@@ -182,18 +182,16 @@ func TestBlobGet(t *testing.T) {
 	t.Run("Get", func(t *testing.T) {
 		ref, err := ref.New(tsURL.Host + blobRepo)
 		if err != nil {
-			t.Errorf("Failed creating ref: %v", err)
+			t.Fatalf("Failed creating ref: %v", err)
 		}
 		br, err := rc.BlobGet(ctx, ref, types.Descriptor{Digest: d1, Size: int64(len(blob1))})
 		if err != nil {
-			t.Errorf("Failed running BlobGet: %v", err)
-			return
+			t.Fatalf("Failed running BlobGet: %v", err)
 		}
 		defer br.Close()
 		brBlob, err := io.ReadAll(br)
 		if err != nil {
-			t.Errorf("Failed reading blob: %v", err)
-			return
+			t.Fatalf("Failed reading blob: %v", err)
 		}
 		if !bytes.Equal(blob1, brBlob) {
 			t.Errorf("Blob does not match")
@@ -204,7 +202,7 @@ func TestBlobGet(t *testing.T) {
 	t.Run("Data", func(t *testing.T) {
 		ref, err := ref.New(tsURL.Host + blobRepo + "/data")
 		if err != nil {
-			t.Errorf("Failed creating ref: %v", err)
+			t.Fatalf("Failed creating ref: %v", err)
 		}
 		desc := types.Descriptor{
 			Digest: d1,
@@ -213,14 +211,12 @@ func TestBlobGet(t *testing.T) {
 		}
 		br, err := rc.BlobGet(ctx, ref, desc)
 		if err != nil {
-			t.Errorf("Failed running BlobGet: %v", err)
-			return
+			t.Fatalf("Failed running BlobGet: %v", err)
 		}
 		defer br.Close()
 		brBlob, err := io.ReadAll(br)
 		if err != nil {
-			t.Errorf("Failed reading blob: %v", err)
-			return
+			t.Fatalf("Failed reading blob: %v", err)
 		}
 		if !bytes.Equal(blob1, brBlob) {
 			t.Errorf("Blob does not match")
@@ -230,12 +226,11 @@ func TestBlobGet(t *testing.T) {
 	t.Run("Head", func(t *testing.T) {
 		ref, err := ref.New(tsURL.Host + blobRepo)
 		if err != nil {
-			t.Errorf("Failed creating ref: %v", err)
+			t.Fatalf("Failed creating ref: %v", err)
 		}
 		br, err := rc.BlobHead(ctx, ref, types.Descriptor{Digest: d1})
 		if err != nil {
-			t.Errorf("Failed running BlobHead: %v", err)
-			return
+			t.Fatalf("Failed running BlobHead: %v", err)
 		}
 		defer br.Close()
 		if br.GetDescriptor().Size != int64(blobLen) {
@@ -246,13 +241,12 @@ func TestBlobGet(t *testing.T) {
 	t.Run("Missing", func(t *testing.T) {
 		ref, err := ref.New(tsURL.Host + blobRepo)
 		if err != nil {
-			t.Errorf("Failed creating ref: %v", err)
+			t.Fatalf("Failed creating ref: %v", err)
 		}
 		br, err := rc.BlobGet(ctx, ref, types.Descriptor{Digest: dMissing})
 		if err == nil {
 			defer br.Close()
-			t.Errorf("Unexpected success running BlobGet")
-			return
+			t.Fatalf("Unexpected success running BlobGet")
 		}
 		if !errors.Is(err, types.ErrNotFound) {
 			t.Errorf("Error does not match \"ErrNotFound\": %v", err)
@@ -262,18 +256,16 @@ func TestBlobGet(t *testing.T) {
 	t.Run("Retry", func(t *testing.T) {
 		ref, err := ref.New(tsURL.Host + blobRepo)
 		if err != nil {
-			t.Errorf("Failed creating ref: %v", err)
+			t.Fatalf("Failed creating ref: %v", err)
 		}
 		br, err := rc.BlobGet(ctx, ref, types.Descriptor{Digest: d2})
 		if err != nil {
-			t.Errorf("Failed running BlobGet: %v", err)
-			return
+			t.Fatalf("Failed running BlobGet: %v", err)
 		}
 		defer br.Close()
 		brBlob, err := io.ReadAll(br)
 		if err != nil {
-			t.Errorf("Failed reading blob: %v", err)
-			return
+			t.Fatalf("Failed reading blob: %v", err)
 		}
 		if !bytes.Equal(blob2, brBlob) {
 			t.Errorf("Blob does not match")
@@ -283,13 +275,12 @@ func TestBlobGet(t *testing.T) {
 	t.Run("Forbidden", func(t *testing.T) {
 		ref, err := ref.New(tsURL.Host + privateRepo)
 		if err != nil {
-			t.Errorf("Failed creating ref: %v", err)
+			t.Fatalf("Failed creating ref: %v", err)
 		}
 		br, err := rc.BlobGet(ctx, ref, types.Descriptor{Digest: d1})
 		if err == nil {
-			defer br.Close()
-			t.Errorf("Unexpected success running BlobGet")
-			return
+			br.Close()
+			t.Fatalf("Unexpected success running BlobGet")
 		}
 		if !errors.Is(err, types.ErrHTTPUnauthorized) {
 			t.Errorf("Error does not match \"ErrUnauthorized\": %v", err)
@@ -678,13 +669,12 @@ func TestBlobPut(t *testing.T) {
 	t.Run("Put", func(t *testing.T) {
 		ref, err := ref.New(tsURL.Host + blobRepo)
 		if err != nil {
-			t.Errorf("Failed creating ref: %v", err)
+			t.Fatalf("Failed creating ref: %v", err)
 		}
 		br := bytes.NewReader(blob1)
 		dp, err := rc.BlobPut(ctx, ref, types.Descriptor{Digest: d1, Size: int64(len(blob1))}, br)
 		if err != nil {
-			t.Errorf("Failed running BlobPut: %v", err)
-			return
+			t.Fatalf("Failed running BlobPut: %v", err)
 		}
 		if dp.Digest.String() != d1.String() {
 			t.Errorf("Digest mismatch, expected %s, received %s", d1.String(), dp.Digest.String())
@@ -698,13 +688,12 @@ func TestBlobPut(t *testing.T) {
 	t.Run("Retry", func(t *testing.T) {
 		ref, err := ref.New(tsURL.Host + blobRepo)
 		if err != nil {
-			t.Errorf("Failed creating ref: %v", err)
+			t.Fatalf("Failed creating ref: %v", err)
 		}
 		br := bytes.NewReader(blob2)
 		dp, err := rc.BlobPut(ctx, ref, types.Descriptor{Digest: d2, Size: int64(len(blob2))}, br)
 		if err != nil {
-			t.Errorf("Failed running BlobPut: %v", err)
-			return
+			t.Fatalf("Failed running BlobPut: %v", err)
 		}
 		if dp.Digest.String() != d2.String() {
 			t.Errorf("Digest mismatch, expected %s, received %s", d2.String(), dp.Digest.String())
@@ -718,13 +707,12 @@ func TestBlobPut(t *testing.T) {
 	t.Run("PartialChunk", func(t *testing.T) {
 		ref, err := ref.New(tsURL.Host + blobRepo)
 		if err != nil {
-			t.Errorf("Failed creating ref: %v", err)
+			t.Fatalf("Failed creating ref: %v", err)
 		}
 		br := bytes.NewReader(blob3)
 		dp, err := rc.BlobPut(ctx, ref, types.Descriptor{Digest: d3, Size: int64(len(blob3))}, br)
 		if err != nil {
-			t.Errorf("Failed running BlobPut: %v", err)
-			return
+			t.Fatalf("Failed running BlobPut: %v", err)
 		}
 		if dp.Digest.String() != d3.String() {
 			t.Errorf("Digest mismatch, expected %s, received %s", d3.String(), dp.Digest.String())
@@ -1166,18 +1154,18 @@ func TestBlobCopy(t *testing.T) {
 
 	refA, err := ref.New(tsURL.Host + blobRepoA)
 	if err != nil {
-		t.Errorf("Failed creating ref: %v", err)
+		t.Fatalf("Failed creating ref: %v", err)
 	}
 	refB, err := ref.New(tsURL.Host + blobRepoB)
 	if err != nil {
-		t.Errorf("Failed creating ref: %v", err)
+		t.Fatalf("Failed creating ref: %v", err)
 	}
 
 	// same repo
 	t.Run("Copy Same Repo", func(t *testing.T) {
 		err = rc.BlobCopy(ctx, refA, refA, types.Descriptor{Digest: d1})
 		if err != nil {
-			t.Errorf("Failed to copy d1 from repo a to a: %v", err)
+			t.Fatalf("Failed to copy d1 from repo a to a: %v", err)
 		}
 	})
 
@@ -1185,7 +1173,7 @@ func TestBlobCopy(t *testing.T) {
 	t.Run("Copy Diff Repo", func(t *testing.T) {
 		err = rc.BlobCopy(ctx, refA, refB, types.Descriptor{Digest: d1})
 		if err != nil {
-			t.Errorf("Failed to copy d1 from repo a to b: %v", err)
+			t.Fatalf("Failed to copy d1 from repo a to b: %v", err)
 		}
 	})
 
@@ -1193,7 +1181,7 @@ func TestBlobCopy(t *testing.T) {
 	t.Run("Copy Existing Blob", func(t *testing.T) {
 		err = rc.BlobCopy(ctx, refA, refB, types.Descriptor{Digest: d1})
 		if err != nil {
-			t.Errorf("Failed to copy d1 from repo a to b: %v", err)
+			t.Fatalf("Failed to copy d1 from repo a to b: %v", err)
 		}
 	})
 
@@ -1201,7 +1189,7 @@ func TestBlobCopy(t *testing.T) {
 	t.Run("Copy Flaky Get", func(t *testing.T) {
 		err = rc.BlobCopy(ctx, refA, refB, types.Descriptor{Digest: d2})
 		if err != nil {
-			t.Errorf("Failed to copy d2 from repo a to b: %v", err)
+			t.Fatalf("Failed to copy d2 from repo a to b: %v", err)
 		}
 	})
 
@@ -1209,7 +1197,7 @@ func TestBlobCopy(t *testing.T) {
 	t.Run("Copy Flaky Put", func(t *testing.T) {
 		err = rc.BlobCopy(ctx, refA, refB, types.Descriptor{Digest: d3})
 		if err != nil {
-			t.Errorf("Failed to copy d3 from repo a to b: %v", err)
+			t.Fatalf("Failed to copy d3 from repo a to b: %v", err)
 		}
 	})
 

--- a/cmd/regbot/internal/go2lua/go2lua_test.go
+++ b/cmd/regbot/internal/go2lua/go2lua_test.go
@@ -66,7 +66,7 @@ func TestExportImport(t *testing.T) {
 
 	jsonIn, err := json.Marshal(tsIn)
 	if err != nil {
-		t.Errorf("Failed to marshal test struct in: %v", err)
+		t.Fatalf("Failed to marshal test struct in: %v", err)
 	}
 	lv := Export(ls, tsIn)
 
@@ -74,12 +74,12 @@ func TestExportImport(t *testing.T) {
 	tsOut := reflect.New(reflect.ValueOf(tsIn).Type()).Interface()
 	err = Import(ls, lv, tsOut, tsIn)
 	if err != nil {
-		t.Errorf("Import failed: %v", err)
+		t.Fatalf("Import failed: %v", err)
 	}
 
 	jsonOut, err := json.Marshal(tsOut)
 	if err != nil {
-		t.Errorf("Failed to marshal test struct out: %v", err)
+		t.Fatalf("Failed to marshal test struct out: %v", err)
 	}
 
 	if !bytes.Equal(jsonIn, jsonOut) {

--- a/cmd/regbot/regbot_test.go
+++ b/cmd/regbot/regbot_test.go
@@ -20,8 +20,7 @@ func TestRegbot(t *testing.T) {
 	fsMem := rwfs.MemNew()
 	err := rwfs.CopyRecursive(fsOS, "testdata", fsMem, ".")
 	if err != nil {
-		t.Errorf("failed to setup memfs copy: %v", err)
-		return
+		t.Fatalf("failed to setup memfs copy: %v", err)
 	}
 	// setup various globals normally done by loadConf
 	throttleC = throttle.New(1)
@@ -35,13 +34,11 @@ func TestRegbot(t *testing.T) {
 	confRdr := bytes.NewReader([]byte(confBytes))
 	conf, err = ConfigLoadReader(confRdr)
 	if err != nil {
-		t.Errorf("failed parsing config: %v", err)
-		return
+		t.Fatalf("failed parsing config: %v", err)
 	}
 	shortTime, err := time.ParseDuration("10ms")
 	if err != nil {
-		t.Errorf("failed to setup shortTime: %v", err)
-		return
+		t.Fatalf("failed to setup shortTime: %v", err)
 	}
 	tests := []struct {
 		name      string
@@ -167,8 +164,7 @@ func TestRegbot(t *testing.T) {
 				return
 			}
 			if err != nil {
-				t.Errorf("unexpected error on process: %v", err)
-				return
+				t.Fatalf("unexpected error on process: %v", err)
 			}
 			for _, exist := range tt.exists {
 				r, err := ref.New(exist)
@@ -184,8 +180,7 @@ func TestRegbot(t *testing.T) {
 			for _, missing := range tt.missing {
 				r, err := ref.New(missing)
 				if err != nil {
-					t.Errorf("cannot parse ref %s: %v", missing, err)
-					continue
+					t.Fatalf("cannot parse ref %s: %v", missing, err)
 				}
 				_, err = rc.ManifestHead(ctx, r)
 				if err == nil {

--- a/cmd/regctl/artifact_test.go
+++ b/cmd/regctl/artifact_test.go
@@ -63,8 +63,7 @@ func TestArtifactGet(t *testing.T) {
 				return
 			}
 			if err != nil {
-				t.Errorf("returned unexpected error: %v", err)
-				return
+				t.Fatalf("returned unexpected error: %v", err)
 			}
 			if (!tc.outContains && out != tc.expectOut) || (tc.outContains && !strings.Contains(out, tc.expectOut)) {
 				t.Errorf("unexpected output, expected %s, received %s", tc.expectOut, out)
@@ -138,8 +137,7 @@ func TestArtifactList(t *testing.T) {
 				return
 			}
 			if err != nil {
-				t.Errorf("returned unexpected error: %v", err)
-				return
+				t.Fatalf("returned unexpected error: %v", err)
 			}
 			if (!tc.outContains && out != tc.expectOut) || (tc.outContains && !strings.Contains(out, tc.expectOut)) {
 				t.Errorf("unexpected output, expected %s, received %s", tc.expectOut, out)
@@ -154,14 +152,12 @@ func TestArtifactPut(t *testing.T) {
 	testConfName := filepath.Join(testDir, "exConf")
 	err := os.WriteFile(testConfName, []byte(`{"hello": "world"}`), 0600)
 	if err != nil {
-		t.Errorf("failed creating test conf: %v", err)
-		return
+		t.Fatalf("failed creating test conf: %v", err)
 	}
 	testFileName := filepath.Join(testDir, "exFile")
 	err = os.WriteFile(testFileName, []byte(`example test file`), 0600)
 	if err != nil {
-		t.Errorf("failed creating test conf: %v", err)
-		return
+		t.Fatalf("failed creating test conf: %v", err)
 	}
 
 	tt := []struct {
@@ -244,8 +240,7 @@ func TestArtifactPut(t *testing.T) {
 				return
 			}
 			if err != nil {
-				t.Errorf("returned unexpected error: %v", err)
-				return
+				t.Fatalf("returned unexpected error: %v", err)
 			}
 			if (!tc.outContains && out != tc.expectOut) || (tc.outContains && !strings.Contains(out, tc.expectOut)) {
 				t.Errorf("unexpected output, expected %s, received %s", tc.expectOut, out)
@@ -324,8 +319,7 @@ func TestArtifactTree(t *testing.T) {
 				return
 			}
 			if err != nil {
-				t.Errorf("returned unexpected error: %v", err)
-				return
+				t.Fatalf("returned unexpected error: %v", err)
 			}
 			if (!tc.outContains && out != tc.expectOut) || (tc.outContains && !strings.Contains(out, tc.expectOut)) {
 				t.Errorf("unexpected output, expected %s, received %s", tc.expectOut, out)

--- a/cmd/regctl/blob_test.go
+++ b/cmd/regctl/blob_test.go
@@ -5,32 +5,30 @@ import (
 	"testing"
 )
 
-// TODO: implement tests
-
 func TestBlob(t *testing.T) {
 	repo := "ocidir://../../testdata/testrepo"
 	digBaseA, err := cobraTest(t, nil, "manifest", "get", repo+":b1", "--platform", "linux/amd64", "--format", "{{(index .Layers 0).Digest}}")
 	if err != nil {
-		t.Errorf("failed getting layer digest: %v", err)
+		t.Fatalf("failed getting layer digest: %v", err)
 	}
 	digBaseB, err := cobraTest(t, nil, "manifest", "get", repo+":b3", "--platform", "linux/amd64", "--format", "{{(index .Layers 0).Digest}}")
 	if err != nil {
-		t.Errorf("failed getting layer digest: %v", err)
+		t.Fatalf("failed getting layer digest: %v", err)
 	}
 	digConf1, err := cobraTest(t, nil, "manifest", "get", repo+":b1", "--platform", "linux/amd64", "--format", "{{.Config.Digest}}")
 	if err != nil {
-		t.Errorf("failed getting layer digest: %v", err)
+		t.Fatalf("failed getting layer digest: %v", err)
 	}
 	digConf3, err := cobraTest(t, nil, "manifest", "get", repo+":b3", "--platform", "linux/amd64", "--format", "{{.Config.Digest}}")
 	if err != nil {
-		t.Errorf("failed getting layer digest: %v", err)
+		t.Fatalf("failed getting layer digest: %v", err)
 	}
 
 	t.Run("Get", func(t *testing.T) {
 		// run a get request
 		out, err := cobraTest(t, nil, "blob", "get", "--format", "{{printPretty .}}", repo, digBaseA)
 		if err != nil {
-			t.Errorf("failed to blob get: %v", err)
+			t.Fatalf("failed to blob get: %v", err)
 		}
 		if out == "" {
 			t.Errorf("no blob output received")
@@ -62,7 +60,7 @@ func TestBlob(t *testing.T) {
 		// put a blob
 		dig, err := cobraTest(t, &cobraOpts, "blob", "put", "--format", "{{println .Digest}}", "ocidir://"+dir)
 		if err != nil {
-			t.Errorf("failed to put blob: %v", err)
+			t.Fatalf("failed to put blob: %v", err)
 		}
 		// get the blob from the tempdir
 		out, err := cobraTest(t, nil, "blob", "get", "--format", "{{printPretty .}}", "ocidir://"+dir, dig)
@@ -75,7 +73,7 @@ func TestBlob(t *testing.T) {
 		// delete the blob
 		_, err = cobraTest(t, nil, "blob", "delete", "ocidir://"+dir, dig)
 		if err != nil {
-			t.Errorf("failed to delete blob: %v", err)
+			t.Fatalf("failed to delete blob: %v", err)
 		}
 		// verify blob was deleted
 		_, err = cobraTest(t, nil, "blob", "get", "--format", "{{printPretty .}}", "ocidir://"+dir, dig)
@@ -89,7 +87,7 @@ func TestBlob(t *testing.T) {
 		// copy the blob to the tempdir
 		_, err := cobraTest(t, nil, "blob", "copy", repo, "ocidir://"+dir, digBaseA)
 		if err != nil {
-			t.Errorf("failed to blob copy: %v", err)
+			t.Fatalf("failed to blob copy: %v", err)
 		}
 		// get the blob from the tempdir
 		out, err := cobraTest(t, nil, "blob", "get", "--format", "{{printPretty .}}", "ocidir://"+dir, digBaseA)
@@ -105,7 +103,7 @@ func TestBlob(t *testing.T) {
 		// diff the layers between two images
 		out, err := cobraTest(t, nil, "blob", "diff-layer", repo, digBaseA, repo, digBaseB)
 		if err != nil {
-			t.Errorf("failed to diff layers: %v", err)
+			t.Fatalf("failed to diff layers: %v", err)
 		}
 		if out == "" {
 			t.Errorf("no output received from diff-layer")
@@ -113,7 +111,7 @@ func TestBlob(t *testing.T) {
 		// diff the config between two images
 		out, err = cobraTest(t, nil, "blob", "diff-config", repo, digConf1, repo, digConf3)
 		if err != nil {
-			t.Errorf("failed to diff config: %v", err)
+			t.Fatalf("failed to diff config: %v", err)
 		}
 		if out == "" {
 			t.Errorf("no output received from diff-config")

--- a/cmd/regctl/image_test.go
+++ b/cmd/regctl/image_test.go
@@ -15,8 +15,7 @@ func TestImageExportImport(t *testing.T) {
 
 	out, err := cobraTest(t, nil, "image", "export", "--name", exportName, srcRef, exportFile)
 	if err != nil {
-		t.Errorf("failed to run image export: %v", err)
-		return
+		t.Fatalf("failed to run image export: %v", err)
 	}
 	if out != "" {
 		t.Errorf("unexpected output: %v", out)
@@ -24,8 +23,7 @@ func TestImageExportImport(t *testing.T) {
 
 	out, err = cobraTest(t, nil, "image", "import", importRefA, exportFile)
 	if err != nil {
-		t.Errorf("failed to run image import: %v", err)
-		return
+		t.Fatalf("failed to run image import: %v", err)
 	}
 	if out != "" {
 		t.Errorf("unexpected output: %v", out)
@@ -33,8 +31,7 @@ func TestImageExportImport(t *testing.T) {
 
 	out, err = cobraTest(t, nil, "image", "export", "--name", exportName, "--platform", "linux/amd64", srcRef, exportFile)
 	if err != nil {
-		t.Errorf("failed to run image export: %v", err)
-		return
+		t.Fatalf("failed to run image export: %v", err)
 	}
 	if out != "" {
 		t.Errorf("unexpected output: %v", out)
@@ -78,8 +75,7 @@ func TestImageInspect(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			out, err := cobraTest(t, nil, tc.cmd...)
 			if err != nil {
-				t.Errorf("error: %v", err)
-				return
+				t.Fatalf("error: %v", err)
 			}
 			if (!tc.outContains && out != tc.expectOut) || (tc.outContains && !strings.Contains(out, tc.expectOut)) {
 				t.Errorf("unexpected output, expected %s, received %s", tc.expectOut, out)
@@ -96,8 +92,7 @@ func TestImageMod(t *testing.T) {
 
 	out, err := cobraTest(t, nil, "image", "mod", srcRef, "--create", modRef, "--time", "set=2000-01-01T00:00:00Z,base-ref="+baseRef)
 	if err != nil {
-		t.Errorf("failed to run image mod: %v", err)
-		return
+		t.Fatalf("failed to run image mod: %v", err)
 	}
 	if out == "" {
 		t.Errorf("missing output")

--- a/cmd/regctl/index_test.go
+++ b/cmd/regctl/index_test.go
@@ -14,8 +14,7 @@ func TestIndex(t *testing.T) {
 	// create index with 2 platforms from test repo
 	out, err := cobraTest(t, nil, "index", "create", "--ref", srcRef, "--platform", "linux/amd64", "--platform", "linux/arm/v7", latestRef)
 	if err != nil {
-		t.Errorf("failed to run index create: %v", err)
-		return
+		t.Fatalf("failed to run index create: %v", err)
 	}
 	if out != "" {
 		t.Errorf("unexpected output: %s", out)
@@ -41,8 +40,7 @@ func TestIndex(t *testing.T) {
 	// add artifact with referrers
 	out, err = cobraTest(t, nil, "index", "add", "--ref", srcRef, "--platform", "linux/arm64", "--referrers", "--digest-tags", latestRef)
 	if err != nil {
-		t.Errorf("failed to run index add: %v", err)
-		return
+		t.Fatalf("failed to run index add: %v", err)
 	}
 	if out != "" {
 		t.Errorf("unexpected output: %s", out)
@@ -64,8 +62,7 @@ func TestIndex(t *testing.T) {
 	testArtifactType := "application/example.test"
 	out, err = cobraTest(t, nil, "index", "create", artifactRef, "--subject", "latest", "--artifact-type", testArtifactType, "--ref", srcRef)
 	if err != nil {
-		t.Errorf("failed to run index create for artifact: %v", err)
-		return
+		t.Fatalf("failed to run index create for artifact: %v", err)
 	}
 	if out != "" {
 		t.Errorf("unexpected output: %s", out)

--- a/cmd/regctl/manifest_test.go
+++ b/cmd/regctl/manifest_test.go
@@ -62,8 +62,7 @@ func TestManifestHead(t *testing.T) {
 				return
 			}
 			if err != nil {
-				t.Errorf("returned unexpected error: %v", err)
-				return
+				t.Fatalf("returned unexpected error: %v", err)
 			}
 			if (!tc.outContains && out != tc.expectOut) || (tc.outContains && !strings.Contains(out, tc.expectOut)) {
 				t.Errorf("unexpected output, expected %s, received %s", tc.expectOut, out)

--- a/cmd/regctl/registry_test.go
+++ b/cmd/regctl/registry_test.go
@@ -133,8 +133,7 @@ func TestRegistry(t *testing.T) {
 				return
 			}
 			if err != nil {
-				t.Errorf("returned unexpected error: %v", err)
-				return
+				t.Fatalf("returned unexpected error: %v", err)
 			}
 			if (!tc.outContains && out != tc.expectOut) || (tc.outContains && !strings.Contains(out, tc.expectOut)) {
 				t.Errorf("unexpected output, expected %s, received %s", tc.expectOut, out)

--- a/cmd/regctl/tag_test.go
+++ b/cmd/regctl/tag_test.go
@@ -70,8 +70,7 @@ func TestTagList(t *testing.T) {
 				return
 			}
 			if err != nil {
-				t.Errorf("returned unexpected error: %v", err)
-				return
+				t.Fatalf("returned unexpected error: %v", err)
 			}
 			if (!tc.outContains && out != tc.expectOut) || (tc.outContains && !strings.Contains(out, tc.expectOut)) {
 				t.Errorf("unexpected output, expected %s, received %s", tc.expectOut, out)

--- a/cmd/regsync/regsync_test.go
+++ b/cmd/regsync/regsync_test.go
@@ -26,8 +26,7 @@ func TestProcess(t *testing.T) {
 	fsMem := rwfs.MemNew()
 	err := rwfs.CopyRecursive(fsOS, "../../testdata", fsMem, ".")
 	if err != nil {
-		t.Errorf("failed to setup memfs copy: %v", err)
-		return
+		t.Fatalf("failed to setup memfs copy: %v", err)
 	}
 	// setup various globals normally done by loadConf
 	rc = regclient.New(regclient.WithFS(fsMem))
@@ -40,94 +39,93 @@ func TestProcess(t *testing.T) {
 	confRdr := bytes.NewReader([]byte(confBytes))
 	conf, err = ConfigLoadReader(confRdr)
 	if err != nil {
-		t.Errorf("failed parsing config: %v", err)
-		return
+		t.Fatalf("failed parsing config: %v", err)
 	}
 	pAMD, err := platform.Parse("linux/amd64")
 	if err != nil {
-		t.Errorf("failed to parse amd platform: %v", err)
+		t.Fatalf("failed to parse amd platform: %v", err)
 	}
 	pARM, err := platform.Parse("linux/arm64")
 	if err != nil {
-		t.Errorf("failed to parse arm platform: %v", err)
+		t.Fatalf("failed to parse arm platform: %v", err)
 	}
 	r1, err := ref.New("ocidir://testrepo:v1")
 	if err != nil {
-		t.Errorf("failed to parse v1 reference: %v", err)
+		t.Fatalf("failed to parse v1 reference: %v", err)
 	}
 	r2, err := ref.New("ocidir://testrepo:v2")
 	if err != nil {
-		t.Errorf("failed to parse v2 reference: %v", err)
+		t.Fatalf("failed to parse v2 reference: %v", err)
 	}
 	r3, err := ref.New("ocidir://testrepo:v3")
 	if err != nil {
-		t.Errorf("failed to parse v3 reference: %v", err)
+		t.Fatalf("failed to parse v3 reference: %v", err)
 	}
 	rMirror, err := ref.New("ocidir://testrepo:mirror")
 	if err != nil {
-		t.Errorf("failed to parse mirror reference: %v", err)
+		t.Fatalf("failed to parse mirror reference: %v", err)
 	}
 	rChild, err := ref.New("ocidir://testrepo:child")
 	if err != nil {
-		t.Errorf("failed to parse child reference: %v", err)
+		t.Fatalf("failed to parse child reference: %v", err)
 	}
 	rLoop, err := ref.New("ocidir://testrepo:loop")
 	if err != nil {
-		t.Errorf("failed to parse loop reference: %v", err)
+		t.Fatalf("failed to parse loop reference: %v", err)
 	}
 	m1, err := rc.ManifestGet(ctx, r1)
 	if err != nil {
-		t.Errorf("failed to get manifest v1: %v", err)
+		t.Fatalf("failed to get manifest v1: %v", err)
 	}
 	d1 := m1.GetDescriptor().Digest
 	desc1AMD, err := manifest.GetPlatformDesc(m1, &pAMD)
 	if err != nil {
-		t.Errorf("failed to get platform ")
+		t.Fatalf("failed to get platform ")
 	}
 	d1AMD := desc1AMD.Digest
 	desc1ARM, err := manifest.GetPlatformDesc(m1, &pARM)
 	if err != nil {
-		t.Errorf("failed to get platform ")
+		t.Fatalf("failed to get platform ")
 	}
 	d1ARM := desc1ARM.Digest
 	m2, err := rc.ManifestGet(ctx, r2)
 	if err != nil {
-		t.Errorf("failed to get manifest v2: %v", err)
+		t.Fatalf("failed to get manifest v2: %v", err)
 	}
 	d2 := m2.GetDescriptor().Digest
 	desc2AMD, err := manifest.GetPlatformDesc(m2, &pAMD)
 	if err != nil {
-		t.Errorf("failed to get platform ")
+		t.Fatalf("failed to get platform ")
 	}
 	d2AMD := desc2AMD.Digest
 	desc2SBOM, err := rc.ReferrerList(ctx, r2, scheme.WithReferrerMatchOpt(types.MatchOpt{ArtifactType: "application/example.sbom"}))
 	if err != nil || len(desc2SBOM.Descriptors) == 0 {
-		t.Errorf("failed to get SBOM for v2: %v", err)
+		t.Fatalf("failed to get SBOM for v2: %v", err)
 	}
 	d2SBOM := desc2SBOM.Descriptors[0].Digest
 	desc2Sig, err := rc.ReferrerList(ctx, r2, scheme.WithReferrerMatchOpt(types.MatchOpt{ArtifactType: "application/example.signature"}))
 	if err != nil || len(desc2Sig.Descriptors) == 0 {
-		t.Errorf("failed to get signature for v2: %v", err)
+		t.Fatalf("failed to get signature for v2: %v", err)
 	}
 	d2Sig := desc2Sig.Descriptors[0].Digest
 	m3, err := rc.ManifestGet(ctx, r3)
 	if err != nil {
-		t.Errorf("failed to get manifest v3: %v", err)
+		t.Fatalf("failed to get manifest v3: %v", err)
 	}
 	d3 := m3.GetDescriptor().Digest
 	mMirror, err := rc.ManifestGet(ctx, rMirror)
 	if err != nil {
-		t.Errorf("failed to get manifest vMirror: %v", err)
+		t.Fatalf("failed to get manifest vMirror: %v", err)
 	}
 	dMirror := mMirror.GetDescriptor().Digest
 	mChild, err := rc.ManifestGet(ctx, rChild)
 	if err != nil {
-		t.Errorf("failed to get manifest vChild: %v", err)
+		t.Fatalf("failed to get manifest vChild: %v", err)
 	}
 	dChild := mChild.GetDescriptor().Digest
 	mLoop, err := rc.ManifestGet(ctx, rLoop)
 	if err != nil {
-		t.Errorf("failed to get manifest vLoop: %v", err)
+		t.Fatalf("failed to get manifest vLoop: %v", err)
 	}
 	dLoop := mLoop.GetDescriptor().Digest
 
@@ -645,15 +643,13 @@ func TestProcess(t *testing.T) {
 				return
 			}
 			if err != nil {
-				t.Errorf("unexpected error on process: %v", err)
-				return
+				t.Fatalf("unexpected error on process: %v", err)
 			}
 			// validate tags and files exist/don't exist
 			for _, exist := range tc.exists {
 				r, err := ref.New(exist)
 				if err != nil {
-					t.Errorf("cannot parse ref %s: %v", exist, err)
-					continue
+					t.Fatalf("cannot parse ref %s: %v", exist, err)
 				}
 				_, err = rc.ManifestHead(ctx, r)
 				if err != nil {
@@ -683,8 +679,7 @@ func TestProcessRef(t *testing.T) {
 	fsMem := rwfs.MemNew()
 	err := rwfs.CopyRecursive(fsOS, "../../testdata", fsMem, ".")
 	if err != nil {
-		t.Errorf("failed to setup memfs copy: %v", err)
-		return
+		t.Fatalf("failed to setup memfs copy: %v", err)
 	}
 	// setup various globals normally done by loadConf
 	rc = regclient.New(regclient.WithFS(fsMem))
@@ -736,13 +731,11 @@ func TestProcessRef(t *testing.T) {
 			rootOpts := rootCmd{}
 			src, err := ref.New(cs.Source)
 			if err != nil {
-				t.Errorf("failed to create src ref: %v", err)
-				return
+				t.Fatalf("failed to create src ref: %v", err)
 			}
 			tgt, err := ref.New(cs.Target)
 			if err != nil {
-				t.Errorf("failed to create tgt ref: %v", err)
-				return
+				t.Fatalf("failed to create tgt ref: %v", err)
 			}
 			src.Tag = tc.src
 			tgt.Tag = tc.tgt
@@ -757,17 +750,16 @@ func TestProcessRef(t *testing.T) {
 				return
 			}
 			if err != nil {
-				t.Errorf("unexpected error on process: %v", err)
-				return
+				t.Fatalf("unexpected error on process: %v", err)
 			}
 			if tc.checkTgtEq || tc.checkTgtDiff {
 				mSrc, err := rc.ManifestHead(ctx, src)
 				if err != nil {
-					t.Errorf("error fetching src: %v", err)
+					t.Fatalf("error fetching src: %v", err)
 				}
 				mTgt, err := rc.ManifestHead(ctx, tgt)
 				if err != nil && tc.checkTgtEq {
-					t.Errorf("error fetching tgt: %v", err)
+					t.Fatalf("error fetching tgt: %v", err)
 				}
 				if tc.checkTgtEq {
 					if mTgt == nil || mSrc.GetDescriptor().Digest != mTgt.GetDescriptor().Digest {
@@ -828,8 +820,7 @@ func TestConfigRead(t *testing.T) {
   `))
 	c, err := ConfigLoadReader(cRead)
 	if err != nil {
-		t.Errorf("Filed to load reader: %v", err)
-		return
+		t.Fatalf("Filed to load reader: %v", err)
 	}
 	if c.Sync[1].Target != "registry:5000/hub/alpine" {
 		t.Errorf("template sync-hub mismatch, expected: %s, received: %s", "registry:5000/hub/alpine", c.Sync[1].Target)

--- a/config/credhelper_test.go
+++ b/config/credhelper_test.go
@@ -55,8 +55,7 @@ func TestCredHelper(t *testing.T) {
 	}
 	cwd, err := os.Getwd()
 	if err != nil {
-		t.Errorf("failed checking current directory: %v", err)
-		return
+		t.Fatalf("failed checking current directory: %v", err)
 	}
 	curPath := os.Getenv("PATH")
 	t.Setenv("PATH", filepath.Join(cwd, "testdata")+string(os.PathListSeparator)+curPath)
@@ -74,7 +73,7 @@ func TestCredHelper(t *testing.T) {
 				return
 			}
 			if err != nil {
-				t.Errorf("error running get: %v", err)
+				t.Fatalf("error running get: %v", err)
 			}
 			if tt.expectUser != h.User {
 				t.Errorf("user mismatch: expected %s, received %s", tt.expectUser, h.User)

--- a/config/docker_test.go
+++ b/config/docker_test.go
@@ -12,16 +12,14 @@ func TestDocker(t *testing.T) {
 	// cannot run cred helper in parallel because of OS working directory race conditions
 	pwd, err := os.Getwd()
 	if err != nil {
-		t.Errorf("failed to get working dir: %v", err)
-		return
+		t.Fatalf("failed to get working dir: %v", err)
 	}
 	curPath := os.Getenv("PATH")
 	t.Setenv("PATH", filepath.Join(pwd, "testdata")+string(os.PathListSeparator)+curPath)
 	t.Setenv(dockerEnv, "testdata")
 	hosts, err := DockerLoad()
 	if err != nil {
-		t.Errorf("error loading docker credentials: %v", err)
-		return
+		t.Fatalf("error loading docker credentials: %v", err)
 	}
 	hostMap := map[string]*Host{}
 	for _, h := range hosts {
@@ -91,8 +89,7 @@ func TestDocker(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h, ok := hostMap[tt.hostname]
 			if !ok {
-				t.Errorf("host not found: %s", tt.hostname)
-				return
+				t.Fatalf("host not found: %s", tt.hostname)
 			}
 			if tt.expectUser != h.User {
 				t.Errorf("user mismatch, expect %s, received %s", tt.expectUser, h.User)

--- a/config/host_test.go
+++ b/config/host_test.go
@@ -15,8 +15,7 @@ func TestConfig(t *testing.T) {
 	// cannot run cred helper in parallel because of OS working directory race conditions
 	cwd, err := os.Getwd()
 	if err != nil {
-		t.Errorf("failed checking current directory: %v", err)
-		return
+		t.Fatalf("failed checking current directory: %v", err)
 	}
 	curPath := os.Getenv("PATH")
 	t.Setenv("PATH", filepath.Join(cwd, "testdata")+string(os.PathListSeparator)+curPath)

--- a/image_test.go
+++ b/image_test.go
@@ -28,47 +28,39 @@ func TestImageCheckBase(t *testing.T) {
 	fsMem := rwfs.MemNew()
 	err := rwfs.CopyRecursive(fsOS, "testdata", fsMem, ".")
 	if err != nil {
-		t.Errorf("failed to setup memfs copy: %v", err)
-		return
+		t.Fatalf("failed to setup memfs copy: %v", err)
 	}
 	delayInit, _ := time.ParseDuration("0.05s")
 	delayMax, _ := time.ParseDuration("0.10s")
 	rc := New(WithFS(fsMem), WithRetryDelay(delayInit, delayMax))
 	rb1, err := ref.New("ocidir://testrepo:b1")
 	if err != nil {
-		t.Errorf("failed to setup ref: %v", err)
-		return
+		t.Fatalf("failed to setup ref: %v", err)
 	}
 	rb2, err := ref.New("ocidir://testrepo:b2")
 	if err != nil {
-		t.Errorf("failed to setup ref: %v", err)
-		return
+		t.Fatalf("failed to setup ref: %v", err)
 	}
 	rb3, err := ref.New("ocidir://testrepo:b3")
 	if err != nil {
-		t.Errorf("failed to setup ref: %v", err)
-		return
+		t.Fatalf("failed to setup ref: %v", err)
 	}
 	m3, err := rc.ManifestHead(ctx, rb3)
 	if err != nil {
-		t.Errorf("failed to get digest for base3: %v", err)
-		return
+		t.Fatalf("failed to get digest for base3: %v", err)
 	}
 	dig3 := m3.GetDescriptor().Digest
 	r1, err := ref.New("ocidir://testrepo:v1")
 	if err != nil {
-		t.Errorf("failed to setup ref: %v", err)
-		return
+		t.Fatalf("failed to setup ref: %v", err)
 	}
 	r2, err := ref.New("ocidir://testrepo:v2")
 	if err != nil {
-		t.Errorf("failed to setup ref: %v", err)
-		return
+		t.Fatalf("failed to setup ref: %v", err)
 	}
 	r3, err := ref.New("ocidir://testrepo:v3")
 	if err != nil {
-		t.Errorf("failed to setup ref: %v", err)
-		return
+		t.Fatalf("failed to setup ref: %v", err)
 	}
 
 	tt := []struct {
@@ -289,13 +281,11 @@ func TestCopy(t *testing.T) {
 			t.Parallel()
 			rSrc, err := ref.New(tc.src)
 			if err != nil {
-				t.Errorf("failed to parse ref %s: %v", tc.src, err)
-				return
+				t.Fatalf("failed to parse ref %s: %v", tc.src, err)
 			}
 			rTgt, err := ref.New(tc.tgt)
 			if err != nil {
-				t.Errorf("failed to parse ref %s: %v", tc.tgt, err)
-				return
+				t.Fatalf("failed to parse ref %s: %v", tc.tgt, err)
 			}
 			err = rc.ImageCopy(ctx, rSrc, rTgt, tc.opts...)
 			if tc.expectErr != nil {
@@ -307,8 +297,7 @@ func TestCopy(t *testing.T) {
 				return
 			}
 			if err != nil {
-				t.Errorf("copy failed: %v", err)
-				return
+				t.Fatalf("copy failed: %v", err)
 			}
 		})
 	}
@@ -322,8 +311,7 @@ func TestExportImport(t *testing.T) {
 	fsMem := rwfs.MemNew()
 	err := rwfs.CopyRecursive(fsOS, "testdata", fsMem, ".")
 	if err != nil {
-		t.Errorf("failed to setup memfs copy: %v", err)
-		return
+		t.Fatalf("failed to setup memfs copy: %v", err)
 	}
 	// create regclient
 	delayInit, _ := time.ParseDuration("0.05s")
@@ -331,25 +319,25 @@ func TestExportImport(t *testing.T) {
 	rc := New(WithFS(fsMem), WithRetryDelay(delayInit, delayMax))
 	rIn1, err := ref.New("ocidir://testrepo:v1")
 	if err != nil {
-		t.Errorf("failed to parse ref: %v", err)
+		t.Fatalf("failed to parse ref: %v", err)
 	}
 	rOut1, err := ref.New("ocidir://testout:v1")
 	if err != nil {
-		t.Errorf("failed to parse ref: %v", err)
+		t.Fatalf("failed to parse ref: %v", err)
 	}
 	rIn3, err := ref.New("ocidir://testrepo:v3")
 	if err != nil {
-		t.Errorf("failed to parse ref: %v", err)
+		t.Fatalf("failed to parse ref: %v", err)
 	}
 	rOut3, err := ref.New("ocidir://testout:v3")
 	if err != nil {
-		t.Errorf("failed to parse ref: %v", err)
+		t.Fatalf("failed to parse ref: %v", err)
 	}
 
 	// export repo to tar
 	fileOut1, err := fsMem.Create("test1.tar")
 	if err != nil {
-		t.Errorf("failed to create output tar: %v", err)
+		t.Fatalf("failed to create output tar: %v", err)
 	}
 	err = rc.ImageExport(ctx, rIn1, fileOut1)
 	fileOut1.Close()
@@ -358,7 +346,7 @@ func TestExportImport(t *testing.T) {
 	}
 	fileOut3, err := fsMem.Create("test3.tar.gz")
 	if err != nil {
-		t.Errorf("failed to create output tar: %v", err)
+		t.Fatalf("failed to create output tar: %v", err)
 	}
 	err = rc.ImageExport(ctx, rIn3, fileOut3, ImageWithExportCompress())
 	fileOut3.Close()
@@ -369,7 +357,7 @@ func TestExportImport(t *testing.T) {
 	// modify tar for tests
 	fileR, err := fsMem.Open("test1.tar")
 	if err != nil {
-		t.Errorf("failed to open tar: %v", err)
+		t.Fatalf("failed to open tar: %v", err)
 	}
 	fileW, err := fsMem.Create("test2.tar")
 	if err != nil {
@@ -403,7 +391,7 @@ func TestExportImport(t *testing.T) {
 	// import tar to repo
 	fileIn2, err := fsMem.Open("test2.tar")
 	if err != nil {
-		t.Errorf("failed to open tar: %v", err)
+		t.Fatalf("failed to open tar: %v", err)
 	}
 	fileIn2Seeker, ok := fileIn2.(io.ReadSeeker)
 	if !ok {
@@ -416,7 +404,7 @@ func TestExportImport(t *testing.T) {
 
 	fileIn3, err := fsMem.Open("test3.tar.gz")
 	if err != nil {
-		t.Errorf("failed to open tar: %v", err)
+		t.Fatalf("failed to open tar: %v", err)
 	}
 	fileIn3Seeker, ok := fileIn3.(io.ReadSeeker)
 	if !ok {

--- a/internal/conffile/conffile_test.go
+++ b/internal/conffile/conffile_test.go
@@ -90,8 +90,7 @@ func TestNew(t *testing.T) {
 				return
 			}
 			if cf == nil {
-				t.Errorf("result was nil")
-				return
+				t.Fatalf("result was nil")
 			}
 			if cf.Name() != tt.expectName {
 				t.Errorf("fullname mismatch, expected %s, received %s", tt.expectName, cf.Name())
@@ -108,19 +107,16 @@ func TestWriteOpen(t *testing.T) {
 	cf := New(WithFS(memfs), WithFullname("test.json"))
 	err := cf.Write(bytes.NewReader(confContent))
 	if err != nil {
-		t.Errorf("failed to write config file: %v", err)
-		return
+		t.Fatalf("failed to write config file: %v", err)
 	}
 	rc, err := cf.Open()
 	if err != nil {
-		t.Errorf("failed to open config file: %v", err)
-		return
+		t.Fatalf("failed to open config file: %v", err)
 	}
 	defer rc.Close()
 	readBytes, err := io.ReadAll(rc)
 	if err != nil {
-		t.Errorf("failed to read content: %v", err)
-		return
+		t.Fatalf("failed to read content: %v", err)
 	}
 	if !bytes.Equal(readBytes, confContent) {
 		t.Errorf("content mismatch, write: %s, read: %s", string(confContent), string(readBytes))

--- a/internal/httplink/httplink_test.go
+++ b/internal/httplink/httplink_test.go
@@ -118,8 +118,7 @@ func TestParseGet(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			links, err := Parse(tt.headers)
 			if err != nil {
-				t.Errorf("parse failed: %v", err)
-				return
+				t.Fatalf("parse failed: %v", err)
 			}
 			link, err := links.Get(tt.parm, tt.val)
 			if tt.expectMissing {
@@ -129,8 +128,7 @@ func TestParseGet(t *testing.T) {
 				return
 			}
 			if err != nil {
-				t.Errorf("failed to run get: %v", err)
-				return
+				t.Fatalf("failed to run get: %v", err)
 			}
 			if link.URI != tt.expectURI {
 				t.Errorf("URI mismatch: expected %s, received %s", tt.expectURI, link.URI)

--- a/internal/limitread/limitread_test.go
+++ b/internal/limitread/limitread_test.go
@@ -90,8 +90,7 @@ func TestLimitRead(t *testing.T) {
 				return
 			}
 			if err != nil {
-				t.Errorf("read failed: %v", err)
-				return
+				t.Fatalf("read failed: %v", err)
 			}
 			if result != tc.expectLen {
 				t.Errorf("read length mismatch, expected %d, received %d", tc.expectLen, result)

--- a/internal/reghttp/http_test.go
+++ b/internal/reghttp/http_test.go
@@ -769,15 +769,14 @@ func TestRegHttp(t *testing.T) {
 		}
 		resp, err := hc.Do(ctx, getReq)
 		if err != nil {
-			t.Errorf("failed to run get: %v", err)
-			return
+			t.Fatalf("failed to run get: %v", err)
 		}
 		if resp.HTTPResponse().StatusCode != 200 {
 			t.Errorf("invalid status code, expected 200, received %d", resp.HTTPResponse().StatusCode)
 		}
 		body, err := io.ReadAll(resp)
 		if err != nil {
-			t.Errorf("body read failure: %v", err)
+			t.Fatalf("body read failure: %v", err)
 		} else if !bytes.Equal(body, getBody) {
 			t.Errorf("body read mismatch, expected %s, received %s", getBody, body)
 		}
@@ -802,8 +801,7 @@ func TestRegHttp(t *testing.T) {
 		}
 		resp, err := hc.Do(ctx, getReq)
 		if err != nil {
-			t.Errorf("failed to run get: %v", err)
-			return
+			t.Fatalf("failed to run get: %v", err)
 		}
 		if resp.HTTPResponse().StatusCode != 200 {
 			t.Errorf("invalid status code, expected 200, received %d", resp.HTTPResponse().StatusCode)
@@ -811,7 +809,7 @@ func TestRegHttp(t *testing.T) {
 		b := make([]byte, 2)
 		l, err := resp.Read(b)
 		if err != nil {
-			t.Errorf("body read failure: %v", err)
+			t.Fatalf("body read failure: %v", err)
 		}
 		if l != 2 {
 			t.Errorf("unexpected length, expected 2, received %d", l)
@@ -828,7 +826,7 @@ func TestRegHttp(t *testing.T) {
 		}
 		body, err := io.ReadAll(resp)
 		if err != nil {
-			t.Errorf("body read failure: %v", err)
+			t.Fatalf("body read failure: %v", err)
 		} else if !bytes.Equal(body, getBody) {
 			t.Errorf("body read mismatch, expected %s, received %s", getBody, body)
 		}
@@ -854,15 +852,14 @@ func TestRegHttp(t *testing.T) {
 		}
 		resp, err := hc.Do(ctx, getReq)
 		if err != nil {
-			t.Errorf("failed to run get: %v", err)
-			return
+			t.Fatalf("failed to run get: %v", err)
 		}
 		if resp.HTTPResponse().StatusCode != 200 {
 			t.Errorf("invalid status code, expected 200, received %d", resp.HTTPResponse().StatusCode)
 		}
 		body, err := io.ReadAll(resp)
 		if err != nil {
-			t.Errorf("body read failure: %v", err)
+			t.Fatalf("body read failure: %v", err)
 		} else if !bytes.Equal(body, getBody) {
 			t.Errorf("body read mismatch, expected %s, received %s", getBody, body)
 		}
@@ -888,8 +885,7 @@ func TestRegHttp(t *testing.T) {
 		}
 		resp, err := hc.Do(ctx, badDigestReq)
 		if err != nil {
-			t.Errorf("failed to run get: %v", err)
-			return
+			t.Fatalf("failed to run get: %v", err)
 		}
 		if resp.HTTPResponse().StatusCode != 200 {
 			t.Errorf("invalid status code, expected 200, received %d", resp.HTTPResponse().StatusCode)
@@ -922,8 +918,7 @@ func TestRegHttp(t *testing.T) {
 		}
 		resp, err := hc.Do(ctx, getReq)
 		if err != nil {
-			t.Errorf("failed to run get: %v", err)
-			return
+			t.Fatalf("failed to run get: %v", err)
 		}
 		if resp.HTTPResponse().StatusCode != 200 {
 			t.Errorf("invalid status code, expected 200, received %d", resp.HTTPResponse().StatusCode)
@@ -960,9 +955,8 @@ func TestRegHttp(t *testing.T) {
 		}
 		resp, err := hc.Do(expCtx, getReq)
 		if err == nil {
-			t.Errorf("get unexpectedly succeeded")
 			resp.Close()
-			return
+			t.Errorf("get unexpectedly succeeded")
 		}
 	})
 	// test head requests
@@ -983,14 +977,13 @@ func TestRegHttp(t *testing.T) {
 		resp, err := hc.Do(ctx, headReq)
 		if err != nil {
 			t.Errorf("failed to run head: %v", err)
-			return
 		}
 		if resp.HTTPResponse().StatusCode != 200 {
 			t.Errorf("invalid status code, expected 200, received %d", resp.HTTPResponse().StatusCode)
 		}
 		body, err := io.ReadAll(resp)
 		if err != nil {
-			t.Errorf("body read failure: %v", err)
+			t.Fatalf("body read failure: %v", err)
 		} else if len(body) > 0 {
 			t.Errorf("body read mismatch, expected empty body, received %s", body)
 		}
@@ -1016,9 +1009,8 @@ func TestRegHttp(t *testing.T) {
 		}
 		resp, err := hc.Do(ctx, headReq)
 		if err == nil {
-			t.Errorf("unexpected success running head request")
 			resp.Close()
-			return
+			t.Fatalf("unexpected success running head request")
 		}
 	})
 	// test auth
@@ -1038,15 +1030,14 @@ func TestRegHttp(t *testing.T) {
 		}
 		resp, err := hc.Do(ctx, authReq)
 		if err != nil {
-			t.Errorf("failed to run get: %v", err)
-			return
+			t.Fatalf("failed to run get: %v", err)
 		}
 		if resp.HTTPResponse().StatusCode != 200 {
 			t.Errorf("invalid status code, expected 200, received %d", resp.HTTPResponse().StatusCode)
 		}
 		body, err := io.ReadAll(resp)
 		if err != nil {
-			t.Errorf("body read failure: %v", err)
+			t.Fatalf("body read failure: %v", err)
 		} else if !bytes.Equal(body, getBody) {
 			t.Errorf("body read mismatch, expected %s, received %s", getBody, body)
 		}
@@ -1071,9 +1062,8 @@ func TestRegHttp(t *testing.T) {
 		}
 		resp, err := hc.Do(ctx, authReq)
 		if err == nil {
-			t.Errorf("unexpected success with bad password")
 			resp.Close()
-			return
+			t.Fatalf("unexpected success with bad password")
 		} else if !errors.Is(err, auth.ErrUnauthorized) {
 			t.Errorf("expected error %v, received error %v", auth.ErrUnauthorized, err)
 		}
@@ -1094,9 +1084,8 @@ func TestRegHttp(t *testing.T) {
 		}
 		resp, err := hc.Do(ctx, authReq)
 		if err == nil {
-			t.Errorf("unexpected success with bad auth header")
 			resp.Close()
-			return
+			t.Fatalf("unexpected success with bad auth header")
 		} else if !errors.Is(err, types.ErrParsingFailed) {
 			t.Errorf("expected error %v, received error %v", types.ErrParsingFailed, err)
 		}
@@ -1117,9 +1106,8 @@ func TestRegHttp(t *testing.T) {
 		}
 		resp, err := hc.Do(ctx, authReq)
 		if err == nil {
-			t.Errorf("unexpected success with missing auth header")
 			resp.Close()
-			return
+			t.Fatalf("unexpected success with missing auth header")
 		} else if !errors.Is(err, types.ErrEmptyChallenge) {
 			t.Errorf("expected error %v, received error %v", types.ErrEmptyChallenge, err)
 		}
@@ -1141,15 +1129,14 @@ func TestRegHttp(t *testing.T) {
 		}
 		resp, err := hc.Do(ctx, authReq1G)
 		if err != nil {
-			t.Errorf("failed to run get: %v", err)
-			return
+			t.Fatalf("failed to run get: %v", err)
 		}
 		if resp.HTTPResponse().StatusCode != 200 {
 			t.Errorf("invalid status code, expected 200, received %d", resp.HTTPResponse().StatusCode)
 		}
 		body, err := io.ReadAll(resp)
 		if err != nil {
-			t.Errorf("body read failure: %v", err)
+			t.Fatalf("body read failure: %v", err)
 		} else if !bytes.Equal(body, getBody) {
 			t.Errorf("body read mismatch, expected %s, received %s", getBody, body)
 		}
@@ -1174,8 +1161,7 @@ func TestRegHttp(t *testing.T) {
 		}
 		resp, err = hc.Do(ctx, authReq1P)
 		if err != nil {
-			t.Errorf("failed to run put: %v", err)
-			return
+			t.Fatalf("failed to run put: %v", err)
 		}
 		if resp.HTTPResponse().StatusCode != 201 {
 			t.Errorf("invalid status code, expected 201, received %d", resp.HTTPResponse().StatusCode)
@@ -1200,15 +1186,14 @@ func TestRegHttp(t *testing.T) {
 		}
 		resp, err = hc.Do(ctx, authReq2G)
 		if err != nil {
-			t.Errorf("failed to run get: %v", err)
-			return
+			t.Fatalf("failed to run get: %v", err)
 		}
 		if resp.HTTPResponse().StatusCode != 200 {
 			t.Errorf("invalid status code, expected 200, received %d", resp.HTTPResponse().StatusCode)
 		}
 		body, err = io.ReadAll(resp)
 		if err != nil {
-			t.Errorf("body read failure: %v", err)
+			t.Fatalf("body read failure: %v", err)
 		} else if !bytes.Equal(body, getBody) {
 			t.Errorf("body read mismatch, expected %s, received %s", getBody, body)
 		}
@@ -1233,8 +1218,7 @@ func TestRegHttp(t *testing.T) {
 		}
 		resp, err = hc.Do(ctx, authReq2P)
 		if err != nil {
-			t.Errorf("failed to run put: %v", err)
-			return
+			t.Fatalf("failed to run put: %v", err)
 		}
 		if resp.HTTPResponse().StatusCode != 201 {
 			t.Errorf("invalid status code, expected 201, received %d", resp.HTTPResponse().StatusCode)
@@ -1261,15 +1245,14 @@ func TestRegHttp(t *testing.T) {
 		}
 		resp, err := hc.Do(ctx, postReq)
 		if err != nil {
-			t.Errorf("failed to run post: %v", err)
-			return
+			t.Fatalf("failed to run post: %v", err)
 		}
 		if resp.HTTPResponse().StatusCode != http.StatusAccepted {
 			t.Errorf("invalid status code, expected %d, received %d", http.StatusAccepted, resp.HTTPResponse().StatusCode)
 		}
 		body, err := io.ReadAll(resp)
 		if err != nil {
-			t.Errorf("body read failure: %v", err)
+			t.Fatalf("body read failure: %v", err)
 		} else if len(body) > 0 {
 			t.Errorf("body read mismatch, expected empty body, received %s", body)
 		}
@@ -1293,15 +1276,14 @@ func TestRegHttp(t *testing.T) {
 		}
 		resp, err := hc.Do(ctx, putReq)
 		if err != nil {
-			t.Errorf("failed to run put: %v", err)
-			return
+			t.Fatalf("failed to run put: %v", err)
 		}
 		if resp.HTTPResponse().StatusCode != http.StatusCreated {
 			t.Errorf("invalid status code, expected %d, received %d", http.StatusCreated, resp.HTTPResponse().StatusCode)
 		}
 		body, err := io.ReadAll(resp)
 		if err != nil {
-			t.Errorf("body read failure: %v", err)
+			t.Fatalf("body read failure: %v", err)
 		} else if len(body) > 0 {
 			t.Errorf("body read mismatch, expected empty body, received %s", body)
 		}
@@ -1326,15 +1308,14 @@ func TestRegHttp(t *testing.T) {
 		}
 		resp, err := hc.Do(ctx, putReq)
 		if err != nil {
-			t.Errorf("failed to run put: %v", err)
-			return
+			t.Fatalf("failed to run put: %v", err)
 		}
 		if resp.HTTPResponse().StatusCode != http.StatusCreated {
 			t.Errorf("invalid status code, expected %d, received %d", http.StatusCreated, resp.HTTPResponse().StatusCode)
 		}
 		body, err := io.ReadAll(resp)
 		if err != nil {
-			t.Errorf("body read failure: %v", err)
+			t.Fatalf("body read failure: %v", err)
 		} else if len(body) > 0 {
 			t.Errorf("body read mismatch, expected empty body, received %s", body)
 		}
@@ -1358,15 +1339,14 @@ func TestRegHttp(t *testing.T) {
 		}
 		resp, err := hc.Do(ctx, deleteReq)
 		if err != nil {
-			t.Errorf("failed to run delete: %v", err)
-			return
+			t.Fatalf("failed to run delete: %v", err)
 		}
 		if resp.HTTPResponse().StatusCode != http.StatusAccepted {
 			t.Errorf("invalid status code, expected %d, received %d", http.StatusAccepted, resp.HTTPResponse().StatusCode)
 		}
 		body, err := io.ReadAll(resp)
 		if err != nil {
-			t.Errorf("body read failure: %v", err)
+			t.Fatalf("body read failure: %v", err)
 		} else if len(body) > 0 {
 			t.Errorf("body read mismatch, expected empty body, received %s", body)
 		}
@@ -1393,15 +1373,14 @@ func TestRegHttp(t *testing.T) {
 		}
 		resp, err := hc.Do(ctx, getReq)
 		if err != nil {
-			t.Errorf("failed to run get: %v", err)
-			return
+			t.Fatalf("failed to run get: %v", err)
 		}
 		if resp.HTTPResponse().StatusCode != 200 {
 			t.Errorf("invalid status code, expected 200, received %d", resp.HTTPResponse().StatusCode)
 		}
 		body, err := io.ReadAll(resp)
 		if err != nil {
-			t.Errorf("body read failure: %v", err)
+			t.Fatalf("body read failure: %v", err)
 		} else if !bytes.Equal(body, getBody) {
 			t.Errorf("body read mismatch, expected %s, received %s", getBody, body)
 		}
@@ -1427,9 +1406,8 @@ func TestRegHttp(t *testing.T) {
 		}
 		resp, err := hc.Do(ctx, getReq)
 		if err == nil {
-			t.Errorf("unexpected success on get for missing manifest")
 			resp.Close()
-			return
+			t.Fatalf("unexpected success on get for missing manifest")
 		} else if !errors.Is(err, types.ErrNotFound) {
 			t.Errorf("unexpected error, expected %v, received %v", types.ErrNotFound, err)
 		}
@@ -1450,9 +1428,8 @@ func TestRegHttp(t *testing.T) {
 		}
 		resp, err := hc.Do(ctx, getReq)
 		if err == nil {
-			t.Errorf("unexpected success on get for missing manifest")
 			resp.Close()
-			return
+			t.Fatalf("unexpected success on get for missing manifest")
 		} else if !errors.Is(err, types.ErrHTTPUnauthorized) {
 			t.Errorf("unexpected error, expected %v, received %v", types.ErrHTTPUnauthorized, err)
 		}
@@ -1473,9 +1450,8 @@ func TestRegHttp(t *testing.T) {
 		}
 		resp, err := hc.Do(ctx, getReq)
 		if err == nil {
-			t.Errorf("unexpected success on get for missing manifest")
 			resp.Close()
-			return
+			t.Fatalf("unexpected success on get for missing manifest")
 		} else if !errors.Is(err, types.ErrHTTPStatus) {
 			t.Errorf("unexpected error, expected %v, received %v", types.ErrHTTPStatus, err)
 		}
@@ -1496,9 +1472,8 @@ func TestRegHttp(t *testing.T) {
 		}
 		resp, err := hc.Do(ctx, getReq)
 		if err == nil {
-			t.Errorf("unexpected success on get for missing manifest")
 			resp.Close()
-			return
+			t.Fatalf("unexpected success on get for missing manifest")
 		} else if !errors.Is(err, types.ErrHTTPStatus) {
 			t.Errorf("unexpected error, expected %v, received %v", types.ErrHTTPStatus, err)
 		}
@@ -1519,9 +1494,8 @@ func TestRegHttp(t *testing.T) {
 		}
 		resp, err := hc.Do(ctx, getReq)
 		if err == nil {
-			t.Errorf("unexpected success on get for missing manifest")
 			resp.Close()
-			return
+			t.Fatalf("unexpected success on get for missing manifest")
 		} else if !errors.Is(err, types.ErrHTTPStatus) {
 			t.Errorf("unexpected error, expected %v, received %v", types.ErrHTTPStatus, err)
 		}
@@ -1545,9 +1519,8 @@ func TestRegHttp(t *testing.T) {
 		}
 		resp, err := hc.Do(ctxTimeout, getReq)
 		if err == nil {
-			t.Errorf("unexpected success on get for missing manifest")
 			resp.Close()
-			return
+			t.Fatalf("unexpected success on get for missing manifest")
 		} else if !errors.Is(err, context.DeadlineExceeded) {
 			t.Errorf("unexpected error, expected %v, received %v", context.DeadlineExceeded, err)
 		}
@@ -1568,8 +1541,7 @@ func TestRegHttp(t *testing.T) {
 		}
 		resp, err := hc.Do(ctx, shortReq)
 		if err != nil {
-			t.Errorf("failed to run get: %v", err)
-			return
+			t.Fatalf("failed to run get: %v", err)
 		}
 		if resp.HTTPResponse().StatusCode != 200 {
 			t.Errorf("invalid status code, expected 200, received %d", resp.HTTPResponse().StatusCode)
@@ -1601,15 +1573,14 @@ func TestRegHttp(t *testing.T) {
 		}
 		resp, err := hc.Do(ctx, retryReq)
 		if err != nil {
-			t.Errorf("failed to run get: %v", err)
-			return
+			t.Fatalf("failed to run get: %v", err)
 		}
 		if resp.HTTPResponse().StatusCode != 200 {
 			t.Errorf("invalid status code, expected 200, received %d", resp.HTTPResponse().StatusCode)
 		}
 		body, err := io.ReadAll(resp)
 		if err != nil {
-			t.Errorf("body read failure: %v", err)
+			t.Fatalf("body read failure: %v", err)
 		} else if !bytes.Equal(body, retryBody) {
 			t.Errorf("body read mismatch, expected %s, received %s", retryBody, body)
 		}
@@ -1636,8 +1607,7 @@ func TestRegHttp(t *testing.T) {
 		wCtx := warning.NewContext(ctx, w)
 		resp, err := hc.Do(wCtx, getReq)
 		if err != nil {
-			t.Errorf("failed to run get: %v", err)
-			return
+			t.Fatalf("failed to run get: %v", err)
 		}
 		if len(w.List) != 2 {
 			t.Errorf("warning count, expected 2, received %d", len(w.List))
@@ -1670,15 +1640,14 @@ func TestRegHttp(t *testing.T) {
 		}
 		resp, err := hc.Do(ctx, getReq)
 		if err != nil {
-			t.Errorf("failed to run get: %v", err)
-			return
+			t.Fatalf("failed to run get: %v", err)
 		}
 		if resp.HTTPResponse().StatusCode != 200 {
 			t.Errorf("invalid status code, expected 200, received %d", resp.HTTPResponse().StatusCode)
 		}
 		body, err := io.ReadAll(resp)
 		if err != nil {
-			t.Errorf("body read failure: %v", err)
+			t.Fatalf("body read failure: %v", err)
 		} else if !bytes.Equal(body, getBody) {
 			t.Errorf("body read mismatch, expected %s, received %s", getBody, body)
 		}

--- a/internal/rwfs/mem_test.go
+++ b/internal/rwfs/mem_test.go
@@ -6,8 +6,7 @@ func TestMem(t *testing.T) {
 	t.Parallel()
 	fs := MemNew()
 	if fs == nil {
-		t.Errorf("MemNew returned nil")
-		return
+		t.Fatalf("MemNew returned nil")
 	}
 	testRWFS(t, fs)
 }

--- a/internal/rwfs/os_test.go
+++ b/internal/rwfs/os_test.go
@@ -10,20 +10,19 @@ func TestOS(t *testing.T) {
 	t.Logf("tempdir: %s", tempDir)
 	fs := OSNew(tempDir)
 	if fs == nil {
-		t.Errorf("OSNew returned nil")
-		return
+		t.Fatalf("OSNew returned nil")
 	}
 	testRWFS(t, fs)
 
 	fsOS := OSNew("")
 	f, err := fsOS.Open("..")
 	if err != nil {
-		t.Errorf("failed opening relative dir: %v", err)
+		t.Fatalf("failed opening relative dir: %v", err)
 	} else {
 		defer f.Close()
 		fi, err := f.Stat()
 		if err != nil {
-			t.Errorf("failed stat on relative dir: %v", err)
+			t.Fatalf("failed stat on relative dir: %v", err)
 		}
 		if !fi.IsDir() {
 			t.Errorf("relative dir is not a directory")
@@ -34,6 +33,6 @@ func TestOS(t *testing.T) {
 	f, err = fsCur.Open("..")
 	if err == nil {
 		t.Errorf("opened relative dir")
-		defer f.Close()
+		f.Close()
 	}
 }

--- a/internal/rwfs/rwfs_test.go
+++ b/internal/rwfs/rwfs_test.go
@@ -36,19 +36,18 @@ func testRWFS(t *testing.T, rwfs RWFS) {
 	t.Run("curdir", func(t *testing.T) {
 		fh, err := rwfs.Open(".")
 		if err != nil {
-			t.Errorf("open: %v", err)
-			return
+			t.Fatalf("open: %v", err)
 		}
 		fi, err := fh.Stat()
 		if err != nil {
-			t.Errorf("stat: %v", err)
+			t.Fatalf("stat: %v", err)
 		}
 		if !fi.IsDir() {
 			t.Errorf("is not a directory")
 		}
 		b, err := io.ReadAll(fh)
 		if err == nil {
-			t.Errorf("readall on directory succeeded")
+			t.Fatalf("readall on directory succeeded")
 		}
 		err = fh.Close()
 		if err != nil {
@@ -84,8 +83,7 @@ func testRWFS(t *testing.T, rwfs RWFS) {
 		// create a file in the root dir
 		fh, err := rwfs.Create(exRootFile)
 		if err != nil {
-			t.Errorf("create %s: %v", exRootFile, err)
-			return
+			t.Fatalf("create %s: %v", exRootFile, err)
 		}
 		i, err := fh.Write(exRootTxt)
 		if err != nil {
@@ -102,8 +100,7 @@ func testRWFS(t *testing.T, rwfs RWFS) {
 		// create a file one level down
 		fh, err = rwfs.Create(exSubFile1)
 		if err != nil {
-			t.Errorf("create %s: %v", exSubFile1, err)
-			return
+			t.Fatalf("create %s: %v", exSubFile1, err)
 		}
 		i, err = fh.Write(exSubTxt1)
 		if err != nil {
@@ -120,8 +117,7 @@ func testRWFS(t *testing.T, rwfs RWFS) {
 		// create a file more than one level down
 		fh, err = rwfs.Create(exNestedFile)
 		if err != nil {
-			t.Errorf("create %s: %v", exNestedFile, err)
-			return
+			t.Fatalf("create %s: %v", exNestedFile, err)
 		}
 		i, err = fh.Write(exNestedTxt1)
 		if err != nil {
@@ -150,8 +146,7 @@ func testRWFS(t *testing.T, rwfs RWFS) {
 		// recreate a file that exists
 		fh, err = rwfs.Create(exNestedFile)
 		if err != nil {
-			t.Errorf("create again %s: %v", exNestedFile, err)
-			return
+			t.Fatalf("create again %s: %v", exNestedFile, err)
 		}
 		i, err = fh.Write(exNestedTxt2)
 		if err != nil {
@@ -177,13 +172,11 @@ func testRWFS(t *testing.T, rwfs RWFS) {
 		// open, read, and cmp contents
 		fh, err := rwfs.Open(exRootFile)
 		if err != nil {
-			t.Errorf("open %s: %v", exRootFile, err)
-			return
+			t.Fatalf("open %s: %v", exRootFile, err)
 		}
 		b, err := io.ReadAll(fh)
 		if err != nil {
-			t.Errorf("readall %s: %v", exRootFile, err)
-			return
+			t.Fatalf("readall %s: %v", exRootFile, err)
 		}
 		if !bytes.Equal(exRootTxt, b) {
 			t.Errorf("contents mismatch %s, expected %s, received %s", exRootFile, string(exRootTxt), string(b))
@@ -196,8 +189,7 @@ func testRWFS(t *testing.T, rwfs RWFS) {
 		// verify ReadFile works
 		b, err = ReadFile(rwfs, exNestedFile)
 		if err != nil {
-			t.Errorf("readfile %s: %v", exNestedFile, err)
-			return
+			t.Fatalf("readfile %s: %v", exNestedFile, err)
 		}
 		if !bytes.Equal(exNestedTxt2, b) {
 			t.Errorf("contents mismatch %s, expected %s, received %s", exNestedFile, string(exNestedTxt2), string(b))
@@ -206,13 +198,11 @@ func testRWFS(t *testing.T, rwfs RWFS) {
 		// verify open with a subdir
 		fh, err = rwfs.Open(exSubFile1)
 		if err != nil {
-			t.Errorf("open %s: %v", exSubFile1, err)
-			return
+			t.Fatalf("open %s: %v", exSubFile1, err)
 		}
 		b, err = io.ReadAll(fh)
 		if err != nil {
-			t.Errorf("readall %s: %v", exSubFile1, err)
-			return
+			t.Fatalf("readall %s: %v", exSubFile1, err)
 		}
 		if !bytes.Equal(exSubTxt1, b) {
 			t.Errorf("contents mismatch %s, expected %s, received %s", exSubFile1, string(exSubTxt1), string(b))
@@ -273,11 +263,11 @@ func testRWFS(t *testing.T, rwfs RWFS) {
 		// read file
 		fh, err = rwfs.OpenFile(exSubFile2, O_RDONLY, 0666)
 		if err != nil {
-			t.Errorf("read-only %s: %v", exSubFile2, err)
+			t.Fatalf("read-only %s: %v", exSubFile2, err)
 		}
 		b, err := io.ReadAll(fh)
 		if err != nil {
-			t.Errorf("readall %s: %v", exSubFile2, err)
+			t.Fatalf("readall %s: %v", exSubFile2, err)
 		}
 		if !bytes.Equal(b, exSubTxt2) {
 			t.Errorf("readall %s: expected %s, received %s", exSubFile2, string(exSubTxt2), string(b))
@@ -287,11 +277,11 @@ func testRWFS(t *testing.T, rwfs RWFS) {
 		// read-write file, read first
 		fh, err = rwfs.OpenFile(exSubFile2, O_RDWR, 0666)
 		if err != nil {
-			t.Errorf("read-write %s: %v", exSubFile2, err)
+			t.Fatalf("read-write %s: %v", exSubFile2, err)
 		}
 		b, err = io.ReadAll(fh)
 		if err != nil {
-			t.Errorf("readall %s: %v", exSubFile2, err)
+			t.Fatalf("readall %s: %v", exSubFile2, err)
 		}
 		if !bytes.Equal(b, exSubTxt2) {
 			t.Errorf("contents after append, expect %s, received %s", string(exSubTxt2), string(b))
@@ -303,7 +293,7 @@ func testRWFS(t *testing.T, rwfs RWFS) {
 		fh.Close()
 		b, err = fs.ReadFile(rwfs, exSubFile2)
 		if err != nil {
-			t.Errorf("readfile %s: %v", exSubFile2, err)
+			t.Fatalf("readfile %s: %v", exSubFile2, err)
 		}
 		exB := append(exSubTxt2, []byte("append string")...)
 		if !bytes.Equal(b, exB) {
@@ -313,7 +303,7 @@ func testRWFS(t *testing.T, rwfs RWFS) {
 		// read-write file, w/o reading
 		fh, err = rwfs.OpenFile(exSubFile2, O_RDWR, 0666)
 		if err != nil {
-			t.Errorf("read-write %s: %v", exSubFile2, err)
+			t.Fatalf("read-write %s: %v", exSubFile2, err)
 		}
 		_, err = fh.Write([]byte("replace string"))
 		if err != nil {
@@ -322,7 +312,7 @@ func testRWFS(t *testing.T, rwfs RWFS) {
 		fh.Close()
 		b, err = fs.ReadFile(rwfs, exSubFile2)
 		if err != nil {
-			t.Errorf("readfile %s: %v", exSubFile2, err)
+			t.Fatalf("readfile %s: %v", exSubFile2, err)
 		}
 		copy(exB, []byte("replace string"))
 		if !bytes.Equal(b, exB) {
@@ -332,7 +322,7 @@ func testRWFS(t *testing.T, rwfs RWFS) {
 		// read-write file+append
 		fh, err = rwfs.OpenFile(exSubFile2, O_RDWR|O_APPEND, 0666)
 		if err != nil {
-			t.Errorf("read-write %s: %v", exSubFile2, err)
+			t.Fatalf("read-write %s: %v", exSubFile2, err)
 		}
 		_, err = fh.Write([]byte("append again string"))
 		if err != nil {
@@ -341,7 +331,7 @@ func testRWFS(t *testing.T, rwfs RWFS) {
 		fh.Close()
 		b, err = fs.ReadFile(rwfs, exSubFile2)
 		if err != nil {
-			t.Errorf("readfile %s: %v", exSubFile2, err)
+			t.Fatalf("readfile %s: %v", exSubFile2, err)
 		}
 		exB = append(exB, []byte("append again string")...)
 		if !bytes.Equal(b, exB) {
@@ -351,7 +341,7 @@ func testRWFS(t *testing.T, rwfs RWFS) {
 		// read-write file+truncate
 		fh, err = rwfs.OpenFile(exSubFile2, O_RDWR|O_TRUNC, 0666)
 		if err != nil {
-			t.Errorf("read-write %s: %v", exSubFile2, err)
+			t.Fatalf("read-write %s: %v", exSubFile2, err)
 		}
 		_, err = fh.Write([]byte(exSubTxt2))
 		if err != nil {
@@ -360,7 +350,7 @@ func testRWFS(t *testing.T, rwfs RWFS) {
 		fh.Close()
 		b, err = fs.ReadFile(rwfs, exSubFile2)
 		if err != nil {
-			t.Errorf("readfile %s: %v", exSubFile2, err)
+			t.Fatalf("readfile %s: %v", exSubFile2, err)
 		}
 		if !bytes.Equal(b, exSubTxt2) {
 			t.Errorf("contents after truncate, expect %s, received %s", string(exSubTxt2), string(b))
@@ -376,7 +366,7 @@ func testRWFS(t *testing.T, rwfs RWFS) {
 		// write existing file with create
 		fh, err = rwfs.OpenFile(exSubFile2, O_WRONLY|O_CREATE, 0666)
 		if err != nil {
-			t.Errorf("write %s: %v", exSubFile2, err)
+			t.Fatalf("write %s: %v", exSubFile2, err)
 		}
 		_, err = fh.Write([]byte("replace"))
 		if err != nil {
@@ -385,7 +375,7 @@ func testRWFS(t *testing.T, rwfs RWFS) {
 		fh.Close()
 		b, err = fs.ReadFile(rwfs, exSubFile2)
 		if err != nil {
-			t.Errorf("readfile %s: %v", exSubFile2, err)
+			t.Fatalf("readfile %s: %v", exSubFile2, err)
 		}
 		exB = append([]byte{}, exSubTxt2...)
 		copy(exB, []byte("replace"))
@@ -396,7 +386,7 @@ func testRWFS(t *testing.T, rwfs RWFS) {
 		// write existing file with create+append
 		fh, err = rwfs.OpenFile(exSubFile2, O_WRONLY|O_CREATE|O_APPEND, 0666)
 		if err != nil {
-			t.Errorf("write %s: %v", exSubFile2, err)
+			t.Fatalf("write %s: %v", exSubFile2, err)
 		}
 		_, err = fh.Write([]byte("append string"))
 		if err != nil {
@@ -405,7 +395,7 @@ func testRWFS(t *testing.T, rwfs RWFS) {
 		fh.Close()
 		b, err = fs.ReadFile(rwfs, exSubFile2)
 		if err != nil {
-			t.Errorf("readfile %s: %v", exSubFile2, err)
+			t.Fatalf("readfile %s: %v", exSubFile2, err)
 		}
 		exB = append(exB, []byte("append string")...)
 		if !bytes.Equal(b, exB) {
@@ -415,7 +405,7 @@ func testRWFS(t *testing.T, rwfs RWFS) {
 		// write existing file with create+truncate
 		fh, err = rwfs.OpenFile(exSubFile2, O_WRONLY|O_CREATE|O_TRUNC, 0666)
 		if err != nil {
-			t.Errorf("write %s: %v", exSubFile2, err)
+			t.Fatalf("write %s: %v", exSubFile2, err)
 		}
 		_, err = fh.Write([]byte(exSubTxt2))
 		if err != nil {
@@ -424,7 +414,7 @@ func testRWFS(t *testing.T, rwfs RWFS) {
 		fh.Close()
 		b, err = fs.ReadFile(rwfs, exSubFile2)
 		if err != nil {
-			t.Errorf("readfile %s: %v", exSubFile2, err)
+			t.Fatalf("readfile %s: %v", exSubFile2, err)
 		}
 		if !bytes.Equal(b, exSubTxt2) {
 			t.Errorf("contents after truncate, expect %s, received %s", string(exSubTxt2), string(b))
@@ -439,7 +429,7 @@ func testRWFS(t *testing.T, rwfs RWFS) {
 		// write new file create+exclusive
 		fh, err = rwfs.OpenFile(exSubFile3, O_WRONLY|O_CREATE|O_EXCL, 0666)
 		if err != nil {
-			t.Errorf("write new file with create failed: %v", err)
+			t.Fatalf("write new file with create failed: %v", err)
 		}
 		_, err = fh.Write(exSubTxt3)
 		if err != nil {
@@ -453,8 +443,7 @@ func testRWFS(t *testing.T, rwfs RWFS) {
 	t.Run("readdir", func(t *testing.T) {
 		dl, err := fs.ReadDir(rwfs, ".")
 		if err != nil {
-			t.Errorf("readdir %s: %v", ".", err)
-			return
+			t.Fatalf("readdir %s: %v", ".", err)
 		}
 		if len(dl) != 3 {
 			t.Errorf("too many entries in %s, expected %d, received %d", ".", 3, len(dl))
@@ -503,8 +492,7 @@ func testRWFS(t *testing.T, rwfs RWFS) {
 
 		dl, err = fs.ReadDir(rwfs, exNestedDir)
 		if err != nil {
-			t.Errorf("readdir %s: %v", exNestedDir, err)
-			return
+			t.Fatalf("readdir %s: %v", exNestedDir, err)
 		}
 		if len(dl) != 2 {
 			t.Errorf("too many entries in %s, expected %d, received %d", exNestedDir, 2, len(dl))
@@ -549,7 +537,7 @@ func testRWFS(t *testing.T, rwfs RWFS) {
 		}
 		fi, err := Stat(rwfs, "copy/dir/file")
 		if err != nil {
-			t.Errorf("file not copied: %v", err)
+			t.Fatalf("file not copied: %v", err)
 		}
 		if fi.IsDir() {
 			t.Errorf("file appears to be a directory")
@@ -561,7 +549,7 @@ func testRWFS(t *testing.T, rwfs RWFS) {
 		}
 		fi, err = Stat(rwfs, exNestedFile)
 		if err != nil {
-			t.Errorf("file not copied: %v", err)
+			t.Fatalf("file not copied: %v", err)
 		}
 		if fi.IsDir() {
 			t.Errorf("file appears to be a directory")
@@ -579,7 +567,7 @@ func testRWFS(t *testing.T, rwfs RWFS) {
 		}
 		fi, err := Stat(rwfs, "renamed")
 		if err != nil {
-			t.Errorf("renamed folder not found: %v", err)
+			t.Fatalf("renamed folder not found: %v", err)
 		}
 		if !fi.IsDir() {
 			t.Errorf("renamed folder is not a directory")
@@ -590,7 +578,7 @@ func testRWFS(t *testing.T, rwfs RWFS) {
 		}
 		fi, err = Stat(rwfs, "nested")
 		if err != nil {
-			t.Errorf("nested not recreated after rename: %v", err)
+			t.Fatalf("nested not recreated after rename: %v", err)
 		}
 		if !fi.IsDir() {
 			t.Errorf("nested is not a directory after rename")
@@ -604,8 +592,7 @@ func testRWFS(t *testing.T, rwfs RWFS) {
 	t.Run("StatFile", func(t *testing.T) {
 		fi, err := Stat(rwfs, exNestedFile)
 		if err != nil {
-			t.Errorf("failed to stat file: %v", err)
-			return
+			t.Fatalf("failed to stat file: %v", err)
 		}
 		if fi.IsDir() {
 			t.Errorf("file stat indicates it is a directory")
@@ -614,8 +601,7 @@ func testRWFS(t *testing.T, rwfs RWFS) {
 	t.Run("StatDir", func(t *testing.T) {
 		fi, err := Stat(rwfs, exNestedDir)
 		if err != nil {
-			t.Errorf("failed to stat directory: %v", err)
-			return
+			t.Fatalf("failed to stat directory: %v", err)
 		}
 		if !fi.IsDir() {
 			t.Errorf("directory stat indicates it is not a directory")
@@ -653,17 +639,16 @@ func testRWFS(t *testing.T, rwfs RWFS) {
 	t.Run("CreateTemp", func(t *testing.T) {
 		err := MkdirAll(rwfs, "tempdir", 0700)
 		if err != nil {
-			t.Errorf("failed creating tempdir: %v", err)
+			t.Fatalf("failed creating tempdir: %v", err)
 		}
 		fh, err := CreateTemp(rwfs, "tempdir", "tempfile")
 		if err != nil {
-			t.Errorf("failed creating temp file: %v", err)
-			return
+			t.Fatalf("failed creating temp file: %v", err)
 		}
 		defer fh.Close()
 		fhStat, err := fh.Stat()
 		if err != nil {
-			t.Errorf("stat failed: %v", err)
+			t.Fatalf("stat failed: %v", err)
 		}
 		tmpName := filepath.Join("tempdir", fhStat.Name())
 		defer rwfs.Remove(tmpName)

--- a/internal/strparse/strparse_test.go
+++ b/internal/strparse/strparse_test.go
@@ -89,8 +89,7 @@ func TestSplitCSKV(t *testing.T) {
 				}
 				return
 			} else if err != nil {
-				t.Errorf("unexpected error, received %v", err)
-				return
+				t.Fatalf("unexpected error, received %v", err)
 			}
 			for k, v := range tc.result {
 				if result[k] != v {

--- a/internal/throttle/throttle_test.go
+++ b/internal/throttle/throttle_test.go
@@ -39,8 +39,7 @@ func TestSingleThrottle(t *testing.T) {
 	// simple acquire
 	err := t1.Acquire(ctx)
 	if err != nil {
-		t.Errorf("failed to acquire: %v", err)
-		return
+		t.Fatalf("failed to acquire: %v", err)
 	}
 	// try to acquire in a goroutine
 	acquired := false

--- a/internal/timejson/timejson_test.go
+++ b/internal/timejson/timejson_test.go
@@ -31,8 +31,7 @@ func TestMarshal(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			b, err := tt.d.MarshalJSON()
 			if err != nil {
-				t.Errorf("failed marshaling: %v", err)
-				return
+				t.Fatalf("failed marshaling: %v", err)
 			}
 			if !bytes.Equal(b, []byte(tt.expect)) {
 				t.Errorf("mismatch, expected %s, received %s", tt.expect, string(b))
@@ -97,8 +96,7 @@ func TestUnmarshal(t *testing.T) {
 				return
 			}
 			if err != nil {
-				t.Errorf("failed unmarshaling: %v", err)
-				return
+				t.Fatalf("failed unmarshaling: %v", err)
 			}
 			if d != tt.expect {
 				t.Errorf("duration mismatch, expected %s, received %s", time.Duration(tt.expect).String(), time.Duration(d).String())

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -10,8 +10,7 @@ func TestVersion(t *testing.T) {
 	i := GetInfo()
 	ij, err := json.MarshalIndent(i, "", "  ")
 	if err != nil {
-		t.Errorf("failed to marshal info: %v", err)
-		return
+		t.Fatalf("failed to marshal info: %v", err)
 	}
 	t.Logf("received info:\n%s", string(ij))
 }

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -217,12 +217,11 @@ func TestManifest(t *testing.T) {
 	t.Run("Get", func(t *testing.T) {
 		getRef, err := ref.New(tsURL.Host + repoPath + ":" + getTag)
 		if err != nil {
-			t.Errorf("Failed creating getRef: %v", err)
+			t.Fatalf("Failed creating getRef: %v", err)
 		}
 		mGet, err := rc.ManifestGet(ctx, getRef)
 		if err != nil {
-			t.Errorf("Failed running ManifestGet: %v", err)
-			return
+			t.Fatalf("Failed running ManifestGet: %v", err)
 		}
 		if manifest.GetMediaType(mGet) != types.MediaTypeDocker2Manifest {
 			t.Errorf("Unexpected media type: %s", manifest.GetMediaType(mGet))
@@ -234,12 +233,11 @@ func TestManifest(t *testing.T) {
 	t.Run("Head", func(t *testing.T) {
 		headRef, err := ref.New(tsURL.Host + repoPath + ":" + headTag)
 		if err != nil {
-			t.Errorf("Failed creating getRef: %v", err)
+			t.Fatalf("Failed creating getRef: %v", err)
 		}
 		mHead, err := rc.ManifestHead(ctx, headRef)
 		if err != nil {
-			t.Errorf("Failed running ManifestHead: %v", err)
-			return
+			t.Fatalf("Failed running ManifestHead: %v", err)
 		}
 		if manifest.GetMediaType(mHead) != types.MediaTypeDocker2Manifest {
 			t.Errorf("Unexpected media type: %s", manifest.GetMediaType(mHead))
@@ -251,12 +249,11 @@ func TestManifest(t *testing.T) {
 	t.Run("Head no digest", func(t *testing.T) {
 		headRef, err := ref.New(tsURL.Host + repoPath + ":" + nodigestTag)
 		if err != nil {
-			t.Errorf("Failed creating getRef: %v", err)
+			t.Fatalf("Failed creating getRef: %v", err)
 		}
 		mHead, err := rc.ManifestHead(ctx, headRef, WithManifestRequireDigest())
 		if err != nil {
-			t.Errorf("Failed running ManifestHead: %v", err)
-			return
+			t.Fatalf("Failed running ManifestHead: %v", err)
 		}
 		if manifest.GetMediaType(mHead) != types.MediaTypeDocker2Manifest {
 			t.Errorf("Unexpected media type: %s", manifest.GetMediaType(mHead))
@@ -268,7 +265,7 @@ func TestManifest(t *testing.T) {
 	t.Run("Head No Head", func(t *testing.T) {
 		noheadRef, err := ref.New("nohead." + tsURL.Host + repoPath + ":" + noheadTag)
 		if err != nil {
-			t.Errorf("Failed creating getRef: %v", err)
+			t.Fatalf("Failed creating getRef: %v", err)
 		}
 		mNohead, err := rc.ManifestHead(ctx, noheadRef)
 		if err == nil {
@@ -280,12 +277,11 @@ func TestManifest(t *testing.T) {
 	t.Run("Get No Head", func(t *testing.T) {
 		noheadRef, err := ref.New("nohead." + tsURL.Host + repoPath + ":" + noheadTag)
 		if err != nil {
-			t.Errorf("Failed creating getRef: %v", err)
+			t.Fatalf("Failed creating getRef: %v", err)
 		}
 		mNohead, err := rc.ManifestGet(ctx, noheadRef)
 		if err != nil {
-			t.Errorf("Failed running ManifestGet: %v", err)
-			return
+			t.Fatalf("Failed running ManifestGet: %v", err)
 		}
 		if manifest.GetMediaType(mNohead) != types.MediaTypeDocker2Manifest {
 			t.Errorf("Unexpected media type: %s", manifest.GetMediaType(mNohead))
@@ -297,7 +293,7 @@ func TestManifest(t *testing.T) {
 	t.Run("Missing", func(t *testing.T) {
 		missingRef, err := ref.New("missing." + tsURL.Host + repoPath + ":" + missingTag)
 		if err != nil {
-			t.Errorf("Failed creating missingRef: %v", err)
+			t.Fatalf("Failed creating missingRef: %v", err)
 		}
 		mMissing, err := rc.ManifestGet(ctx, missingRef)
 		if err == nil {
@@ -318,11 +314,11 @@ func TestManifest(t *testing.T) {
 		}
 		mGet, err := rc.ManifestGet(ctx, dataRef, WithManifestDesc(d))
 		if err != nil {
-			t.Errorf("failed running ManifestGet: %v", err)
+			t.Fatalf("failed running ManifestGet: %v", err)
 		}
 		mBodyOut, err := mGet.RawBody()
 		if err != nil {
-			t.Errorf("failed running RawBody: %v", err)
+			t.Fatalf("failed running RawBody: %v", err)
 		}
 		if !bytes.Equal(mBody, mBodyOut) {
 			t.Errorf("manifest body mismatch: expected %s, received %s", string(mBody), string(mBodyOut))
@@ -331,7 +327,7 @@ func TestManifest(t *testing.T) {
 	t.Run("Data fallback", func(t *testing.T) {
 		getRef, err := ref.New(tsURL.Host + repoPath + ":" + getTag)
 		if err != nil {
-			t.Errorf("Failed creating getRef: %v", err)
+			t.Fatalf("Failed creating getRef: %v", err)
 		}
 		d := types.Descriptor{
 			MediaType: types.MediaTypeDocker2Manifest,
@@ -348,7 +344,7 @@ func TestManifest(t *testing.T) {
 	t.Run("Bad Data and Found Digest", func(t *testing.T) {
 		missingRef, err := ref.New("missing." + tsURL.Host + repoPath + ":" + missingTag)
 		if err != nil {
-			t.Errorf("Failed creating missingRef: %v", err)
+			t.Fatalf("Failed creating missingRef: %v", err)
 		}
 		d := types.Descriptor{
 			MediaType: types.MediaTypeDocker2Manifest,
@@ -365,7 +361,7 @@ func TestManifest(t *testing.T) {
 	t.Run("Bad Data and Missing Digest", func(t *testing.T) {
 		missingRef, err := ref.New("missing." + tsURL.Host + repoPath + ":" + missingTag)
 		if err != nil {
-			t.Errorf("Failed creating missingRef: %v", err)
+			t.Fatalf("Failed creating missingRef: %v", err)
 		}
 		d := types.Descriptor{
 			MediaType: types.MediaTypeDocker2Manifest,
@@ -382,7 +378,7 @@ func TestManifest(t *testing.T) {
 	t.Run("Invalid ref", func(t *testing.T) {
 		r, err := ref.NewHost("registry.example.org")
 		if err != nil {
-			t.Errorf("Failed creating ref: %v", err)
+			t.Fatalf("Failed creating ref: %v", err)
 		}
 		_, err = rc.ManifestGet(ctx, r)
 		if !errors.Is(err, types.ErrInvalidReference) {

--- a/mod/mod_test.go
+++ b/mod/mod_test.go
@@ -32,21 +32,20 @@ func TestMod(t *testing.T) {
 	fsMem := rwfs.MemNew()
 	err := rwfs.CopyRecursive(fsOS, "../testdata", fsMem, ".")
 	if err != nil {
-		t.Errorf("failed to setup memfs copy: %v", err)
-		return
+		t.Fatalf("failed to setup memfs copy: %v", err)
 	}
 	baseTime, err := time.Parse(time.RFC3339, "2020-01-01T00:00:00Z")
 	if err != nil {
-		t.Errorf("failed to parse test time: %v", err)
+		t.Fatalf("failed to parse test time: %v", err)
 	}
 	oldTime, err := time.Parse(time.RFC3339, "1999-01-01T00:00:00Z")
 	if err != nil {
-		t.Errorf("failed to parse test time: %v", err)
+		t.Fatalf("failed to parse test time: %v", err)
 	}
 	bDig := digest.FromString("digest for base image")
 	bRef, err := ref.New("base:latest")
 	if err != nil {
-		t.Errorf("failed to parse base image: %v", err)
+		t.Fatalf("failed to parse base image: %v", err)
 	}
 	bTrue := true
 	regSrc := olareg.New(oConfig.Config{
@@ -101,55 +100,55 @@ func TestMod(t *testing.T) {
 
 	rTgt1, err := ref.New(tTgtHost + "/tgtrepo1:v1")
 	if err != nil {
-		t.Errorf("failed to parse ref: %v", err)
+		t.Fatalf("failed to parse ref: %v", err)
 	}
 	rTgt2, err := ref.New(tTgtHost + "/tgtrepo2:v2")
 	if err != nil {
-		t.Errorf("failed to parse ref: %v", err)
+		t.Fatalf("failed to parse ref: %v", err)
 	}
 	rTgt3, err := ref.New(tTgtHost + "/tgtrepo3:v3")
 	if err != nil {
-		t.Errorf("failed to parse ref: %v", err)
+		t.Fatalf("failed to parse ref: %v", err)
 	}
 	rb1, err := ref.New("ocidir://testrepo:b1")
 	if err != nil {
-		t.Errorf("failed to parse ref: %v", err)
+		t.Fatalf("failed to parse ref: %v", err)
 	}
 	rb2, err := ref.New("ocidir://testrepo:b2")
 	if err != nil {
-		t.Errorf("failed to parse ref: %v", err)
+		t.Fatalf("failed to parse ref: %v", err)
 	}
 	rb3, err := ref.New("ocidir://testrepo:b3")
 	if err != nil {
-		t.Errorf("failed to parse ref: %v", err)
+		t.Fatalf("failed to parse ref: %v", err)
 	}
 	// r1, err := ref.New("ocidir://testrepo:v1")
 	// if err != nil {
-	// 	t.Errorf("failed to parse ref: %v", err)
+	// 	t.Fatalf("failed to parse ref: %v", err)
 	// }
 	// r2, err := ref.New("ocidir://testrepo:v2")
 	// if err != nil {
-	// 	t.Errorf("failed to parse ref: %v", err)
+	// 	t.Fatalf("failed to parse ref: %v", err)
 	// }
 	r3, err := ref.New("ocidir://testrepo:v3")
 	if err != nil {
-		t.Errorf("failed to parse ref: %v", err)
+		t.Fatalf("failed to parse ref: %v", err)
 	}
 	m3, err := rc.ManifestGet(ctx, r3)
 	if err != nil {
-		t.Errorf("failed to retrieve v3 ref: %v", err)
+		t.Fatalf("failed to retrieve v3 ref: %v", err)
 	}
 	pAMD, err := platform.Parse("linux/amd64")
 	if err != nil {
-		t.Errorf("failed to parse platform: %v", err)
+		t.Fatalf("failed to parse platform: %v", err)
 	}
 	m3DescAmd, err := manifest.GetPlatformDesc(m3, &pAMD)
 	if err != nil {
-		t.Errorf("failed to get amd64 descriptor: %v", err)
+		t.Fatalf("failed to get amd64 descriptor: %v", err)
 	}
 	r3amd, err := ref.New(fmt.Sprintf("ocidir://testrepo@%s", m3DescAmd.Digest.String()))
 	if err != nil {
-		t.Errorf("failed to parse platform specific descriptor: %v", err)
+		t.Fatalf("failed to parse platform specific descriptor: %v", err)
 	}
 
 	// define tests
@@ -813,8 +812,7 @@ func TestMod(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			rSrc, err := ref.New(tt.ref)
 			if err != nil {
-				t.Errorf("failed creating ref: %v", err)
-				return
+				t.Fatalf("failed creating ref: %v", err)
 			}
 			// run mod with opts
 			rMod, err := Apply(ctx, rc, rSrc, tt.opts...)
@@ -826,19 +824,16 @@ func TestMod(t *testing.T) {
 				}
 				return
 			} else if err != nil {
-				t.Errorf("unexpected error: %v", err)
-				return
+				t.Fatalf("unexpected error: %v", err)
 			}
 
 			mSrc, err := rc.ManifestHead(ctx, rSrc, regclient.WithManifestRequireDigest())
 			if err != nil {
-				t.Errorf("failed to get manifest from src: %v", err)
-				return
+				t.Fatalf("failed to get manifest from src: %v", err)
 			}
 			mTgt, err := rc.ManifestHead(ctx, rMod, regclient.WithManifestRequireDigest())
 			if err != nil {
-				t.Errorf("failed to get manifest from mod \"%s\": %v", rMod.CommonName(), err)
-				return
+				t.Fatalf("failed to get manifest from mod \"%s\": %v", rMod.CommonName(), err)
 			}
 
 			if tt.wantSame {

--- a/mod/time_test.go
+++ b/mod/time_test.go
@@ -13,8 +13,7 @@ func TestTimeNow(t *testing.T) {
 		if envIsSet {
 			err := os.Unsetenv(epocEnv)
 			if err != nil {
-				t.Errorf("failed to unset %s", epocEnv)
-				return
+				t.Fatalf("failed to unset %s", epocEnv)
 			}
 			defer os.Setenv(epocEnv, curEnv)
 		}

--- a/scheme/ocidir/close_test.go
+++ b/scheme/ocidir/close_test.go
@@ -18,13 +18,11 @@ func TestClose(t *testing.T) {
 	fsMem := rwfs.MemNew()
 	err := rwfs.MkdirAll(fsMem, "testdata/regctl", 0777)
 	if err != nil {
-		t.Errorf("failed to setup memfs dir: %v", err)
-		return
+		t.Fatalf("failed to setup memfs dir: %v", err)
 	}
 	err = rwfs.CopyRecursive(fsOS, "testdata/regctl", fsMem, "testdata/regctl")
 	if err != nil {
-		t.Errorf("failed to setup memfs copy: %v", err)
-		return
+		t.Fatalf("failed to setup memfs copy: %v", err)
 	}
 	oMem := New(WithFS(fsMem))
 	tRef := "ocidir://testdata/regctl"

--- a/scheme/ocidir/manifest_test.go
+++ b/scheme/ocidir/manifest_test.go
@@ -26,15 +26,13 @@ func TestManifest(t *testing.T) {
 	fsMem := rwfs.MemNew()
 	err := rwfs.CopyRecursive(fsOS, "../../testdata", fsMem, ".")
 	if err != nil {
-		t.Errorf("failed to setup memfs copy: %v", err)
-		return
+		t.Fatalf("failed to setup memfs copy: %v", err)
 	}
 	o := New(WithFS(fsMem))
 	rs := "ocidir://testrepo:v1"
 	r, err := ref.New(rs)
 	if err != nil {
-		t.Errorf("failed to parse ref %s: %v", rs, err)
-		return
+		t.Fatalf("failed to parse ref %s: %v", rs, err)
 	}
 	// manifest head
 	_, err = o.ManifestHead(ctx, r)
@@ -44,7 +42,7 @@ func TestManifest(t *testing.T) {
 	// manifest list
 	ml, err := o.ManifestGet(ctx, r)
 	if err != nil {
-		t.Errorf("manifest get: %v", err)
+		t.Fatalf("manifest get: %v", err)
 	}
 	if manifest.GetMediaType(ml) != types.MediaTypeOCI1ManifestList {
 		t.Errorf("manifest mt, expected %s, received %s", types.MediaTypeOCI1ManifestList, manifest.GetMediaType(ml))
@@ -54,19 +52,17 @@ func TestManifest(t *testing.T) {
 	}
 	mli, ok := ml.(manifest.Indexer)
 	if !ok {
-		t.Errorf("manifest doesn't support index methods")
-		return
+		t.Fatalf("manifest doesn't support index methods")
 	}
 	dl, err := mli.GetManifestList()
 	if err != nil || len(dl) < 1 {
-		t.Errorf("descriptor list (%d): %v", len(dl), err)
+		t.Fatalf("descriptor list (%d): %v", len(dl), err)
 	}
 	// manifest head on a child digest
 	rs = fmt.Sprintf("%s@%s", rs, dl[0].Digest)
 	r, err = ref.New(rs)
 	if err != nil {
-		t.Errorf("failed to parse ref %s: %v", rs, err)
-		return
+		t.Fatalf("failed to parse ref %s: %v", rs, err)
 	}
 	_, err = o.ManifestHead(ctx, r)
 	if err != nil {
@@ -81,13 +77,11 @@ func TestManifest(t *testing.T) {
 	// image manifest
 	m, err := o.ManifestGet(ctx, r)
 	if err != nil {
-		t.Errorf("manifest get: %v", err)
-		return
+		t.Fatalf("manifest get: %v", err)
 	}
 	mi, ok := m.(manifest.Imager)
 	if !ok {
-		t.Errorf("manifest doesn't support image methods")
-		return
+		t.Fatalf("manifest doesn't support image methods")
 	}
 	_, err = mi.GetConfig()
 	if err != nil {
@@ -103,17 +97,16 @@ func TestManifest(t *testing.T) {
 	}
 	fh, err := fm.Open("testrepo/" + imageLayoutFile)
 	if err != nil {
-		t.Errorf("open oci-layout: %v", err)
-		return
+		t.Fatalf("open oci-layout: %v", err)
 	}
 	lb, err := io.ReadAll(fh)
 	if err != nil {
-		t.Errorf("readall oci-layout: %v", err)
+		t.Fatalf("readall oci-layout: %v", err)
 	}
 	l := v1.ImageLayout{}
 	err = json.Unmarshal(lb, &l)
 	if err != nil {
-		t.Errorf("json unmarshal oci-layout: %v", err)
+		t.Fatalf("json unmarshal oci-layout: %v", err)
 	}
 	if l.Version != "1.0.0" {
 		t.Errorf("oci-layout version, expected 1.0.0, received %s", l.Version)
@@ -125,22 +118,22 @@ func TestManifest(t *testing.T) {
 	}
 	bRaw, err := io.ReadAll(fh)
 	if err != nil {
-		t.Errorf("failed to read manifest blob: %v", err)
+		t.Fatalf("failed to read manifest blob: %v", err)
 	}
 	mRaw, err := m.RawBody()
 	if err != nil {
-		t.Errorf("failed to run RawBody: %v", err)
+		t.Fatalf("failed to run RawBody: %v", err)
 	}
 	if !bytes.Equal(bRaw, mRaw) {
 		t.Errorf("blob and raw do not match, raw %s, blob %s", string(mRaw), string(bRaw))
 	}
 	tl, err := om.TagList(ctx, r)
 	if err != nil {
-		t.Errorf("tag list: %v", err)
+		t.Fatalf("tag list: %v", err)
 	}
 	tlt, err := tl.GetTags()
 	if err != nil {
-		t.Errorf("tag list tags: %v", err)
+		t.Fatalf("tag list tags: %v", err)
 	}
 	if len(tlt) != 1 || tlt[0] != "v1" {
 		t.Errorf("tag list, expected v1, received %v", tlt)
@@ -152,11 +145,11 @@ func TestManifest(t *testing.T) {
 	}
 	tl, err = om.TagList(ctx, r)
 	if err != nil {
-		t.Errorf("tag list: %v", err)
+		t.Fatalf("tag list: %v", err)
 	}
 	tlt, err = tl.GetTags()
 	if err != nil {
-		t.Errorf("tag list tags: %v", err)
+		t.Fatalf("tag list tags: %v", err)
 	}
 	if len(tlt) != 0 {
 		t.Errorf("tag list, expected empty list, received %v", tlt)

--- a/scheme/ocidir/ocidir_test.go
+++ b/scheme/ocidir/ocidir_test.go
@@ -174,11 +174,11 @@ func TestIndex(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			err := o.writeIndex(r, tt.index, false)
 			if err != nil {
-				t.Errorf("failed to write index: %v", err)
+				t.Fatalf("failed to write index: %v", err)
 			}
 			index, err := o.readIndex(r, false)
 			if err != nil {
-				t.Errorf("failed to read index: %v", err)
+				t.Fatalf("failed to read index: %v", err)
 			}
 			if !tt.get.IsZero() {
 				d, err := indexGet(index, tt.get)

--- a/scheme/ocidir/ping_test.go
+++ b/scheme/ocidir/ping_test.go
@@ -15,13 +15,11 @@ func TestPing(t *testing.T) {
 	o := New(WithFS(f))
 	rOkay, err := ref.NewHost("ocidir://testdata/regctl")
 	if err != nil {
-		t.Errorf("failed to create ref: %v", err)
-		return
+		t.Fatalf("failed to create ref: %v", err)
 	}
 	result, err := o.Ping(ctx, rOkay)
 	if err != nil {
-		t.Errorf("failed to ping: %v", err)
-		return
+		t.Fatalf("failed to ping: %v", err)
 	}
 	if result.Header != nil {
 		t.Errorf("header is not nil")
@@ -36,8 +34,7 @@ func TestPing(t *testing.T) {
 
 	rMissing, err := ref.NewHost("ocidir://testdata/missing")
 	if err != nil {
-		t.Errorf("failed to create ref: %v", err)
-		return
+		t.Fatalf("failed to create ref: %v", err)
 	}
 	result, err = o.Ping(ctx, rMissing)
 	if err == nil {
@@ -52,13 +49,11 @@ func TestPing(t *testing.T) {
 
 	rFile, err := ref.NewHost("ocidir://testdata/regctl/index.json")
 	if err != nil {
-		t.Errorf("failed to create ref: %v", err)
-		return
+		t.Fatalf("failed to create ref: %v", err)
 	}
 	result, err = o.Ping(ctx, rFile)
 	if err == nil {
-		t.Errorf("ping to a file did not fail")
-		return
+		t.Fatalf("ping to a file did not fail")
 	}
 	if result.Header != nil {
 		t.Errorf("header is not nil")

--- a/scheme/ocidir/referrer_test.go
+++ b/scheme/ocidir/referrer_test.go
@@ -25,8 +25,7 @@ func TestReferrer(t *testing.T) {
 	fsMem := rwfs.MemNew()
 	err := rwfs.CopyRecursive(fsOS, "../../testdata", fsMem, ".")
 	if err != nil {
-		t.Errorf("failed to setup memfs copy: %v", err)
-		return
+		t.Fatalf("failed to setup memfs copy: %v", err)
 	}
 	log := &logrus.Logger{
 		Out:       os.Stderr,
@@ -51,8 +50,7 @@ func TestReferrer(t *testing.T) {
 	digest2 := digest.FromString("example2")
 	mRef, err := ref.New(repo + ":" + tagName)
 	if err != nil {
-		t.Errorf("failed to parse ref %s: %v", repo+":"+tagName, err)
-		return
+		t.Fatalf("failed to parse ref %s: %v", repo+":"+tagName, err)
 	}
 	m, err := o.ManifestGet(ctx, mRef)
 	if err != nil {
@@ -69,13 +67,11 @@ func TestReferrer(t *testing.T) {
 	pAMDStr := "linux/amd64"
 	pAMD, err := platform.Parse(pAMDStr)
 	if err != nil {
-		t.Errorf("failed to parse platform: %v", err)
-		return
+		t.Fatalf("failed to parse platform: %v", err)
 	}
 	mAMDDesc, err := manifest.GetPlatformDesc(m, &pAMD)
 	if err != nil {
-		t.Errorf("failed to get AMD descriptor: %v", err)
-		return
+		t.Fatalf("failed to get AMD descriptor: %v", err)
 	}
 	artifactA := v1.Manifest{
 		Versioned: v1.ManifestSchemaVersion,
@@ -122,13 +118,11 @@ func TestReferrer(t *testing.T) {
 	}
 	artifactBM, err := manifest.New(manifest.WithOrig(artifactB))
 	if err != nil {
-		t.Errorf("failed creating artifact manifest: %v", err)
-		return
+		t.Fatalf("failed creating artifact manifest: %v", err)
 	}
 	artifactBBody, err := artifactBM.RawBody()
 	if err != nil {
-		t.Errorf("failed extracting raw body from artifact: %v", err)
-		return
+		t.Fatalf("failed extracting raw body from artifact: %v", err)
 	}
 	artifactC := v1.ArtifactManifest{
 		MediaType:    types.MediaTypeOCI1Artifact,
@@ -144,8 +138,7 @@ func TestReferrer(t *testing.T) {
 	}
 	artifactCM, err := manifest.New(manifest.WithOrig(artifactC))
 	if err != nil {
-		t.Errorf("failed creating artifact manifest: %v", err)
-		return
+		t.Fatalf("failed creating artifact manifest: %v", err)
 	}
 
 	// list empty
@@ -153,12 +146,10 @@ func TestReferrer(t *testing.T) {
 		r := mRef
 		rl, err := o.ReferrerList(ctx, r)
 		if err != nil {
-			t.Errorf("Failed running ReferrerList: %v", err)
-			return
+			t.Fatalf("Failed running ReferrerList: %v", err)
 		}
 		if len(rl.Descriptors) > 0 {
-			t.Errorf("descriptors exist")
-			return
+			t.Fatalf("descriptors exist")
 		}
 	})
 
@@ -167,25 +158,21 @@ func TestReferrer(t *testing.T) {
 		r := mRef.SetDigest(artifactAM.GetDescriptor().Digest.String())
 		err = o.ManifestPut(ctx, r, artifactAM, scheme.WithManifestChild())
 		if err != nil {
-			t.Errorf("Failed running ManifestPut on Manifest: %v", err)
-			return
+			t.Fatalf("Failed running ManifestPut on Manifest: %v", err)
 		}
 		err = o.ManifestPut(ctx, r, artifactAM, scheme.WithManifestChild())
 		if err != nil {
-			t.Errorf("Failed running ManifestPut on Manifest again: %v", err)
-			return
+			t.Fatalf("Failed running ManifestPut on Manifest again: %v", err)
 		}
 		r.Digest = artifactBM.GetDescriptor().Digest.String()
 		err = o.ManifestPut(ctx, r, artifactBM, scheme.WithManifestChild())
 		if err != nil {
-			t.Errorf("Failed running ManifestPut on Artifact: %v", err)
-			return
+			t.Fatalf("Failed running ManifestPut on Artifact: %v", err)
 		}
 		r.Digest = artifactCM.GetDescriptor().Digest.String()
 		err = o.ManifestPut(ctx, r, artifactCM, scheme.WithManifestChild())
 		if err != nil {
-			t.Errorf("Failed running ManifestPut on Artifact: %v", err)
-			return
+			t.Fatalf("Failed running ManifestPut on Artifact: %v", err)
 		}
 	})
 
@@ -193,17 +180,14 @@ func TestReferrer(t *testing.T) {
 	t.Run("List", func(t *testing.T) {
 		r, err := ref.New(repo + ":" + tagName)
 		if err != nil {
-			t.Errorf("Failed creating getRef: %v", err)
-			return
+			t.Fatalf("Failed creating getRef: %v", err)
 		}
 		rl, err := o.ReferrerList(ctx, r, scheme.WithReferrerMatchOpt(types.MatchOpt{SortAnnotation: timeAnnot}))
 		if err != nil {
-			t.Errorf("Failed running ReferrerList: %v", err)
-			return
+			t.Fatalf("Failed running ReferrerList: %v", err)
 		}
 		if len(rl.Descriptors) != 2 {
-			t.Errorf("descriptor list length, expected 2, received %d", len(rl.Descriptors))
-			return
+			t.Fatalf("descriptor list length, expected 2, received %d", len(rl.Descriptors))
 		}
 		// expecting artifact A in index 0
 		if rl.Descriptors[0].MediaType != types.MediaTypeOCI1Manifest ||
@@ -226,12 +210,10 @@ func TestReferrer(t *testing.T) {
 		}
 		rl, err = o.ReferrerList(ctx, r, scheme.WithReferrerMatchOpt(types.MatchOpt{SortAnnotation: timeAnnot, SortDesc: true}))
 		if err != nil {
-			t.Errorf("Failed running ReferrerList reverse: %v", err)
-			return
+			t.Fatalf("Failed running ReferrerList reverse: %v", err)
 		}
 		if len(rl.Descriptors) != 2 {
-			t.Errorf("descriptor list length, expected 2, received %d", len(rl.Descriptors))
-			return
+			t.Fatalf("descriptor list length, expected 2, received %d", len(rl.Descriptors))
 		}
 		// check order of responses
 		if rl.Descriptors[0].Digest != artifactBM.GetDescriptor().Digest ||
@@ -242,77 +224,62 @@ func TestReferrer(t *testing.T) {
 	t.Run("List with artifact filter", func(t *testing.T) {
 		r, err := ref.New(repo + ":" + tagName)
 		if err != nil {
-			t.Errorf("Failed creating getRef: %v", err)
-			return
+			t.Fatalf("Failed creating getRef: %v", err)
 		}
 		rl, err := o.ReferrerList(ctx, r, scheme.WithReferrerMatchOpt(types.MatchOpt{ArtifactType: aType}))
 		if err != nil {
-			t.Errorf("Failed running ReferrerList: %v", err)
-			return
+			t.Fatalf("Failed running ReferrerList: %v", err)
 		}
 		if len(rl.Descriptors) != 1 {
-			t.Errorf("descriptor list length, expected 1, received %d", len(rl.Descriptors))
-			return
+			t.Fatalf("descriptor list length, expected 1, received %d", len(rl.Descriptors))
 		}
 		rl, err = o.ReferrerList(ctx, r, scheme.WithReferrerMatchOpt(types.MatchOpt{ArtifactType: "application/vnd.example.unknown"}))
 		if err != nil {
-			t.Errorf("Failed running ReferrerList: %v", err)
-			return
+			t.Fatalf("Failed running ReferrerList: %v", err)
 		}
 		if len(rl.Descriptors) > 0 {
-			t.Errorf("unexpected descriptors")
-			return
+			t.Fatalf("unexpected descriptors")
 		}
 	})
 	t.Run("List with annotation filter", func(t *testing.T) {
 		r, err := ref.New(repo + ":" + tagName)
 		if err != nil {
-			t.Errorf("Failed creating getRef: %v", err)
-			return
+			t.Fatalf("Failed creating getRef: %v", err)
 		}
 		rl, err := o.ReferrerList(ctx, r, scheme.WithReferrerMatchOpt(types.MatchOpt{Annotations: map[string]string{extraAnnot: extraValueB}}))
 		if err != nil {
-			t.Errorf("Failed running ReferrerList: %v", err)
-			return
+			t.Fatalf("Failed running ReferrerList: %v", err)
 		}
 		if len(rl.Descriptors) != 1 {
-			t.Errorf("descriptor list length, expected 1, received %d", len(rl.Descriptors))
-			return
+			t.Fatalf("descriptor list length, expected 1, received %d", len(rl.Descriptors))
 		}
 		rl, err = o.ReferrerList(ctx, r, scheme.WithReferrerMatchOpt(types.MatchOpt{Annotations: map[string]string{extraAnnot: "unknown value"}}))
 		if err != nil {
-			t.Errorf("Failed running ReferrerList: %v", err)
-			return
+			t.Fatalf("Failed running ReferrerList: %v", err)
 		}
 		if len(rl.Descriptors) > 0 {
-			t.Errorf("unexpected descriptors")
-			return
+			t.Fatalf("unexpected descriptors")
 		}
 		rl, err = o.ReferrerList(ctx, r, scheme.WithReferrerMatchOpt(types.MatchOpt{Annotations: map[string]string{extraAnnot: ""}}))
 		if err != nil {
-			t.Errorf("Failed running ReferrerList: %v", err)
-			return
+			t.Fatalf("Failed running ReferrerList: %v", err)
 		}
 		if len(rl.Descriptors) != 2 {
-			t.Errorf("descriptor list length, expected 2, received %d", len(rl.Descriptors))
-			return
+			t.Fatalf("descriptor list length, expected 2, received %d", len(rl.Descriptors))
 		}
 	})
 	// list platform=linux/amd64
 	t.Run("List Annotation for Platform", func(t *testing.T) {
 		r, err := ref.New(repo + ":" + tagName)
 		if err != nil {
-			t.Errorf("Failed creating getRef: %v", err)
-			return
+			t.Fatalf("Failed creating getRef: %v", err)
 		}
 		rl, err := o.ReferrerList(ctx, r, scheme.WithReferrerPlatform(pAMDStr))
 		if err != nil {
-			t.Errorf("Failed running ReferrerList: %v", err)
-			return
+			t.Fatalf("Failed running ReferrerList: %v", err)
 		}
 		if len(rl.Descriptors) != 1 {
-			t.Errorf("descriptor list length, expected 1, received %d", len(rl.Descriptors))
-			return
+			t.Fatalf("descriptor list length, expected 1, received %d", len(rl.Descriptors))
 		}
 	})
 
@@ -321,14 +288,12 @@ func TestReferrer(t *testing.T) {
 		r := mRef.SetDigest(artifactAM.GetDescriptor().Digest.String())
 		err = o.ManifestDelete(ctx, r, scheme.WithManifest(artifactAM))
 		if err != nil {
-			t.Errorf("Failed running ManifestDelete on Manifest: %v", err)
-			return
+			t.Fatalf("Failed running ManifestDelete on Manifest: %v", err)
 		}
 		r.Digest = artifactBM.GetDescriptor().Digest.String()
 		err = o.ManifestDelete(ctx, r, scheme.WithManifestCheckReferrers())
 		if err != nil {
-			t.Errorf("Failed running ManifestDelete on Artifact: %v", err)
-			return
+			t.Fatalf("Failed running ManifestDelete on Artifact: %v", err)
 		}
 	})
 
@@ -337,12 +302,10 @@ func TestReferrer(t *testing.T) {
 		r := mRef
 		rl, err := o.ReferrerList(ctx, r)
 		if err != nil {
-			t.Errorf("Failed running ReferrerList: %v", err)
-			return
+			t.Fatalf("Failed running ReferrerList: %v", err)
 		}
 		if len(rl.Descriptors) > 0 {
-			t.Errorf("descriptors exist")
-			return
+			t.Fatalf("descriptors exist")
 		}
 	})
 }

--- a/scheme/ocidir/tag_test.go
+++ b/scheme/ocidir/tag_test.go
@@ -17,19 +17,17 @@ func TestTag(t *testing.T) {
 	fsMem := rwfs.MemNew()
 	err := rwfs.MkdirAll(fsMem, "testdata/regctl", 0777)
 	if err != nil {
-		t.Errorf("failed to setup memfs dir: %v", err)
-		return
+		t.Fatalf("failed to setup memfs dir: %v", err)
 	}
 	err = rwfs.CopyRecursive(fsOS, "testdata/regctl", fsMem, "testdata/regctl")
 	if err != nil {
-		t.Errorf("failed to setup memfs copy: %v", err)
-		return
+		t.Fatalf("failed to setup memfs copy: %v", err)
 	}
 	oMem := New(WithFS(fsMem))
 	tRef := "ocidir://testdata/regctl"
 	r, err := ref.New(tRef)
 	if err != nil {
-		t.Errorf("failed to parse ref %s: %v", tRef, err)
+		t.Fatalf("failed to parse ref %s: %v", tRef, err)
 	}
 	rCp := r
 
@@ -37,12 +35,11 @@ func TestTag(t *testing.T) {
 		exTags := []string{"broken", "latest", "v0.3", "v0.3.10"}
 		tl, err := oMem.TagList(ctx, r)
 		if err != nil {
-			t.Errorf("failed to retrieve tag list: %v", err)
-			return
+			t.Fatalf("failed to retrieve tag list: %v", err)
 		}
 		tlTags, err := tl.GetTags()
 		if err != nil {
-			t.Errorf("failed to get tags: %v", err)
+			t.Fatalf("failed to get tags: %v", err)
 		}
 		if !cmpSliceString(exTags, tlTags) {
 			t.Errorf("unexpected tag list, expected %v, received %v", exTags, tlTags)
@@ -69,8 +66,7 @@ func TestTag(t *testing.T) {
 
 		tl, err := oMem.TagList(ctx, r)
 		if err != nil {
-			t.Errorf("failed to retrieve tag list: %v", err)
-			return
+			t.Fatalf("failed to retrieve tag list: %v", err)
 		}
 		tlTags, err := tl.GetTags()
 		if err != nil {

--- a/scheme/reg/blob_test.go
+++ b/scheme/reg/blob_test.go
@@ -235,18 +235,16 @@ func TestBlobGet(t *testing.T) {
 	t.Run("Get", func(t *testing.T) {
 		r, err := ref.New(tsURL.Host + blobRepo)
 		if err != nil {
-			t.Errorf("Failed creating ref: %v", err)
+			t.Fatalf("Failed creating ref: %v", err)
 		}
 		br, err := reg.BlobGet(ctx, r, types.Descriptor{Digest: d1})
 		if err != nil {
-			t.Errorf("Failed running BlobGet: %v", err)
-			return
+			t.Fatalf("Failed running BlobGet: %v", err)
 		}
 		defer br.Close()
 		brBlob, err := io.ReadAll(br)
 		if err != nil {
-			t.Errorf("Failed reading blob: %v", err)
-			return
+			t.Fatalf("Failed reading blob: %v", err)
 		}
 		if !bytes.Equal(blob1, brBlob) {
 			t.Errorf("Blob does not match")
@@ -256,12 +254,11 @@ func TestBlobGet(t *testing.T) {
 	t.Run("Head", func(t *testing.T) {
 		r, err := ref.New(tsURL.Host + blobRepo)
 		if err != nil {
-			t.Errorf("Failed creating ref: %v", err)
+			t.Fatalf("Failed creating ref: %v", err)
 		}
 		br, err := reg.BlobHead(ctx, r, types.Descriptor{Digest: d1})
 		if err != nil {
-			t.Errorf("Failed running BlobHead: %v", err)
-			return
+			t.Fatalf("Failed running BlobHead: %v", err)
 		}
 		defer br.Close()
 		if br.GetDescriptor().Size != int64(blobLen) {
@@ -273,18 +270,16 @@ func TestBlobGet(t *testing.T) {
 	t.Run("External Get", func(t *testing.T) {
 		r, err := ref.New(tsURL.Host + externalRepo)
 		if err != nil {
-			t.Errorf("Failed creating ref: %v", err)
+			t.Fatalf("Failed creating ref: %v", err)
 		}
 		br, err := reg.BlobGet(ctx, r, types.Descriptor{Digest: d1, URLs: []string{tsURL.Scheme + "://" + tsURL.Host + "/external/" + d1.String()}})
 		if err != nil {
-			t.Errorf("Failed running external BlobGet: %v", err)
-			return
+			t.Fatalf("Failed running external BlobGet: %v", err)
 		}
 		defer br.Close()
 		brBlob, err := io.ReadAll(br)
 		if err != nil {
-			t.Errorf("Failed reading external blob: %v", err)
-			return
+			t.Fatalf("Failed reading external blob: %v", err)
 		}
 		if !bytes.Equal(blob1, brBlob) {
 			t.Errorf("External blob does not match")
@@ -294,12 +289,11 @@ func TestBlobGet(t *testing.T) {
 	t.Run("External Head", func(t *testing.T) {
 		r, err := ref.New(tsURL.Host + externalRepo)
 		if err != nil {
-			t.Errorf("Failed creating ref: %v", err)
+			t.Fatalf("Failed creating ref: %v", err)
 		}
 		br, err := reg.BlobHead(ctx, r, types.Descriptor{Digest: d1, URLs: []string{tsURL.Scheme + "://" + tsURL.Host + "/external/" + d1.String()}})
 		if err != nil {
-			t.Errorf("Failed running external BlobHead: %v", err)
-			return
+			t.Fatalf("Failed running external BlobHead: %v", err)
 		}
 		defer br.Close()
 		if br.GetDescriptor().Size != int64(blobLen) {
@@ -310,13 +304,12 @@ func TestBlobGet(t *testing.T) {
 	t.Run("Missing", func(t *testing.T) {
 		r, err := ref.New(tsURL.Host + blobRepo)
 		if err != nil {
-			t.Errorf("Failed creating ref: %v", err)
+			t.Fatalf("Failed creating ref: %v", err)
 		}
 		br, err := reg.BlobGet(ctx, r, types.Descriptor{Digest: dMissing})
 		if err == nil {
 			defer br.Close()
-			t.Errorf("Unexpected success running BlobGet")
-			return
+			t.Fatalf("Unexpected success running BlobGet")
 		}
 		if !errors.Is(err, types.ErrNotFound) {
 			t.Errorf("Error does not match \"ErrNotFound\": %v", err)
@@ -326,18 +319,16 @@ func TestBlobGet(t *testing.T) {
 	t.Run("Retry", func(t *testing.T) {
 		r, err := ref.New(tsURL.Host + blobRepo)
 		if err != nil {
-			t.Errorf("Failed creating ref: %v", err)
+			t.Fatalf("Failed creating ref: %v", err)
 		}
 		br, err := reg.BlobGet(ctx, r, types.Descriptor{Digest: d2})
 		if err != nil {
-			t.Errorf("Failed running BlobGet: %v", err)
-			return
+			t.Fatalf("Failed running BlobGet: %v", err)
 		}
 		defer br.Close()
 		brBlob, err := io.ReadAll(br)
 		if err != nil {
-			t.Errorf("Failed reading blob: %v", err)
-			return
+			t.Fatalf("Failed reading blob: %v", err)
 		}
 		if !bytes.Equal(blob2, brBlob) {
 			t.Errorf("Blob does not match")
@@ -347,13 +338,12 @@ func TestBlobGet(t *testing.T) {
 	t.Run("Forbidden", func(t *testing.T) {
 		r, err := ref.New(tsURL.Host + privateRepo)
 		if err != nil {
-			t.Errorf("Failed creating ref: %v", err)
+			t.Fatalf("Failed creating ref: %v", err)
 		}
 		br, err := reg.BlobGet(ctx, r, types.Descriptor{Digest: d1})
 		if err == nil {
 			defer br.Close()
-			t.Errorf("Unexpected success running BlobGet")
-			return
+			t.Fatalf("Unexpected success running BlobGet")
 		}
 		if !errors.Is(err, types.ErrHTTPUnauthorized) {
 			t.Errorf("Error does not match \"ErrUnauthorized\": %v", err)
@@ -1203,13 +1193,12 @@ func TestBlobPut(t *testing.T) {
 	t.Run("Put", func(t *testing.T) {
 		r, err := ref.New(tsURL.Host + blobRepo)
 		if err != nil {
-			t.Errorf("Failed creating ref: %v", err)
+			t.Fatalf("Failed creating ref: %v", err)
 		}
 		br := bytes.NewReader(blob1)
 		dp, err := reg.BlobPut(ctx, r, types.Descriptor{Digest: d1, Size: int64(len(blob1))}, br)
 		if err != nil {
-			t.Errorf("Failed running BlobPut: %v", err)
-			return
+			t.Fatalf("Failed running BlobPut: %v", err)
 		}
 		if dp.Digest.String() != d1.String() {
 			t.Errorf("Digest mismatch, expected %s, received %s", d1.String(), dp.Digest.String())
@@ -1222,14 +1211,13 @@ func TestBlobPut(t *testing.T) {
 	t.Run("Retry", func(t *testing.T) {
 		r, err := ref.New("retry." + tsURL.Host + blobRepo)
 		if err != nil {
-			t.Errorf("Failed creating ref: %v", err)
+			t.Fatalf("Failed creating ref: %v", err)
 		}
 		br := bytes.NewReader(blob2)
 		mt := "application/vnd.example.test"
 		dp, err := reg.BlobPut(ctx, r, types.Descriptor{MediaType: mt, Digest: d2, Size: int64(len(blob2))}, br)
 		if err != nil {
-			t.Errorf("Failed running BlobPut: %v", err)
-			return
+			t.Fatalf("Failed running BlobPut: %v", err)
 		}
 		if dp.Digest.String() != d2.String() {
 			t.Errorf("Digest mismatch, expected %s, received %s", d2.String(), dp.Digest.String())
@@ -1245,13 +1233,12 @@ func TestBlobPut(t *testing.T) {
 	t.Run("Not retryable", func(t *testing.T) {
 		r, err := ref.New("retry." + tsURL.Host + blobRepo)
 		if err != nil {
-			t.Errorf("Failed creating ref: %v", err)
+			t.Fatalf("Failed creating ref: %v", err)
 		}
 		br := bytes.NewReader(blob2)
 		_, err = reg.BlobPut(ctx, r, types.Descriptor{Digest: d2, Size: int64(len(blob2))}, io.NopCloser(br))
 		if err == nil {
-			t.Errorf("Blob put succeeded on a gateway timeout")
-			return
+			t.Fatalf("Blob put succeeded on a gateway timeout")
 		}
 		if !errors.Is(err, types.ErrHTTPStatus) {
 			t.Errorf("unexpected err, expected %v, received %v", types.ErrHTTPStatus, err)
@@ -1261,7 +1248,7 @@ func TestBlobPut(t *testing.T) {
 	t.Run("Invalid digest", func(t *testing.T) {
 		r, err := ref.New("retry." + tsURL.Host + blobRepo)
 		if err != nil {
-			t.Errorf("Failed creating ref: %v", err)
+			t.Fatalf("Failed creating ref: %v", err)
 		}
 		br := bytes.NewReader(blob2)
 		mt := "application/vnd.example.test"
@@ -1274,7 +1261,7 @@ func TestBlobPut(t *testing.T) {
 	t.Run("Invalid size", func(t *testing.T) {
 		r, err := ref.New("retry." + tsURL.Host + blobRepo)
 		if err != nil {
-			t.Errorf("Failed creating ref: %v", err)
+			t.Fatalf("Failed creating ref: %v", err)
 		}
 		br := bytes.NewReader(blob2)
 		mt := "application/vnd.example.test"
@@ -1287,13 +1274,12 @@ func TestBlobPut(t *testing.T) {
 	t.Run("PartialChunk", func(t *testing.T) {
 		r, err := ref.New(tsURL.Host + blobRepo)
 		if err != nil {
-			t.Errorf("Failed creating ref: %v", err)
+			t.Fatalf("Failed creating ref: %v", err)
 		}
 		br := bytes.NewReader(blob3)
 		dp, err := reg.BlobPut(ctx, r, types.Descriptor{Digest: d3, Size: int64(len(blob3))}, br)
 		if err != nil {
-			t.Errorf("Failed running BlobPut: %v", err)
-			return
+			t.Fatalf("Failed running BlobPut: %v", err)
 		}
 		if dp.Digest.String() != d3.String() {
 			t.Errorf("Digest mismatch, expected %s, received %s", d3.String(), dp.Digest.String())
@@ -1306,13 +1292,12 @@ func TestBlobPut(t *testing.T) {
 	t.Run("Chunk resized", func(t *testing.T) {
 		r, err := ref.New("chunked." + tsURL.Host + blobRepo)
 		if err != nil {
-			t.Errorf("Failed creating ref: %v", err)
+			t.Fatalf("Failed creating ref: %v", err)
 		}
 		br := bytes.NewReader(blob4)
 		dp, err := reg.BlobPut(ctx, r, types.Descriptor{Digest: d4, Size: int64(len(blob4))}, br)
 		if err != nil {
-			t.Errorf("Failed running BlobPut: %v", err)
-			return
+			t.Fatalf("Failed running BlobPut: %v", err)
 		}
 		if dp.Digest.String() != d4.String() {
 			t.Errorf("Digest mismatch, expected %s, received %s", d4.String(), dp.Digest.String())
@@ -1326,13 +1311,12 @@ func TestBlobPut(t *testing.T) {
 	t.Run("No descriptor", func(t *testing.T) {
 		r, err := ref.New(tsURL.Host + blobRepo5)
 		if err != nil {
-			t.Errorf("Failed creating ref: %v", err)
+			t.Fatalf("Failed creating ref: %v", err)
 		}
 		br := bytes.NewReader(blob5)
 		dp, err := reg.BlobPut(ctx, r, types.Descriptor{}, br)
 		if err != nil {
-			t.Errorf("Failed running BlobPut: %v", err)
-			return
+			t.Fatalf("Failed running BlobPut: %v", err)
 		}
 		if dp.Digest.String() != d5.String() {
 			t.Errorf("Digest mismatch, expected %s, received %s", d5.String(), dp.Digest.String())
@@ -1346,13 +1330,12 @@ func TestBlobPut(t *testing.T) {
 	t.Run("Empty blob", func(t *testing.T) {
 		r, err := ref.New(tsURL.Host + blobRepo6)
 		if err != nil {
-			t.Errorf("Failed creating ref: %v", err)
+			t.Fatalf("Failed creating ref: %v", err)
 		}
 		br := bytes.NewReader(blob6)
 		dp, err := reg.BlobPut(ctx, r, types.Descriptor{Digest: d6, Size: int64(len(blob6))}, br)
 		if err != nil {
-			t.Errorf("Failed running BlobPut: %v", err)
-			return
+			t.Fatalf("Failed running BlobPut: %v", err)
 		}
 		if dp.Digest.String() != d6.String() {
 			t.Errorf("Digest mismatch, expected %s, received %s", d6.String(), dp.Digest.String())

--- a/scheme/reg/manifest_test.go
+++ b/scheme/reg/manifest_test.go
@@ -248,12 +248,11 @@ func TestManifest(t *testing.T) {
 	t.Run("Get", func(t *testing.T) {
 		getRef, err := ref.New(tsURL.Host + repoPath + ":" + getTag)
 		if err != nil {
-			t.Errorf("Failed creating getRef: %v", err)
+			t.Fatalf("Failed creating getRef: %v", err)
 		}
 		mGet, err := reg.ManifestGet(ctx, getRef)
 		if err != nil {
-			t.Errorf("Failed running ManifestGet: %v", err)
-			return
+			t.Fatalf("Failed running ManifestGet: %v", err)
 		}
 		if manifest.GetMediaType(mGet) != types.MediaTypeDocker2Manifest {
 			t.Errorf("Unexpected media type: %s", manifest.GetMediaType(mGet))
@@ -265,12 +264,11 @@ func TestManifest(t *testing.T) {
 	t.Run("Head", func(t *testing.T) {
 		headRef, err := ref.New(tsURL.Host + repoPath + ":" + headTag)
 		if err != nil {
-			t.Errorf("Failed creating getRef: %v", err)
+			t.Fatalf("Failed creating getRef: %v", err)
 		}
 		mHead, err := reg.ManifestHead(ctx, headRef)
 		if err != nil {
-			t.Errorf("Failed running ManifestHead: %v", err)
-			return
+			t.Fatalf("Failed running ManifestHead: %v", err)
 		}
 		if manifest.GetMediaType(mHead) != types.MediaTypeDocker2Manifest {
 			t.Errorf("Unexpected media type: %s", manifest.GetMediaType(mHead))
@@ -282,7 +280,7 @@ func TestManifest(t *testing.T) {
 	t.Run("Head No Head", func(t *testing.T) {
 		noheadRef, err := ref.New("nohead." + tsURL.Host + repoPath + ":" + noheadTag)
 		if err != nil {
-			t.Errorf("Failed creating getRef: %v", err)
+			t.Fatalf("Failed creating getRef: %v", err)
 		}
 		mNohead, err := reg.ManifestHead(ctx, noheadRef)
 		if err == nil {
@@ -294,12 +292,11 @@ func TestManifest(t *testing.T) {
 	t.Run("Get No Head", func(t *testing.T) {
 		noheadRef, err := ref.New("nohead." + tsURL.Host + repoPath + ":" + noheadTag)
 		if err != nil {
-			t.Errorf("Failed creating getRef: %v", err)
+			t.Fatalf("Failed creating getRef: %v", err)
 		}
 		mNohead, err := reg.ManifestGet(ctx, noheadRef)
 		if err != nil {
-			t.Errorf("Failed running ManifestGet: %v", err)
-			return
+			t.Fatalf("Failed running ManifestGet: %v", err)
 		}
 		if manifest.GetMediaType(mNohead) != types.MediaTypeDocker2Manifest {
 			t.Errorf("Unexpected media type: %s", manifest.GetMediaType(mNohead))
@@ -311,23 +308,21 @@ func TestManifest(t *testing.T) {
 	t.Run("Missing", func(t *testing.T) {
 		missingRef, err := ref.New("missing." + tsURL.Host + repoPath + ":" + missingTag)
 		if err != nil {
-			t.Errorf("Failed creating missingRef: %v", err)
+			t.Fatalf("Failed creating missingRef: %v", err)
 		}
 		mMissing, err := reg.ManifestGet(ctx, missingRef)
 		if err == nil {
-			t.Errorf("Success running ManifestGet on missing ref: %v", mMissing)
-			return
+			t.Fatalf("Success running ManifestGet on missing ref: %v", mMissing)
 		}
 	})
 	t.Run("Get Digest", func(t *testing.T) {
 		getRef, err := ref.New(tsURL.Host + repoPath + "@" + mDigest.String())
 		if err != nil {
-			t.Errorf("Failed creating getRef: %v", err)
+			t.Fatalf("Failed creating getRef: %v", err)
 		}
 		mGet, err := regCache.ManifestGet(ctx, getRef)
 		if err != nil {
-			t.Errorf("Failed running ManifestGet: %v", err)
-			return
+			t.Fatalf("Failed running ManifestGet: %v", err)
 		}
 		if manifest.GetMediaType(mGet) != types.MediaTypeDocker2Manifest {
 			t.Errorf("Unexpected media type: %s", manifest.GetMediaType(mGet))
@@ -339,12 +334,11 @@ func TestManifest(t *testing.T) {
 	t.Run("Head Digest", func(t *testing.T) {
 		headRef, err := ref.New(tsURL.Host + repoPath + "@" + mDigest.String())
 		if err != nil {
-			t.Errorf("Failed creating getRef: %v", err)
+			t.Fatalf("Failed creating getRef: %v", err)
 		}
 		mHead, err := regCache.ManifestHead(ctx, headRef)
 		if err != nil {
-			t.Errorf("Failed running ManifestHead: %v", err)
-			return
+			t.Fatalf("Failed running ManifestHead: %v", err)
 		}
 		if manifest.GetMediaType(mHead) != types.MediaTypeDocker2Manifest {
 			t.Errorf("Unexpected media type: %s", manifest.GetMediaType(mHead))
@@ -356,12 +350,11 @@ func TestManifest(t *testing.T) {
 	t.Run("Cache Get", func(t *testing.T) {
 		getRef, err := ref.New(tsURL.Host + repoPath + "@" + mDigest.String())
 		if err != nil {
-			t.Errorf("Failed creating getRef: %v", err)
+			t.Fatalf("Failed creating getRef: %v", err)
 		}
 		mGet, err := regCache.ManifestGet(ctx, getRef)
 		if err != nil {
-			t.Errorf("Failed running ManifestGet: %v", err)
-			return
+			t.Fatalf("Failed running ManifestGet: %v", err)
 		}
 		if manifest.GetMediaType(mGet) != types.MediaTypeDocker2Manifest {
 			t.Errorf("Unexpected media type: %s", manifest.GetMediaType(mGet))
@@ -371,55 +364,49 @@ func TestManifest(t *testing.T) {
 		}
 		_, err = reg.ManifestGet(ctx, getRef)
 		if err != nil {
-			t.Errorf("Failed re-running ManifestGet (cache): %v", err)
-			return
+			t.Fatalf("Failed re-running ManifestGet (cache): %v", err)
 		}
 		_, err = reg.ManifestHead(ctx, getRef)
 		if err != nil {
-			t.Errorf("Failed running ManifestHead (cache): %v", err)
-			return
+			t.Fatalf("Failed running ManifestHead (cache): %v", err)
 		}
 	})
 	// TODO: get manifest that is larger than Content-Length header
 	t.Run("Size Limit", func(t *testing.T) {
 		bigRef, err := ref.New(tsURL.Host + repoPath + ":" + bigTag)
 		if err != nil {
-			t.Errorf("Failed creating ref: %v", err)
+			t.Fatalf("Failed creating ref: %v", err)
 		}
 		_, err = reg.ManifestGet(ctx, bigRef)
 		if err == nil {
-			t.Errorf("ManifestGet did not fail")
-			return
+			t.Fatalf("ManifestGet did not fail")
 		}
 		if !errors.Is(err, types.ErrSizeLimitExceeded) {
-			t.Errorf("unexpected error, expected %v, received %v", types.ErrSizeLimitExceeded, err)
-			return
+			t.Fatalf("unexpected error, expected %v, received %v", types.ErrSizeLimitExceeded, err)
 		}
 	})
 	t.Run("Read beyond size", func(t *testing.T) {
 		shortRef, err := ref.New(tsURL.Host + repoPath + ":" + shortReadTag)
 		if err != nil {
-			t.Errorf("Failed creating ref: %v", err)
+			t.Fatalf("Failed creating ref: %v", err)
 		}
 		_, err = reg.ManifestGet(ctx, shortRef)
 		if err == nil {
-			t.Errorf("ManifestGet did not fail")
-			return
+			t.Fatalf("ManifestGet did not fail")
 		}
 		if !errors.Is(err, types.ErrShortRead) && !errors.Is(err, io.ErrUnexpectedEOF) {
-			t.Errorf("unexpected error, expected %v, received %v", types.ErrShortRead, err)
-			return
+			t.Fatalf("unexpected error, expected %v, received %v", types.ErrShortRead, err)
 		}
 	})
 
 	t.Run("PUT", func(t *testing.T) {
 		putRef, err := ref.New(tsURL.Host + repoPath + ":" + putTag)
 		if err != nil {
-			t.Errorf("failed creating ref: %v", err)
+			t.Fatalf("failed creating ref: %v", err)
 		}
 		mm, err := manifest.New(manifest.WithRaw(mBody))
 		if err != nil {
-			t.Errorf("failed to create manifest: %v", err)
+			t.Fatalf("failed to create manifest: %v", err)
 		}
 		err = reg.ManifestPut(ctx, putRef, mm)
 		if err != nil {
@@ -429,8 +416,7 @@ func TestManifest(t *testing.T) {
 	t.Run("PUT size limit", func(t *testing.T) {
 		putRef, err := ref.New(tsURL.Host + repoPath + ":" + putTag)
 		if err != nil {
-			t.Errorf("failed creating ref: %v", err)
-			return
+			t.Fatalf("failed creating ref: %v", err)
 		}
 		mLarge := make([]byte, mLen+defaultManifestMaxPush)
 		copy(mLarge, mBody)
@@ -439,13 +425,11 @@ func TestManifest(t *testing.T) {
 		}
 		mm, err := manifest.New(manifest.WithRaw(mLarge))
 		if err != nil {
-			t.Errorf("failed to create manifest: %v", err)
-			return
+			t.Fatalf("failed to create manifest: %v", err)
 		}
 		err = reg.ManifestPut(ctx, putRef, mm)
 		if err == nil {
-			t.Errorf("put manifest did not fail")
-			return
+			t.Fatalf("put manifest did not fail")
 		}
 		if !errors.Is(err, types.ErrSizeLimitExceeded) {
 			t.Errorf("unexpected error, expected %v, received %v", types.ErrSizeLimitExceeded, err)

--- a/scheme/reg/ping_test.go
+++ b/scheme/reg/ping_test.go
@@ -126,8 +126,7 @@ func TestPing(t *testing.T) {
 	t.Run("Okay", func(t *testing.T) {
 		r, err := ref.NewHost(tsOkayHost)
 		if err != nil {
-			t.Errorf("failed to create ref \"%s\": %v", tsOkayHost, err)
-			return
+			t.Fatalf("failed to create ref \"%s\": %v", tsOkayHost, err)
 		}
 		result, err := reg.Ping(ctx, r)
 		if err != nil {
@@ -142,15 +141,13 @@ func TestPing(t *testing.T) {
 	t.Run("Unauth", func(t *testing.T) {
 		r, err := ref.NewHost(tsUnauthHost)
 		if err != nil {
-			t.Errorf("failed to create ref \"%s\": %v", tsUnauthHost, err)
-			return
+			t.Fatalf("failed to create ref \"%s\": %v", tsUnauthHost, err)
 		}
 		result, err := reg.Ping(ctx, r)
 		if err == nil {
-			t.Errorf("ping did not fail")
-			return
+			t.Fatalf("ping did not fail")
 		} else if !errors.Is(err, types.ErrHTTPUnauthorized) {
-			t.Errorf("unexpected error, expected %v, received %v", types.ErrHTTPUnauthorized, err)
+			t.Fatalf("unexpected error, expected %v, received %v", types.ErrHTTPUnauthorized, err)
 		}
 		if result.Header == nil {
 			t.Errorf("headers missing")
@@ -161,16 +158,13 @@ func TestPing(t *testing.T) {
 	t.Run("NotFound", func(t *testing.T) {
 		r, err := ref.NewHost(tsNotFoundHost)
 		if err != nil {
-			t.Errorf("failed to create ref \"%s\": %v", tsNotFoundHost, err)
-			return
+			t.Fatalf("failed to create ref \"%s\": %v", tsNotFoundHost, err)
 		}
 		result, err := reg.Ping(ctx, r)
 		if err == nil {
-			t.Errorf("ping did not fail")
-			return
+			t.Fatalf("ping did not fail")
 		} else if !errors.Is(err, types.ErrNotFound) {
-			t.Errorf("unexpected error, expected %v, received %v", types.ErrNotFound, err)
-			return
+			t.Fatalf("unexpected error, expected %v, received %v", types.ErrNotFound, err)
 		}
 		if result.Header == nil {
 			t.Errorf("headers missing")

--- a/scheme/reg/referrer_test.go
+++ b/scheme/reg/referrer_test.go
@@ -58,7 +58,7 @@ func TestReferrer(t *testing.T) {
 	}
 	mBody, err := json.Marshal(m)
 	if err != nil {
-		t.Errorf("Failed to marshal manifest: %v", err)
+		t.Fatalf("Failed to marshal manifest: %v", err)
 	}
 	mDigest := digest.FromBytes(mBody)
 	mLen := len(mBody)
@@ -88,7 +88,7 @@ func TestReferrer(t *testing.T) {
 	}
 	mlBody, err := json.Marshal(mList)
 	if err != nil {
-		t.Errorf("Failed to marshal manifest list: %v", err)
+		t.Fatalf("Failed to marshal manifest list: %v", err)
 	}
 	mlDigest := digest.FromBytes(mlBody)
 	mlLen := len(mlBody)
@@ -120,11 +120,11 @@ func TestReferrer(t *testing.T) {
 	}
 	artifactM, err := manifest.New(manifest.WithOrig(artifact))
 	if err != nil {
-		t.Errorf("failed creating artifact manifest: %v", err)
+		t.Fatalf("failed creating artifact manifest: %v", err)
 	}
 	artifactBody, err := artifactM.RawBody()
 	if err != nil {
-		t.Errorf("failed extracting raw body from artifact: %v", err)
+		t.Fatalf("failed extracting raw body from artifact: %v", err)
 	}
 	artifactDigest := digest.FromBytes(artifactBody)
 	artifact2Annot := map[string]string{
@@ -149,11 +149,11 @@ func TestReferrer(t *testing.T) {
 	}
 	artifact2M, err := manifest.New(manifest.WithOrig(artifact2))
 	if err != nil {
-		t.Errorf("failed creating artifact manifest: %v", err)
+		t.Fatalf("failed creating artifact manifest: %v", err)
 	}
 	artifact2Body, err := artifact2M.RawBody()
 	if err != nil {
-		t.Errorf("failed extracting raw body from artifact: %v", err)
+		t.Fatalf("failed extracting raw body from artifact: %v", err)
 	}
 	artifact2Digest := digest.FromBytes(artifact2Body)
 	// empty response
@@ -163,7 +163,7 @@ func TestReferrer(t *testing.T) {
 	}
 	emptyBody, err := json.Marshal(emptyReply)
 	if err != nil {
-		t.Errorf("Failed to marshal manifest: %v", err)
+		t.Fatalf("Failed to marshal manifest: %v", err)
 	}
 	emptyDigest := digest.FromBytes(emptyBody)
 	emptyLen := len(emptyBody)
@@ -183,7 +183,7 @@ func TestReferrer(t *testing.T) {
 	}
 	replyABody, err := json.Marshal(replyA)
 	if err != nil {
-		t.Errorf("Failed to marshal manifest: %v", err)
+		t.Fatalf("Failed to marshal manifest: %v", err)
 	}
 	replyADig := digest.FromBytes(replyABody)
 	replyALen := len(replyABody)
@@ -203,7 +203,7 @@ func TestReferrer(t *testing.T) {
 	}
 	replyBBody, err := json.Marshal(replyB)
 	if err != nil {
-		t.Errorf("Failed to marshal manifest: %v", err)
+		t.Fatalf("Failed to marshal manifest: %v", err)
 	}
 	replyBDig := digest.FromBytes(replyBBody)
 	replyBLen := len(replyBBody)
@@ -230,7 +230,7 @@ func TestReferrer(t *testing.T) {
 	}
 	replyBothBody, err := json.Marshal(replyBoth)
 	if err != nil {
-		t.Errorf("Failed to marshal manifest: %v", err)
+		t.Fatalf("Failed to marshal manifest: %v", err)
 	}
 	replyBothDig := digest.FromBytes(replyBothBody)
 	replyBothLen := len(replyBothBody)
@@ -766,48 +766,40 @@ func TestReferrer(t *testing.T) {
 	t.Run("List empty NoAPI", func(t *testing.T) {
 		r, err := ref.New(tsURLNoAPI.Host + repoPath + ":" + tagV1)
 		if err != nil {
-			t.Errorf("Failed creating ref: %v", err)
-			return
+			t.Fatalf("Failed creating ref: %v", err)
 		}
 		rl, err := reg.ReferrerList(ctx, r)
 		if err != nil {
-			t.Errorf("Failed running ReferrerList: %v", err)
-			return
+			t.Fatalf("Failed running ReferrerList: %v", err)
 		}
 		if len(rl.Descriptors) > 0 {
-			t.Errorf("descriptors exist")
-			return
+			t.Fatalf("descriptors exist")
 		}
 	})
 	t.Run("List empty NoAPIAuth", func(t *testing.T) {
 		r, err := ref.New(tsURLNoAPIAuth.Host + repoPath + ":" + tagV1)
 		if err != nil {
-			t.Errorf("Failed creating ref: %v", err)
-			return
+			t.Fatalf("Failed creating ref: %v", err)
 		}
 		rl, err := reg.ReferrerList(ctx, r)
 		if err != nil {
-			t.Errorf("Failed running ReferrerList: %v", err)
-			return
+			t.Fatalf("Failed running ReferrerList: %v", err)
 		}
 		if len(rl.Descriptors) > 0 {
-			t.Errorf("descriptors exist")
-			return
+			t.Fatalf("descriptors exist")
 		}
 	})
 	t.Run("List empty API", func(t *testing.T) {
 		r, err := ref.New(tsURLAPI.Host + repoPath + ":" + tagV1)
 		if err != nil {
-			t.Errorf("Failed creating ref: %v", err)
+			t.Fatalf("Failed creating ref: %v", err)
 		}
 		rl, err := reg.ReferrerList(ctx, r)
 		if err != nil {
-			t.Errorf("Failed running ReferrerList: %v", err)
-			return
+			t.Fatalf("Failed running ReferrerList: %v", err)
 		}
 		if len(rl.Descriptors) > 0 {
-			t.Errorf("descriptors exist")
-			return
+			t.Fatalf("descriptors exist")
 		}
 	})
 
@@ -815,34 +807,31 @@ func TestReferrer(t *testing.T) {
 	t.Run("Put A NoAPI", func(t *testing.T) {
 		r, err := ref.New(tsURLNoAPI.Host + repoPath + "@" + artifactM.GetDescriptor().Digest.String())
 		if err != nil {
-			t.Errorf("Failed creating ref: %v", err)
+			t.Fatalf("Failed creating ref: %v", err)
 		}
 		err = reg.ManifestPut(ctx, r, artifactM)
 		if err != nil {
-			t.Errorf("Failed running ManifestPut: %v", err)
-			return
+			t.Fatalf("Failed running ManifestPut: %v", err)
 		}
 	})
 	t.Run("Put A NoAPIAuth", func(t *testing.T) {
 		r, err := ref.New(tsURLNoAPIAuth.Host + repoPath + "@" + artifactM.GetDescriptor().Digest.String())
 		if err != nil {
-			t.Errorf("Failed creating ref: %v", err)
+			t.Fatalf("Failed creating ref: %v", err)
 		}
 		err = reg.ManifestPut(ctx, r, artifactM)
 		if err != nil {
-			t.Errorf("Failed running ManifestPut: %v", err)
-			return
+			t.Fatalf("Failed running ManifestPut: %v", err)
 		}
 	})
 	t.Run("Put A API", func(t *testing.T) {
 		r, err := ref.New(tsURLAPI.Host + repoPath + "@" + artifactM.GetDescriptor().Digest.String())
 		if err != nil {
-			t.Errorf("Failed creating ref: %v", err)
+			t.Fatalf("Failed creating ref: %v", err)
 		}
 		err = reg.ManifestPut(ctx, r, artifactM)
 		if err != nil {
-			t.Errorf("Failed running ManifestPut: %v", err)
-			return
+			t.Fatalf("Failed running ManifestPut: %v", err)
 		}
 	})
 
@@ -850,17 +839,14 @@ func TestReferrer(t *testing.T) {
 	t.Run("List A NoAPI", func(t *testing.T) {
 		r, err := ref.New(tsURLNoAPI.Host + repoPath + ":" + tagV1)
 		if err != nil {
-			t.Errorf("Failed creating ref: %v", err)
-			return
+			t.Fatalf("Failed creating ref: %v", err)
 		}
 		rl, err := reg.ReferrerList(ctx, r)
 		if err != nil {
-			t.Errorf("Failed running ReferrerList: %v", err)
-			return
+			t.Fatalf("Failed running ReferrerList: %v", err)
 		}
 		if len(rl.Descriptors) < 1 {
-			t.Errorf("descriptor list missing")
-			return
+			t.Fatalf("descriptor list missing")
 		}
 		if rl.Descriptors[0].MediaType != types.MediaTypeOCI1Manifest ||
 			rl.Descriptors[0].Size != int64(len(artifactBody)) ||
@@ -875,17 +861,14 @@ func TestReferrer(t *testing.T) {
 	t.Run("List A NoAPIAuth", func(t *testing.T) {
 		r, err := ref.New(tsURLNoAPIAuth.Host + repoPath + ":" + tagV1)
 		if err != nil {
-			t.Errorf("Failed creating ref: %v", err)
-			return
+			t.Fatalf("Failed creating ref: %v", err)
 		}
 		rl, err := reg.ReferrerList(ctx, r)
 		if err != nil {
-			t.Errorf("Failed running ReferrerList: %v", err)
-			return
+			t.Fatalf("Failed running ReferrerList: %v", err)
 		}
 		if len(rl.Descriptors) < 1 {
-			t.Errorf("descriptor list missing")
-			return
+			t.Fatalf("descriptor list missing")
 		}
 		if rl.Descriptors[0].MediaType != types.MediaTypeOCI1Manifest ||
 			rl.Descriptors[0].Size != int64(len(artifactBody)) ||
@@ -900,16 +883,14 @@ func TestReferrer(t *testing.T) {
 	t.Run("List A API", func(t *testing.T) {
 		r, err := ref.New(tsURLAPI.Host + repoPath + ":" + tagV1)
 		if err != nil {
-			t.Errorf("Failed creating ref: %v", err)
+			t.Fatalf("Failed creating ref: %v", err)
 		}
 		rl, err := reg.ReferrerList(ctx, r)
 		if err != nil {
-			t.Errorf("Failed running ReferrerList: %v", err)
-			return
+			t.Fatalf("Failed running ReferrerList: %v", err)
 		}
 		if len(rl.Descriptors) < 1 {
-			t.Errorf("descriptor list missing")
-			return
+			t.Fatalf("descriptor list missing")
 		}
 		if rl.Descriptors[0].MediaType != types.MediaTypeOCI1Manifest ||
 			rl.Descriptors[0].Size != int64(len(artifactBody)) ||
@@ -926,23 +907,21 @@ func TestReferrer(t *testing.T) {
 	t.Run("Put B NoAPI", func(t *testing.T) {
 		r, err := ref.New(tsURLNoAPI.Host + repoPath + "@" + artifact2M.GetDescriptor().Digest.String())
 		if err != nil {
-			t.Errorf("Failed creating ref: %v", err)
+			t.Fatalf("Failed creating ref: %v", err)
 		}
 		err = reg.ManifestPut(ctx, r, artifact2M)
 		if err != nil {
-			t.Errorf("Failed running ManifestPut: %v", err)
-			return
+			t.Fatalf("Failed running ManifestPut: %v", err)
 		}
 	})
 	t.Run("Put B API", func(t *testing.T) {
 		r, err := ref.New(tsURLAPI.Host + repoPath + "@" + artifact2M.GetDescriptor().Digest.String())
 		if err != nil {
-			t.Errorf("Failed creating ref: %v", err)
+			t.Fatalf("Failed creating ref: %v", err)
 		}
 		err = reg.ManifestPut(ctx, r, artifact2M)
 		if err != nil {
-			t.Errorf("Failed running ManifestPut: %v", err)
-			return
+			t.Fatalf("Failed running ManifestPut: %v", err)
 		}
 	})
 
@@ -950,17 +929,14 @@ func TestReferrer(t *testing.T) {
 	t.Run("List Both NoAPI", func(t *testing.T) {
 		r, err := ref.New(tsURLNoAPI.Host + repoPath + ":" + tagV1)
 		if err != nil {
-			t.Errorf("Failed creating ref: %v", err)
-			return
+			t.Fatalf("Failed creating ref: %v", err)
 		}
 		rl, err := reg.ReferrerList(ctx, r)
 		if err != nil {
-			t.Errorf("Failed running ReferrerList: %v", err)
-			return
+			t.Fatalf("Failed running ReferrerList: %v", err)
 		}
 		if len(rl.Descriptors) != 2 {
-			t.Errorf("descriptor list expected 2, received %d", len(rl.Descriptors))
-			return
+			t.Fatalf("descriptor list expected 2, received %d", len(rl.Descriptors))
 		}
 		if rl.Descriptors[0].MediaType != types.MediaTypeOCI1Manifest ||
 			rl.Descriptors[0].Size != int64(len(artifactBody)) ||
@@ -983,16 +959,14 @@ func TestReferrer(t *testing.T) {
 	t.Run("List Both API", func(t *testing.T) {
 		r, err := ref.New(tsURLAPI.Host + repoPath + ":" + tagV1)
 		if err != nil {
-			t.Errorf("Failed creating ref: %v", err)
+			t.Fatalf("Failed creating ref: %v", err)
 		}
 		rl, err := reg.ReferrerList(ctx, r)
 		if err != nil {
-			t.Errorf("Failed running ReferrerList: %v", err)
-			return
+			t.Fatalf("Failed running ReferrerList: %v", err)
 		}
 		if len(rl.Descriptors) != 2 {
-			t.Errorf("descriptor list expected 2, received %d", len(rl.Descriptors))
-			return
+			t.Fatalf("descriptor list expected 2, received %d", len(rl.Descriptors))
 		}
 		if rl.Descriptors[0].MediaType != types.MediaTypeOCI1Manifest ||
 			rl.Descriptors[0].Size != int64(len(artifactBody)) ||
@@ -1016,77 +990,62 @@ func TestReferrer(t *testing.T) {
 	t.Run("List with artifact filter API", func(t *testing.T) {
 		r, err := ref.New(tsURLAPI.Host + repoPath + ":" + tagV1)
 		if err != nil {
-			t.Errorf("Failed creating ref: %v", err)
-			return
+			t.Fatalf("Failed creating ref: %v", err)
 		}
 		rl, err := reg.ReferrerList(ctx, r, scheme.WithReferrerMatchOpt(types.MatchOpt{ArtifactType: configMTA}))
 		if err != nil {
-			t.Errorf("Failed running ReferrerList: %v", err)
-			return
+			t.Fatalf("Failed running ReferrerList: %v", err)
 		}
 		if len(rl.Descriptors) != 1 {
-			t.Errorf("descriptor list mismatch: %v", rl.Descriptors)
-			return
+			t.Fatalf("descriptor list mismatch: %v", rl.Descriptors)
 		}
 		rl, err = reg.ReferrerList(ctx, r, scheme.WithReferrerMatchOpt(types.MatchOpt{ArtifactType: "application/vnd.example.unknown"}))
 		if err != nil {
-			t.Errorf("Failed running ReferrerList: %v", err)
-			return
+			t.Fatalf("Failed running ReferrerList: %v", err)
 		}
 		if len(rl.Descriptors) > 0 {
-			t.Errorf("unexpected descriptors: %v", rl.Descriptors)
-			return
+			t.Fatalf("unexpected descriptors: %v", rl.Descriptors)
 		}
 	})
 	t.Run("List with annotation filter", func(t *testing.T) {
 		r, err := ref.New(tsURLAPI.Host + repoPath + ":" + tagV1)
 		if err != nil {
-			t.Errorf("Failed creating ref: %v", err)
-			return
+			t.Fatalf("Failed creating ref: %v", err)
 		}
 		rl, err := reg.ReferrerList(ctx, r, scheme.WithReferrerMatchOpt(types.MatchOpt{Annotations: map[string]string{extraAnnot: extraValue2}}))
 		if err != nil {
-			t.Errorf("Failed running ReferrerList: %v", err)
-			return
+			t.Fatalf("Failed running ReferrerList: %v", err)
 		}
 		if len(rl.Descriptors) != 1 {
-			t.Errorf("descriptor list mismatch: %v", rl.Descriptors)
-			return
+			t.Fatalf("descriptor list mismatch: %v", rl.Descriptors)
 		}
 		rl, err = reg.ReferrerList(ctx, r, scheme.WithReferrerMatchOpt(types.MatchOpt{Annotations: map[string]string{extraAnnot: "unknown value"}}))
 		if err != nil {
-			t.Errorf("Failed running ReferrerList: %v", err)
-			return
+			t.Fatalf("Failed running ReferrerList: %v", err)
 		}
 		if len(rl.Descriptors) > 0 {
-			t.Errorf("unexpected descriptors: %v", rl.Descriptors)
-			return
+			t.Fatalf("unexpected descriptors: %v", rl.Descriptors)
 		}
 		rl, err = reg.ReferrerList(ctx, r, scheme.WithReferrerMatchOpt(types.MatchOpt{Annotations: map[string]string{extraAnnot: ""}}))
 		if err != nil {
-			t.Errorf("Failed running ReferrerList: %v", err)
-			return
+			t.Fatalf("Failed running ReferrerList: %v", err)
 		}
 		if len(rl.Descriptors) != 2 {
-			t.Errorf("descriptor list mismatch: %v", rl.Descriptors)
-			return
+			t.Fatalf("descriptor list mismatch: %v", rl.Descriptors)
 		}
 	})
 
 	t.Run("List for platform", func(t *testing.T) {
 		r, err := ref.New(tsURLAPI.Host + repoPath + ":" + tagV1List)
 		if err != nil {
-			t.Errorf("Failed creating ref: %v", err)
-			return
+			t.Fatalf("Failed creating ref: %v", err)
 		}
 		rl, err := reg.ReferrerList(ctx, r, scheme.WithReferrerPlatform(platStr))
 		if err != nil {
-			t.Errorf("Failed running ReferrerList: %v", err)
-			return
+			t.Fatalf("Failed running ReferrerList: %v", err)
 		}
 		if len(rl.Descriptors) != 2 {
-			t.Errorf("descriptor list expected 2, received %d", len(rl.Descriptors))
-			return
+			t.Fatalf("descriptor list expected 2, received %d", len(rl.Descriptors))
 		}
 	})
 
@@ -1094,46 +1053,42 @@ func TestReferrer(t *testing.T) {
 	t.Run("Delete B NoAPI", func(t *testing.T) {
 		r, err := ref.New(tsURLNoAPI.Host + repoPath + "@" + artifact2M.GetDescriptor().Digest.String())
 		if err != nil {
-			t.Errorf("Failed creating ref: %v", err)
+			t.Fatalf("Failed creating ref: %v", err)
 		}
 		err = reg.ManifestDelete(ctx, r, scheme.WithManifestCheckReferrers())
 		if err != nil {
-			t.Errorf("Failed running ManifestDelete: %v", err)
-			return
+			t.Fatalf("Failed running ManifestDelete: %v", err)
 		}
 	})
 	t.Run("Delete B API", func(t *testing.T) {
 		r, err := ref.New(tsURLAPI.Host + repoPath + "@" + artifact2M.GetDescriptor().Digest.String())
 		if err != nil {
-			t.Errorf("Failed creating ref: %v", err)
+			t.Fatalf("Failed creating ref: %v", err)
 		}
 		err = reg.ManifestDelete(ctx, r, scheme.WithManifestCheckReferrers())
 		if err != nil {
-			t.Errorf("Failed running ManifestDelete: %v", err)
-			return
+			t.Fatalf("Failed running ManifestDelete: %v", err)
 		}
 	})
 
 	t.Run("Delete A NoAPI", func(t *testing.T) {
 		r, err := ref.New(tsURLNoAPI.Host + repoPath + "@" + artifactM.GetDescriptor().Digest.String())
 		if err != nil {
-			t.Errorf("Failed creating ref: %v", err)
+			t.Fatalf("Failed creating ref: %v", err)
 		}
 		err = reg.ManifestDelete(ctx, r, scheme.WithManifest(artifactM))
 		if err != nil {
-			t.Errorf("Failed running ManifestDelete: %v", err)
-			return
+			t.Fatalf("Failed running ManifestDelete: %v", err)
 		}
 	})
 	t.Run("Delete A API", func(t *testing.T) {
 		r, err := ref.New(tsURLAPI.Host + repoPath + "@" + artifactM.GetDescriptor().Digest.String())
 		if err != nil {
-			t.Errorf("Failed creating ref: %v", err)
+			t.Fatalf("Failed creating ref: %v", err)
 		}
 		err = reg.ManifestDelete(ctx, r, scheme.WithManifest(artifactM))
 		if err != nil {
-			t.Errorf("Failed running ManifestDelete: %v", err)
-			return
+			t.Fatalf("Failed running ManifestDelete: %v", err)
 		}
 	})
 
@@ -1141,32 +1096,27 @@ func TestReferrer(t *testing.T) {
 	t.Run("List empty after delete NoAPI", func(t *testing.T) {
 		r, err := ref.New(tsURLNoAPI.Host + repoPath + ":" + tagV1)
 		if err != nil {
-			t.Errorf("Failed creating ref: %v", err)
-			return
+			t.Fatalf("Failed creating ref: %v", err)
 		}
 		rl, err := reg.ReferrerList(ctx, r)
 		if err != nil {
-			t.Errorf("Failed running ReferrerList: %v", err)
-			return
+			t.Fatalf("Failed running ReferrerList: %v", err)
 		}
 		if len(rl.Descriptors) > 0 {
-			t.Errorf("descriptors exist")
-			return
+			t.Fatalf("descriptors exist")
 		}
 	})
 	t.Run("List empty after delete API", func(t *testing.T) {
 		r, err := ref.New(tsURLAPI.Host + repoPath + ":" + tagV1)
 		if err != nil {
-			t.Errorf("Failed creating ref: %v", err)
+			t.Fatalf("Failed creating ref: %v", err)
 		}
 		rl, err := reg.ReferrerList(ctx, r)
 		if err != nil {
-			t.Errorf("Failed running ReferrerList: %v", err)
-			return
+			t.Fatalf("Failed running ReferrerList: %v", err)
 		}
 		if len(rl.Descriptors) > 0 {
-			t.Errorf("descriptors exist")
-			return
+			t.Fatalf("descriptors exist")
 		}
 	})
 }

--- a/scheme/reg/repo_test.go
+++ b/scheme/reg/repo_test.go
@@ -169,8 +169,7 @@ func TestRepo(t *testing.T) {
 		host := u.Host
 		rl, err := reg.RepoList(ctx, host)
 		if err != nil {
-			t.Errorf("error listing repos: %v", err)
-			return
+			t.Fatalf("error listing repos: %v", err)
 		}
 		rlRepos, err := rl.GetRepos()
 		if err != nil {
@@ -185,8 +184,7 @@ func TestRepo(t *testing.T) {
 		host := u.Host
 		rl, err := reg.RepoList(ctx, host)
 		if err != nil {
-			t.Errorf("error listing repos: %v", err)
-			return
+			t.Fatalf("error listing repos: %v", err)
 		}
 		rlRepos, err := rl.GetRepos()
 		if err != nil {
@@ -201,8 +199,7 @@ func TestRepo(t *testing.T) {
 		host := u.Host
 		rl, err := reg.RepoList(ctx, host, scheme.WithRepoLimit(partialLen))
 		if err != nil {
-			t.Errorf("error listing repos: %v", err)
-			return
+			t.Fatalf("error listing repos: %v", err)
 		}
 		rlRepos, err := rl.GetRepos()
 		if err != nil {
@@ -213,8 +210,7 @@ func TestRepo(t *testing.T) {
 
 		rl, err = reg.RepoList(ctx, host, scheme.WithRepoLast(rlRepos[len(rlRepos)-1]))
 		if err != nil {
-			t.Errorf("error listing repos: %v", err)
-			return
+			t.Fatalf("error listing repos: %v", err)
 		}
 		rlRepos, err = rl.GetRepos()
 		if err != nil {
@@ -261,8 +257,7 @@ func TestRepo(t *testing.T) {
 		host := u.Host
 		rl, err := reg.RepoList(ctx, host+"/path")
 		if err != nil {
-			t.Errorf("error listing repos: %v", err)
-			return
+			t.Fatalf("error listing repos: %v", err)
 		}
 		rlRepos, err := rl.GetRepos()
 		if err != nil {

--- a/scheme/reg/tag_test.go
+++ b/scheme/reg/tag_test.go
@@ -269,18 +269,16 @@ func TestTag(t *testing.T) {
 	t.Run("List", func(t *testing.T) {
 		listRef, err := ref.New(tsURL.Host + repoPath)
 		if err != nil {
-			t.Errorf("failed creating getRef: %v", err)
+			t.Fatalf("failed creating getRef: %v", err)
 		}
 
 		tl, err := reg.TagList(ctx, listRef)
 		if err != nil {
-			t.Errorf("failed to list tags: %v", err)
-			return
+			t.Fatalf("failed to list tags: %v", err)
 		}
 		tags, err := tl.GetTags()
 		if err != nil {
-			t.Errorf("failed to extract tag list: %v", err)
-			return
+			t.Fatalf("failed to extract tag list: %v", err)
 		}
 		if !stringSliceCmp(tags, listTagList) {
 			t.Errorf("returned list mismatch, expected %v, received %v", listTagList, tags)
@@ -290,19 +288,17 @@ func TestTag(t *testing.T) {
 	t.Run("Pagination", func(t *testing.T) {
 		listRef, err := ref.New(tsURL.Host + repoPath)
 		if err != nil {
-			t.Errorf("failed creating getRef: %v", err)
+			t.Fatalf("failed creating getRef: %v", err)
 		}
 		// page 1
 		tl, err := reg.TagList(ctx, listRef,
 			scheme.WithTagLimit(pageLen))
 		if err != nil {
-			t.Errorf("failed to list tags: %v", err)
-			return
+			t.Fatalf("failed to list tags: %v", err)
 		}
 		tags, err := tl.GetTags()
 		if err != nil {
-			t.Errorf("failed to extract tag list: %v", err)
-			return
+			t.Fatalf("failed to extract tag list: %v", err)
 		}
 		if !stringSliceCmp(tags, listTagList[:pageLen]) {
 			t.Errorf("returned list mismatch, expected %v, received %v", listTagList[:pageLen], tags)
@@ -313,13 +309,11 @@ func TestTag(t *testing.T) {
 			scheme.WithTagLimit(pageLen),
 			scheme.WithTagLast(tags[len(tags)-1]))
 		if err != nil {
-			t.Errorf("failed to list tags: %v", err)
-			return
+			t.Fatalf("failed to list tags: %v", err)
 		}
 		tags, err = tl.GetTags()
 		if err != nil {
-			t.Errorf("failed to extract tag list: %v", err)
-			return
+			t.Fatalf("failed to extract tag list: %v", err)
 		}
 		if !stringSliceCmp(tags, listTagList[pageLen:]) {
 			t.Errorf("returned list mismatch, expected %v, received %v", listTagList[:pageLen], tags)
@@ -329,18 +323,16 @@ func TestTag(t *testing.T) {
 	t.Run("Pagination automatic", func(t *testing.T) {
 		listRef, err := ref.New(tsURL.Host + repoPath2)
 		if err != nil {
-			t.Errorf("failed creating getRef: %v", err)
+			t.Fatalf("failed creating getRef: %v", err)
 		}
 		// page 1
 		tl, err := reg.TagList(ctx, listRef)
 		if err != nil {
-			t.Errorf("failed to list tags: %v", err)
-			return
+			t.Fatalf("failed to list tags: %v", err)
 		}
 		tags, err := tl.GetTags()
 		if err != nil {
-			t.Errorf("failed to extract tag list: %v", err)
-			return
+			t.Fatalf("failed to extract tag list: %v", err)
 		}
 		if !stringSliceCmp(tags, listTagList) {
 			t.Errorf("returned list mismatch, expected %v, received %v", listTagList, tags)
@@ -350,15 +342,13 @@ func TestTag(t *testing.T) {
 	t.Run("Missing", func(t *testing.T) {
 		listRef, err := ref.New(tsURL.Host + missingRepo)
 		if err != nil {
-			t.Errorf("failed creating getRef: %v", err)
+			t.Fatalf("failed creating getRef: %v", err)
 		}
 		_, err = reg.TagList(ctx, listRef)
 		if err == nil {
-			t.Errorf("tag listing succeeded on missing repo")
-			return
+			t.Fatalf("tag listing succeeded on missing repo")
 		} else if !errors.Is(err, types.ErrNotFound) {
-			t.Errorf("unexpected error: expected %v, received %v", types.ErrNotFound, err)
-			return
+			t.Fatalf("unexpected error: expected %v, received %v", types.ErrNotFound, err)
 		}
 	})
 
@@ -370,8 +360,7 @@ func TestTag(t *testing.T) {
 		}
 		err = reg.TagDelete(ctx, delRef)
 		if err != nil {
-			t.Errorf("failed to delete tag: %v", err)
-			return
+			t.Fatalf("failed to delete tag: %v", err)
 		}
 	})
 
@@ -383,8 +372,7 @@ func TestTag(t *testing.T) {
 		}
 		err = reg.TagDelete(ctx, delRef)
 		if err != nil {
-			t.Errorf("failed to delete tag: %v", err)
-			return
+			t.Fatalf("failed to delete tag: %v", err)
 		}
 	})
 }

--- a/tag_test.go
+++ b/tag_test.go
@@ -81,8 +81,7 @@ func TestTag(t *testing.T) {
 	tempDir := t.TempDir()
 	err := copy.Copy(tempDir+"/"+existingRepo, "./testdata/"+existingRepo)
 	if err != nil {
-		t.Errorf("failed to copy %s to tempDir: %v", existingRepo, err)
-		return
+		t.Fatalf("failed to copy %s to tempDir: %v", existingRepo, err)
 	}
 	tt := []struct {
 		name           string
@@ -107,22 +106,18 @@ func TestTag(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			r, err := ref.New(tc.repo)
 			if err != nil {
-				t.Errorf("failed to parse ref %s: %v", tc.repo, err)
-				return
+				t.Fatalf("failed to parse ref %s: %v", tc.repo, err)
 			}
 			tl, err := rc.TagList(ctx, r)
 			if err != nil {
-				t.Errorf("failed to list tags: %v", err)
-				return
+				t.Fatalf("failed to list tags: %v", err)
 			}
 			if len(tl.Tags) == 0 {
-				t.Errorf("failed to get tags: %v", tl)
-				return
+				t.Fatalf("failed to get tags: %v", tl)
 			}
 			rDel, err := ref.New(tc.repo + ":" + existingTag)
 			if err != nil {
-				t.Errorf("failed to parse ref %s: %v", tc.repo+":"+existingTag, err)
-				return
+				t.Fatalf("failed to parse ref %s: %v", tc.repo+":"+existingTag, err)
 			}
 			err = rc.TagDelete(ctx, rDel)
 			if tc.deleteDisabled {

--- a/types/blob/blob_test.go
+++ b/types/blob/blob_test.go
@@ -191,8 +191,7 @@ func TestCommon(t *testing.T) {
 					return
 				}
 				if err != nil {
-					t.Errorf("rawbody: %v", err)
-					return
+					t.Fatalf("rawbody: %v", err)
 				}
 				if !bytes.Equal(bb, tc.eBytes) {
 					t.Errorf("rawbody, expected %s, received %s", string(tc.eBytes), string(bb))
@@ -233,8 +232,7 @@ func TestReader(t *testing.T) {
 		// test read, expect error
 		_, err := b.RawBody()
 		if err == nil {
-			t.Errorf("unexpected success")
-			return
+			t.Fatalf("unexpected success")
 		}
 		if !errors.Is(err, io.ErrUnexpectedEOF) {
 			t.Errorf("unexpected err from rawbody: %v", err)
@@ -252,8 +250,7 @@ func TestReader(t *testing.T) {
 		bb := make([]byte, bl)
 		i, err := b.Read(bb)
 		if err != nil {
-			t.Errorf("read err: %v", err)
-			return
+			t.Fatalf("read err: %v", err)
 		}
 		if i != bl {
 			t.Errorf("read length, expected %d, received %d", bl, i)
@@ -264,16 +261,14 @@ func TestReader(t *testing.T) {
 		}
 		pos, err := b.Seek(0, io.SeekStart)
 		if err != nil {
-			t.Errorf("seek err: %v", err)
-			return
+			t.Fatalf("seek err: %v", err)
 		}
 		if pos != 0 {
 			t.Errorf("seek pos, expected 0, received %d", pos)
 		}
 		_, err = io.ReadAll(b)
 		if err != nil {
-			t.Errorf("readall: %v", err)
-			return
+			t.Fatalf("readall: %v", err)
 		}
 		if b.GetDescriptor().Digest != exDigest {
 			t.Errorf("digest mismatch, expected %s, received %s", exDigest, b.GetDescriptor().Digest)
@@ -288,21 +283,18 @@ func TestReader(t *testing.T) {
 		)
 		i, err = b.Read(bb)
 		if err != nil {
-			t.Errorf("read err: %v", err)
-			return
+			t.Fatalf("read err: %v", err)
 		}
 		if i != bl {
 			t.Errorf("read length, expected %d, received %d", bl, i)
 		}
 		_, err = b.Seek(0, io.SeekStart)
 		if err != nil {
-			t.Errorf("seek err: %v", err)
-			return
+			t.Fatalf("seek err: %v", err)
 		}
 		_, err = io.ReadAll(b)
 		if err == nil {
-			t.Errorf("readall did not fail")
-			return
+			t.Fatalf("readall did not fail")
 		}
 		if !errors.Is(err, types.ErrSizeLimitExceeded) {
 			t.Errorf("unexpected error on readall, expected %v, received %v", types.ErrSizeLimitExceeded, err)
@@ -323,16 +315,14 @@ func TestReader(t *testing.T) {
 		// test ToOCIConfig on blob 2
 		oc, err := b.ToOCIConfig()
 		if err != nil {
-			t.Errorf("ToOCIConfig: %v", err)
-			return
+			t.Fatalf("ToOCIConfig: %v", err)
 		}
 		if exDigest != oc.GetDescriptor().Digest {
 			t.Errorf("digest, expected %s, received %s", exDigest, oc.GetDescriptor().Digest)
 		}
 		ocb, err := oc.RawBody()
 		if err != nil {
-			t.Errorf("config rawbody: %v", err)
-			return
+			t.Fatalf("config rawbody: %v", err)
 		}
 		if !bytes.Equal(exBlob, ocb) {
 			t.Errorf("config bytes, expected %s, received %s", string(exBlob), string(ocb))
@@ -347,8 +337,7 @@ func TestReader(t *testing.T) {
 		// test RawBytes on blob 3
 		bb, err := b.RawBody()
 		if err != nil {
-			t.Errorf("rawbody: %v", err)
-			return
+			t.Fatalf("rawbody: %v", err)
 		}
 		if !bytes.Equal(exBlob, bb) {
 			t.Errorf("config bytes, expected %s, received %s", string(exBlob), string(bb))
@@ -360,8 +349,7 @@ func TestOCI(t *testing.T) {
 	ociConfig := v1.Image{}
 	err := json.Unmarshal(exBlob, &ociConfig)
 	if err != nil {
-		t.Errorf("failed to unmarshal exBlob: %v", err)
-		return
+		t.Fatalf("failed to unmarshal exBlob: %v", err)
 	}
 	tt := []struct {
 		name     string
@@ -483,14 +471,12 @@ func TestOCI(t *testing.T) {
 func TestTarReader(t *testing.T) {
 	fh, err := os.Open(fileLayer)
 	if err != nil {
-		t.Errorf("failed to open test data: %v", err)
-		return
+		t.Fatalf("failed to open test data: %v", err)
 	}
 	digger := digest.Canonical.Digester()
 	fhSize, err := io.Copy(digger.Hash(), fh)
 	if err != nil {
-		t.Errorf("failed to build digest on test data: %v", err)
-		return
+		t.Fatalf("failed to build digest on test data: %v", err)
 	}
 	fh.Close()
 	dig := digger.Digest()
@@ -530,22 +516,19 @@ func TestTarReader(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			fh, err := os.Open(fileLayer)
 			if err != nil {
-				t.Errorf("failed to open test data: %v", err)
-				return
+				t.Fatalf("failed to open test data: %v", err)
 			}
 			opts := append(tc.opts, WithReader(fh))
 			btr := NewTarReader(opts...)
 			tr, err := btr.GetTarReader()
 			if err != nil {
-				t.Errorf("failed to get tar reader: %v", err)
-				return
+				t.Fatalf("failed to get tar reader: %v", err)
 			}
 			for {
 				th, err := tr.Next()
 				if err != nil {
 					if err != io.EOF {
-						t.Errorf("failed to read tar: %v", err)
-						return
+						t.Fatalf("failed to read tar: %v", err)
 					}
 					break
 				}
@@ -615,18 +598,17 @@ func TestReadFile(t *testing.T) {
 	}
 	fileBytes, err := os.ReadFile(fileLayerWH)
 	if err != nil {
-		t.Errorf("failed to open test data: %v", err)
-		return
+		t.Fatalf("failed to open test data: %v", err)
 	}
 	blobDigest := digest.FromBytes(fileBytes)
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			fh, err := os.Open(fileLayerWH)
 			if err != nil {
-				t.Errorf("failed to open test data: %v", err)
-				return
+				t.Fatalf("failed to open test data: %v", err)
 			}
 			btr := NewTarReader(WithReader(fh), WithDesc(types.Descriptor{Size: int64(len(fileBytes)), Digest: blobDigest, MediaType: types.MediaTypeOCI1Layer}))
+			defer btr.Close()
 			th, rdr, err := btr.ReadFile(tc.filename)
 			if tc.expectErr != nil {
 				if err == nil {
@@ -641,19 +623,13 @@ func TestReadFile(t *testing.T) {
 				return
 			}
 			if err != nil {
-				t.Errorf("ReadFile failed: %v", err)
-				btr.Close()
-				return
+				t.Fatalf("ReadFile failed: %v", err)
 			}
 			if th == nil {
-				t.Errorf("tar header is nil")
-				btr.Close()
-				return
+				t.Fatalf("tar header is nil")
 			}
 			if rdr == nil {
-				t.Errorf("reader is nil")
-				btr.Close()
-				return
+				t.Fatalf("reader is nil")
 			}
 			content, err := io.ReadAll(rdr)
 			if err != nil {
@@ -671,8 +647,7 @@ func TestReadFile(t *testing.T) {
 	t.Run("bad digest", func(t *testing.T) {
 		fh, err := os.Open(fileLayerWH)
 		if err != nil {
-			t.Errorf("failed to open test data: %v", err)
-			return
+			t.Fatalf("failed to open test data: %v", err)
 		}
 		btr := NewTarReader(WithReader(fh), WithDesc(types.Descriptor{Size: int64(len(fileBytes)), Digest: digest.FromString("bad digest"), MediaType: types.MediaTypeOCI1Layer}))
 		_, _, err = btr.ReadFile("missing.txt")

--- a/types/descriptor_test.go
+++ b/types/descriptor_test.go
@@ -526,8 +526,7 @@ func TestDataJSON(t *testing.T) {
 				return
 			}
 			if err != nil {
-				t.Errorf("received error %v", err)
-				return
+				t.Fatalf("received error %v", err)
 			}
 			if !bytes.Equal(out, tt.wantData) {
 				t.Errorf("data mismatch, expected %s, received %s", string(tt.wantData), string(out))
@@ -777,8 +776,7 @@ func TestDescriptorSearch(t *testing.T) {
 				return
 			}
 			if err != nil {
-				t.Errorf("unexpected error, received %v", err)
-				return
+				t.Fatalf("unexpected error, received %v", err)
 			}
 			if !tc.expect.Equal(result) {
 				t.Errorf("unexpected result, expected %v, received %v", tc.expect, result)

--- a/types/manifest/manifest_test.go
+++ b/types/manifest/manifest_test.go
@@ -912,8 +912,7 @@ func TestNew(t *testing.T) {
 				return
 			}
 			if err != nil {
-				t.Errorf("failed running New: %v", err)
-				return
+				t.Fatalf("failed running New: %v", err)
 			}
 			// MarshalPretty succeeds even if manifest is not set (it shows available metadata)
 			if mp, ok := m.(interface{ MarshalPretty() ([]byte, error) }); ok {
@@ -1171,39 +1170,33 @@ func TestModify(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			m, err := New(tt.opts...)
 			if err != nil {
-				t.Errorf("error creating manifest: %v", err)
-				return
+				t.Fatalf("error creating manifest: %v", err)
 			}
 			orig := m.GetOrig()
 			if m.IsList() {
 				ociI, err := OCIIndexFromAny(orig)
 				if err != nil {
-					t.Errorf("error converting to index: %v", err)
-					return
+					t.Fatalf("error converting to index: %v", err)
 				}
 				ociI.Manifests = append(ociI.Manifests, tt.addDesc)
 				err = OCIIndexToAny(ociI, &orig)
 				if err != nil {
-					t.Errorf("error converting back to orig: %v", err)
-					return
+					t.Fatalf("error converting back to orig: %v", err)
 				}
 			} else {
 				ociM, err := OCIManifestFromAny(orig)
 				if err != nil {
-					t.Errorf("error converting to index: %v", err)
-					return
+					t.Fatalf("error converting to index: %v", err)
 				}
 				ociM.Layers = append(ociM.Layers, tt.addDesc)
 				err = OCIManifestToAny(ociM, &orig)
 				if err != nil {
-					t.Errorf("error converting back to orig: %v", err)
-					return
+					t.Fatalf("error converting back to orig: %v", err)
 				}
 			}
 			err = m.SetOrig(orig)
 			if err != nil {
-				t.Errorf("error setting orig: %v", err)
-				return
+				t.Fatalf("error setting orig: %v", err)
 			}
 			raw, _ := m.RawBody()
 			t.Logf("raw manifest: %s", string(raw))
@@ -1224,23 +1217,19 @@ func TestModify(t *testing.T) {
 	var manifestOCIIndex v1.Index
 	err := json.Unmarshal(rawDockerSchema2, &manifestDockerSchema2)
 	if err != nil {
-		t.Errorf("failed to unmarshal docker schema2 json: %v", err)
-		return
+		t.Fatalf("failed to unmarshal docker schema2 json: %v", err)
 	}
 	err = json.Unmarshal(rawDockerSchema2List, &manifestDockerSchema2List)
 	if err != nil {
-		t.Errorf("failed to unmarshal docker schema2 list json: %v", err)
-		return
+		t.Fatalf("failed to unmarshal docker schema2 list json: %v", err)
 	}
 	err = json.Unmarshal(rawOCIImage, &manifestOCIImage)
 	if err != nil {
-		t.Errorf("failed to unmarshal OCI image json: %v", err)
-		return
+		t.Fatalf("failed to unmarshal OCI image json: %v", err)
 	}
 	err = json.Unmarshal(rawOCIIndex, &manifestOCIIndex)
 	if err != nil {
-		t.Errorf("failed to unmarshal OCI index json: %v", err)
-		return
+		t.Fatalf("failed to unmarshal OCI index json: %v", err)
 	}
 	if manifestDockerSchema2.Annotations == nil || manifestDockerSchema2.Annotations["org.example.test"] != "hello world" {
 		t.Errorf("annotation missing from docker manifest")
@@ -1400,8 +1389,7 @@ func TestSet(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			m, err := New(tt.opts...)
 			if err != nil {
-				t.Errorf("error creating manifest: %v", err)
-				return
+				t.Fatalf("error creating manifest: %v", err)
 			}
 			if mi, ok := m.(Imager); ok {
 				if !tt.expectImage {

--- a/types/platform/platform_test.go
+++ b/types/platform/platform_test.go
@@ -164,8 +164,7 @@ func TestPlatformParse(t *testing.T) {
 				return
 			}
 			if err != nil {
-				t.Errorf("unexpected error: %v", err)
-				return
+				t.Fatalf("unexpected error: %v", err)
 			}
 			if !Match(p, tt.goal) {
 				t.Errorf("platform did not match, want %v, received %v", tt.goal, p)

--- a/types/ref/ref_test.go
+++ b/types/ref/ref_test.go
@@ -396,8 +396,7 @@ func TestNew(t *testing.T) {
 				}
 				return
 			} else if err != nil {
-				t.Errorf("failed creating reference, err: %v", err)
-				return
+				t.Fatalf("failed creating reference, err: %v", err)
 			}
 			if tc.ref != r.Reference {
 				t.Errorf("reference mismatch for %s, received %s", tc.ref, r.Reference)
@@ -592,8 +591,7 @@ func TestNewHost(t *testing.T) {
 				}
 				return
 			} else if err != nil {
-				t.Errorf("failed creating reference, err: %v", err)
-				return
+				t.Fatalf("failed creating reference, err: %v", err)
 			}
 			if r.Scheme == "reg" && r.IsSet() {
 				t.Errorf("isSet unexpected for %s, expected %t, received %t", tc.host, false, r.IsSet())
@@ -638,8 +636,7 @@ func TestCommon(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			r, err := New(tc.str)
 			if err != nil {
-				t.Errorf("failed to parse %s: %v", tc.str, err)
-				return
+				t.Fatalf("failed to parse %s: %v", tc.str, err)
 			}
 			cn := r.CommonName()
 			if tc.str != cn {
@@ -901,8 +898,7 @@ func TestSet(t *testing.T) {
 	rTagStr := "example.com/repo:v2"
 	r, err := New(rStr)
 	if err != nil {
-		t.Errorf("unexpected parse failure: %v", err)
-		return
+		t.Fatalf("unexpected parse failure: %v", err)
 	}
 	r = r.SetDigest(testDigest)
 	if r.Tag != "" {
@@ -958,8 +954,7 @@ func TestToReg(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			r, err := New(tc.inRef)
 			if err != nil {
-				t.Errorf("failed parsing input ref: %v", err)
-				return
+				t.Fatalf("failed parsing input ref: %v", err)
 			}
 			outRef := r.ToReg()
 			if outRef.CommonName() != tc.expect {

--- a/types/referrer/referrer_test.go
+++ b/types/referrer/referrer_test.go
@@ -181,7 +181,7 @@ func TestEmpty(t *testing.T) {
 		MediaType: types.MediaTypeOCI1ManifestList,
 	}))
 	if err != nil {
-		t.Errorf("failed to generate index: %v", err)
+		t.Fatalf("failed to generate index: %v", err)
 	}
 	rlEmpty.Manifest = mEmpty
 	if !rlEmpty.IsEmpty() {
@@ -207,7 +207,7 @@ func TestEmpty(t *testing.T) {
 		},
 	}))
 	if err != nil {
-		t.Errorf("failed to generate index: %v", err)
+		t.Fatalf("failed to generate index: %v", err)
 	}
 	rlPopulated.Manifest = mPopulated
 	if rlPopulated.IsEmpty() {
@@ -255,7 +255,7 @@ func TestAdd(t *testing.T) {
 		MediaType: types.MediaTypeOCI1ManifestList,
 	}))
 	if err != nil {
-		t.Errorf("failed to generate empty index: %v", err)
+		t.Fatalf("failed to generate empty index: %v", err)
 	}
 	rl.Manifest = m
 	for _, tt := range tests {
@@ -305,7 +305,7 @@ func TestDelete(t *testing.T) {
 		},
 	}))
 	if err != nil {
-		t.Errorf("failed to generate index: %v", err)
+		t.Fatalf("failed to generate index: %v", err)
 	}
 	rl.Manifest = m
 

--- a/types/repo/repolist_test.go
+++ b/types/repo/repolist_test.go
@@ -70,13 +70,11 @@ func TestNew(t *testing.T) {
 				return
 			}
 			if err != nil {
-				t.Errorf("error creating tag list: %v", err)
-				return
+				t.Fatalf("error creating tag list: %v", err)
 			}
 			raw, err := rl.RawBody()
 			if err != nil {
-				t.Errorf("error from RawBody: %v", err)
-				return
+				t.Fatalf("error from RawBody: %v", err)
 			}
 			if !bytes.Equal(tt.raw, raw) {
 				t.Errorf("unexpected raw body: expected %s, received %s", tt.raw, raw)

--- a/types/tag/taglist_test.go
+++ b/types/tag/taglist_test.go
@@ -20,8 +20,7 @@ func TestNew(t *testing.T) {
 	registryTags := []string{"cache", "edge", "edge-alpine", "alpine", "latest"}
 	reqURL, err := url.Parse("http://localhost:5000/v2/regclient/test/tag/list")
 	if err != nil {
-		t.Errorf("failed to parse URL: %v", err)
-		return
+		t.Fatalf("failed to parse URL: %v", err)
 	}
 	registryRef, _ := ref.New("localhost:5000/regclient/test")
 	registryRepoName := "regclient/test"
@@ -215,8 +214,7 @@ func TestNew(t *testing.T) {
 				return
 			}
 			if err != nil {
-				t.Errorf("error creating tag list: %v", err)
-				return
+				t.Fatalf("error creating tag list: %v", err)
 			}
 			raw, err := tl.RawBody()
 			if err != nil {
@@ -229,8 +227,7 @@ func TestNew(t *testing.T) {
 			}
 			tags, err := tl.GetTags()
 			if err != nil {
-				t.Errorf("error from GetTags: %v", err)
-				return
+				t.Fatalf("error from GetTags: %v", err)
 			}
 			if cmpSliceString(tt.tags, tags) == false {
 				t.Errorf("unexpected tag list: expected %v, received %v", tt.tags, tags)
@@ -252,20 +249,17 @@ func TestAppend(t *testing.T) {
 		WithTags(expectTags[:3]),
 	)
 	if err != nil {
-		t.Errorf("failed to build tag list 1: %v", err)
-		return
+		t.Fatalf("failed to build tag list 1: %v", err)
 	}
 	tl2, err := New(
 		WithTags(expectTags[3:]),
 	)
 	if err != nil {
-		t.Errorf("failed to build tag list 1: %v", err)
-		return
+		t.Fatalf("failed to build tag list 1: %v", err)
 	}
 	err = tl1.Append(tl2)
 	if err != nil {
-		t.Errorf("failed to append tags: %v", err)
-		return
+		t.Fatalf("failed to append tags: %v", err)
 	}
 	if !cmpSliceString(tl1.Tags, expectTags) {
 		t.Errorf("tags mismatch, expected: %v, received %v", expectTags, tl1.Tags)


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Quite a few tests have:

```go
t.Errorf(...)
return
```

which can just be:

```go
t.Fatal(...)
```

This also fixed some errors should should have been fatal so that undefined values aren't used after a failure.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
make test
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Chore: Use `t.Fatal` where appropriate.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
