### PR TITLE
Fix wrapped errors

### DIFF
--- a/cmd/regctl/artifact.go
+++ b/cmd/regctl/artifact.go
@@ -574,14 +574,14 @@ func (artifactOpts *artifactCmd) runArtifactList(cmd *cobra.Command, args []stri
 		}
 		prefix, err := referrer.FallbackTag(rl.Subject)
 		if err != nil {
-			return fmt.Errorf("failed to compute fallback tag: %v", err)
+			return fmt.Errorf("failed to compute fallback tag: %w", err)
 		}
 		for _, t := range tl.Tags {
 			if strings.HasPrefix(t, prefix.Tag) && !sliceHasStr(rl.Tags, t) {
 				rTag := rl.Subject.SetTag(t)
 				mh, err := rc.ManifestHead(ctx, rTag, regclient.WithManifestRequireDigest())
 				if err != nil {
-					return fmt.Errorf("failed to query digest tag: %v", err)
+					return fmt.Errorf("failed to query digest tag: %w", err)
 				}
 				desc := mh.GetDescriptor()
 				if desc.Annotations == nil {
@@ -1096,7 +1096,7 @@ func (artifactOpts *artifactCmd) treeAddResult(ctx context.Context, rc *regclien
 	if artifactOpts.digestTags {
 		prefix, err := referrer.FallbackTag(r)
 		if err != nil {
-			return &tr, fmt.Errorf("failed to compute fallback tag: %v", err)
+			return &tr, fmt.Errorf("failed to compute fallback tag: %w", err)
 		}
 		for _, t := range tags {
 			if strings.HasPrefix(t, prefix.Tag) && !sliceHasStr(rl.Tags, t) {

--- a/cmd/regctl/image.go
+++ b/cmd/regctl/image.go
@@ -331,7 +331,7 @@ regctl image ratelimit alpine --format '{{.Remain}}'`,
 			}
 			r, err := ref.New(vs[0])
 			if err != nil {
-				return fmt.Errorf("invalid image reference: %v", err)
+				return fmt.Errorf("invalid image reference: %w", err)
 			}
 			d := digest.Digest("")
 			if len(vs) == 1 {
@@ -341,14 +341,14 @@ regctl image ratelimit alpine --format '{{.Remain}}'`,
 				}
 				d, err = digest.Parse(r.Digest)
 				if err != nil {
-					return fmt.Errorf("invalid digest: %v", err)
+					return fmt.Errorf("invalid digest: %w", err)
 				}
 				r.Digest = ""
 			} else {
 				// parse separate ref and digest
 				d, err = digest.Parse(vs[1])
 				if err != nil {
-					return fmt.Errorf("invalid digest: %v", err)
+					return fmt.Errorf("invalid digest: %w", err)
 				}
 			}
 			imageOpts.modOpts = append(imageOpts.modOpts, mod.WithAnnotationOCIBase(r, d))

--- a/config/credhelper.go
+++ b/config/credhelper.go
@@ -54,7 +54,7 @@ func (ch *credHelper) get(host *Host) error {
 	outB, err := ch.run("get", hostIn)
 	if err != nil {
 		outS := strings.TrimSpace(string(outB))
-		return fmt.Errorf("error getting credentials, output: %s, error: %v", outS, err)
+		return fmt.Errorf("error getting credentials, output: %s, error: %w", outS, err)
 	}
 	err = json.NewDecoder(bytes.NewReader(outB)).Decode(&credOut)
 	if err != nil {
@@ -78,7 +78,7 @@ func (ch *credHelper) list() ([]Host, error) {
 	outB, err := ch.run("list", bytes.NewReader([]byte{}))
 	if err != nil {
 		outS := strings.TrimSpace(string(outB))
-		return nil, fmt.Errorf("error getting credential list, output: %s, error: %v", outS, err)
+		return nil, fmt.Errorf("error getting credential list, output: %s, error: %w", outS, err)
 	}
 	err = json.NewDecoder(bytes.NewReader(outB)).Decode(&credList)
 	if err != nil {

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -608,14 +608,14 @@ func (b *BearerHandler) GenerateAuth() (string, error) {
 	if err := b.tryPost(); err == nil {
 		return fmt.Sprintf("Bearer %s", b.token.Token), nil
 	} else if err != ErrUnauthorized {
-		return "", fmt.Errorf("failed to request auth token (post): %v%.0w", err, types.ErrHTTPUnauthorized)
+		return "", fmt.Errorf("failed to request auth token (post): %w%.0w", err, types.ErrHTTPUnauthorized)
 	}
 
 	// attempt a get (with basic auth if user/pass available)
 	if err := b.tryGet(); err == nil {
 		return fmt.Sprintf("Bearer %s", b.token.Token), nil
 	} else if err != ErrUnauthorized {
-		return "", fmt.Errorf("failed to request auth token (get): %v%.0w", err, types.ErrHTTPUnauthorized)
+		return "", fmt.Errorf("failed to request auth token (get): %w%.0w", err, types.ErrHTTPUnauthorized)
 	}
 
 	return "", ErrUnauthorized

--- a/internal/reghttp/http.go
+++ b/internal/reghttp/http.go
@@ -858,7 +858,7 @@ func makeRootPool(rootCAPool [][]byte, rootCADirs []string, hostname string, hos
 		files, err := os.ReadDir(hostDir)
 		if err != nil {
 			if !os.IsNotExist(err) {
-				return nil, fmt.Errorf("failed to read directory %s: %v", hostDir, err)
+				return nil, fmt.Errorf("failed to read directory %s: %w", hostDir, err)
 			}
 			continue
 		}
@@ -871,7 +871,7 @@ func makeRootPool(rootCAPool [][]byte, rootCADirs []string, hostname string, hos
 				//#nosec G304 file from a known directory and extension read by the user running the command on their own host
 				cert, err := os.ReadFile(f)
 				if err != nil {
-					return nil, fmt.Errorf("failed to read %s: %v", f, err)
+					return nil, fmt.Errorf("failed to read %s: %w", f, err)
 				}
 				if ok := pool.AppendCertsFromPEM(cert); !ok {
 					return nil, fmt.Errorf("failed to import cert from %s", f)

--- a/scheme/reg/blob.go
+++ b/scheme/reg/blob.go
@@ -404,8 +404,7 @@ func (reg *Reg) blobPutUploadFull(ctx context.Context, r ref.Ref, d types.Descri
 			}
 			_, err := rdrSeek.Seek(0, io.SeekStart)
 			if err != nil {
-				// TODO: after Go 1.19 support is dropped, convert this to multiple errors with %w%.0w
-				return nil, fmt.Errorf("seek on blob source failed: %v%.0w", err, types.ErrNotRetryable)
+				return nil, fmt.Errorf("seek on blob source failed: %w%.0w", err, types.ErrNotRetryable)
 			}
 		}
 		readOnce = true
@@ -684,7 +683,7 @@ func (reg *Reg) blobUploadStatus(ctx context.Context, r ref.Ref, putURL *url.URL
 	}
 	resp, err := reg.reghttp.Do(ctx, req)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get upload status: %v", err)
+		return nil, fmt.Errorf("failed to get upload status: %w", err)
 	}
 	defer resp.Close()
 	if resp.HTTPResponse().StatusCode != 204 {

--- a/types/blob/reader.go
+++ b/types/blob/reader.go
@@ -109,15 +109,15 @@ func (r *BReader) Read(p []byte) (int, error) {
 		if r.desc.Size == 0 {
 			r.desc.Size = r.readBytes
 		} else if r.readBytes < r.desc.Size {
-			err = fmt.Errorf("%w [expected %d, received %d]: %v", types.ErrShortRead, r.desc.Size, r.readBytes, err)
+			err = fmt.Errorf("%w [expected %d, received %d]: %w", types.ErrShortRead, r.desc.Size, r.readBytes, err)
 		} else if r.readBytes > r.desc.Size {
-			err = fmt.Errorf("%w [expected %d, received %d]: %v", types.ErrSizeLimitExceeded, r.desc.Size, r.readBytes, err)
+			err = fmt.Errorf("%w [expected %d, received %d]: %w", types.ErrSizeLimitExceeded, r.desc.Size, r.readBytes, err)
 		}
 		// check/save digest
 		if r.desc.Digest == "" {
 			r.desc.Digest = r.digester.Digest()
 		} else if r.desc.Digest != r.digester.Digest() {
-			err = fmt.Errorf("%w [expected %s, calculated %s]: %v", types.ErrDigestMismatch, r.desc.Digest.String(), r.digester.Digest().String(), err)
+			err = fmt.Errorf("%w [expected %s, calculated %s]: %w", types.ErrDigestMismatch, r.desc.Digest.String(), r.digester.Digest().String(), err)
 		}
 	}
 	return size, err


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Some errors were not properly wrapped.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This fixed `%v` that should have been `%w`. And support for wrapping multiple errors is now available with 1.19 support being dropped, allowing `%w ... %w` in a format.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Change will be transparent to CLI users. Library users will be able to leverage `errors.Is` in more scenarios.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Fix: Error wrapping fixed in several locations.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
