### PR TITLE
Update platform parsing to support variants on more architectures

### DIFF
--- a/cmd/regctl/image.go
+++ b/cmd/regctl/image.go
@@ -111,7 +111,11 @@ regctl image copy registry.example.org/repo:v1.2.3 registry.example.org/repo:v1
 
 # copy an image to an OCI Layout including referrers
 regctl image copy --referrers \
-  ghcr.io/regclient/regctl:edge ocidir://regctl:edge`,
+  ghcr.io/regclient/regctl:edge ocidir://regctl:edge
+
+# copy a windows image, including foreign layers
+regctl image copy --platform windows/amd64,osver=10.0.17763.4974 --include-external \
+  golang:latest registry.example.org/library/golang:windows`,
 		Args:              cobra.ExactArgs(2),
 		ValidArgsFunction: rootOpts.completeArgTag,
 		RunE:              imageOpts.runImageCopy,

--- a/cmd/regctl/index.go
+++ b/cmd/regctl/index.go
@@ -80,7 +80,13 @@ regctl index create registry.example.org/alpine:latest \
 # create a docker manifest list
 regctl index create registry.example.org/busybox:1.34 \
   --media-type application/vnd.docker.distribution.manifest.list.v2+json \
-  --ref busybox:1.34 --platform linux/amd64 --platform linux/arm64`,
+  --ref busybox:1.34 --platform linux/amd64 --platform linux/arm64
+
+# create an index of windows images
+regctl index create registry.example.org/library/golang:windows \
+  --ref golang:latest \
+	--platform windows/amd64,osver=10.0.20348.2322 \
+	--platform windows/amd64,osver=10.0.17763.5458`,
 		Args:      cobra.ExactArgs(1),
 		ValidArgs: []string{}, // do not auto complete digests
 		RunE:      indexOpts.runIndexCreate,

--- a/cmd/regctl/manifest.go
+++ b/cmd/regctl/manifest.go
@@ -99,7 +99,10 @@ regctl manifest diff --context-full \
 regctl manifest get alpine
 
 # show the original manifest body for the local platform
-regctl manifest get alpine --format raw-body --platform local`,
+regctl manifest get alpine --format raw-body --platform local
+
+# retrieve the manifest for a specific windows version
+regctl manifest get golang --platform windows/amd64,osver=10.0.17763.4974`,
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: rootOpts.completeArgTag,
 		RunE:              manifestOpts.runManifestGet,

--- a/docs/README.md
+++ b/docs/README.md
@@ -149,3 +149,8 @@ The following functions have been added in addition to the defaults available in
    ```
 
    For `regctl`, use `regctl registry set --repo-auth gcr.io`.
+
+1. Q: How can I specify the windows OS Version as a platform?
+
+   A: The platform parsing in regclient will default to your local windows version when the OS and architecture matches.
+   For explicitly passing the OS version, a comma separated syntax is available in regclient: `windows/amd64,osver=10.0.17763.4974`.

--- a/types/platform/compare.go
+++ b/types/platform/compare.go
@@ -1,0 +1,213 @@
+package platform
+
+import (
+	"strconv"
+	"strings"
+)
+
+type compare struct {
+	host Platform
+}
+
+type CompareOpts func(*compare)
+
+// NewCompare is used to compare multiple target entries to a host value.
+func NewCompare(host Platform, opts ...CompareOpts) *compare {
+	(&host).normalize()
+	c := compare{
+		host: host,
+	}
+	for _, optFn := range opts {
+		optFn(&c)
+	}
+	return &c
+}
+
+// Better returns true when the target is compatible and a better match than the previous platform.
+// The previous platform value may be the zero value when no previous match has been found.
+func (c *compare) Better(target, prev Platform) bool {
+	if !Compatible(c.host, target) {
+		return false
+	}
+	(&target).normalize()
+	(&prev).normalize()
+	if prev.OS != target.OS {
+		if target.OS == c.host.OS {
+			return true
+		} else if prev.OS == c.host.OS {
+			return false
+		}
+	}
+	if prev.Architecture != target.Architecture {
+		if target.Architecture == c.host.Architecture {
+			return true
+		} else if prev.Architecture == c.host.Architecture {
+			return false
+		}
+	}
+	if prev.Variant != target.Variant {
+		if target.Variant == c.host.Variant {
+			return true
+		} else if prev.Variant == c.host.Variant {
+			return false
+		}
+		pV := variantVer(prev.Variant)
+		tV := variantVer(target.Variant)
+		if tV > pV {
+			return true
+		} else if tV < pV {
+			return false
+		}
+	}
+	if prev.OSVersion != target.OSVersion {
+		if target.OSVersion == c.host.OSVersion {
+			return true
+		} else if prev.OSVersion == c.host.OSVersion {
+			return false
+		}
+		cmp := semverCmp(prev.OSVersion, target.OSVersion)
+		if cmp != 0 {
+			return cmp < 0
+		}
+	}
+	return false
+}
+
+// Compatible indicates if a host can run a specified target platform image.
+// This accounts for Docker Desktop for Mac and Windows using a Linux VM.
+func (c *compare) Compatible(target Platform) bool {
+	(&target).normalize()
+	if c.host.OS == "linux" {
+		return c.host.OS == target.OS && c.host.Architecture == target.Architecture &&
+			variantCompatible(c.host.Variant, target.Variant)
+	} else if c.host.OS == "windows" {
+		if target.OS == "windows" {
+			return c.host.Architecture == target.Architecture &&
+				variantCompatible(c.host.Variant, target.Variant) &&
+				osVerCompatible(c.host.OSVersion, target.OSVersion)
+		} else if target.OS == "linux" {
+			return c.host.Architecture == target.Architecture &&
+				variantCompatible(c.host.Variant, target.Variant)
+		}
+		return false
+	} else if c.host.OS == "darwin" {
+		return (target.OS == "darwin" || target.OS == "linux") &&
+			c.host.Architecture == target.Architecture &&
+			variantCompatible(c.host.Variant, target.Variant)
+	} else {
+		return c.host.OS == target.OS && c.host.Architecture == target.Architecture &&
+			variantCompatible(c.host.Variant, target.Variant) &&
+			c.host.OSVersion == target.OSVersion &&
+			strSliceEq(c.host.OSFeatures, target.OSFeatures) &&
+			strSliceEq(c.host.Features, target.Features)
+	}
+}
+
+// Match indicates if two platforms are the same.
+func (c *compare) Match(target Platform) bool {
+	(&target).normalize()
+	if c.host.OS != target.OS {
+		return false
+	}
+	if c.host.OS == "linux" {
+		return c.host.Architecture == target.Architecture && c.host.Variant == target.Variant
+	} else if c.host.OS == "windows" {
+		return c.host.Architecture == target.Architecture && c.host.Variant == target.Variant &&
+			osVerSemver(c.host.OSVersion) == osVerSemver(target.OSVersion)
+	} else {
+		return c.host.Architecture == target.Architecture &&
+			c.host.Variant == target.Variant &&
+			c.host.OSVersion == target.OSVersion &&
+			strSliceEq(c.host.OSFeatures, target.OSFeatures) &&
+			strSliceEq(c.host.Features, target.Features)
+	}
+}
+
+// Compatible indicates if a host can run a specified target platform image.
+// This accounts for Docker Desktop for Mac and Windows using a Linux VM.
+func Compatible(host, target Platform) bool {
+	comp := NewCompare(host)
+	return comp.Compatible(target)
+}
+
+// Match indicates if two platforms are the same.
+func Match(a, b Platform) bool {
+	comp := NewCompare(a)
+	return comp.Match(b)
+}
+
+func osVerCompatible(host, target string) bool {
+	if host == "" {
+		return true
+	}
+	vHost := osVerSemver(host)
+	vTarget := osVerSemver(target)
+	return vHost == vTarget
+}
+
+func osVerSemver(platVer string) string {
+	verParts := strings.Split(platVer, ".")
+	if len(verParts) < 4 {
+		return platVer
+	}
+	return strings.Join(verParts[0:3], ".")
+}
+
+// return: -1 if a<b, 0 if a==b, 1 if a>b
+func semverCmp(a, b string) int {
+	aParts := strings.Split(a, ".")
+	bParts := strings.Split(b, ".")
+	for i := range aParts {
+		if len(bParts) < i+1 {
+			return 1
+		}
+		aInt, aErr := strconv.Atoi(aParts[i])
+		bInt, bErr := strconv.Atoi(bParts[i])
+		if aErr != nil {
+			if bErr != nil {
+				return 0
+			}
+			return -1
+		}
+		if bErr != nil {
+			return 1
+		}
+		if aInt < bInt {
+			return -1
+		}
+		if aInt > bInt {
+			return 1
+		}
+	}
+	return 0
+}
+
+func strSliceEq(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func variantCompatible(host, target string) bool {
+	vHost := variantVer(host)
+	vTarget := variantVer(target)
+	if vHost >= vTarget || (vHost == 1 && target == "") || (host == "" && vTarget == 1) {
+		return true
+	}
+	return false
+}
+
+func variantVer(v string) int {
+	v = strings.TrimPrefix(v, "v")
+	ver, err := strconv.Atoi(v)
+	if err != nil {
+		return 0
+	}
+	return ver
+}

--- a/types/platform/compare_test.go
+++ b/types/platform/compare_test.go
@@ -1,0 +1,168 @@
+package platform
+
+import "testing"
+
+func TestCompare(t *testing.T) {
+	tests := []struct {
+		name               string
+		host, target, prev Platform
+		expectMatch        bool
+		expectCompat       bool
+		expectBetter       bool
+	}{
+		{
+			name:         "linux match",
+			host:         Platform{OS: "linux", Architecture: "amd64"},
+			target:       Platform{OS: "linux", Architecture: "amd64"},
+			expectMatch:  true,
+			expectCompat: true,
+			expectBetter: true,
+		},
+		{
+			name:         "linux arch",
+			host:         Platform{OS: "linux", Architecture: "amd64"},
+			target:       Platform{OS: "linux", Architecture: "arm64"},
+			expectMatch:  false,
+			expectCompat: false,
+			expectBetter: false,
+		},
+		{
+			name:         "linux normalized",
+			host:         Platform{OS: "linux", Architecture: "arm64"},
+			target:       Platform{OS: "linux", Architecture: "arm64", Variant: "v8"},
+			expectMatch:  true,
+			expectCompat: true,
+			expectBetter: true,
+		},
+		{
+			name:         "linux variant higher",
+			host:         Platform{OS: "linux", Architecture: "arm", Variant: "v6"},
+			target:       Platform{OS: "linux", Architecture: "arm", Variant: "v7"},
+			prev:         Platform{OS: "linux", Architecture: "arm", Variant: "v5"},
+			expectMatch:  false,
+			expectCompat: false,
+			expectBetter: false,
+		},
+		{
+			name:         "linux variant lower",
+			host:         Platform{OS: "linux", Architecture: "arm", Variant: "v7"},
+			target:       Platform{OS: "linux", Architecture: "arm", Variant: "v5"},
+			prev:         Platform{OS: "linux", Architecture: "arm", Variant: "v6"},
+			expectMatch:  false,
+			expectCompat: true,
+			expectBetter: false,
+		},
+		{
+			name:         "linux variant prev undef",
+			host:         Platform{OS: "linux", Architecture: "amd64", Variant: "v3"},
+			target:       Platform{OS: "linux", Architecture: "amd64", Variant: "v2"},
+			prev:         Platform{OS: "linux", Architecture: "amd64", Variant: ""},
+			expectMatch:  false,
+			expectCompat: true,
+			expectBetter: true,
+		},
+		{
+			name:         "linux variant host undef",
+			host:         Platform{OS: "linux", Architecture: "amd64", Variant: ""},
+			target:       Platform{OS: "linux", Architecture: "amd64", Variant: "v2"},
+			prev:         Platform{OS: "linux", Architecture: "amd64", Variant: "v1"},
+			expectMatch:  false,
+			expectCompat: false,
+			expectBetter: false,
+		},
+		{
+			name:         "linux variant target undef",
+			host:         Platform{OS: "linux", Architecture: "amd64", Variant: "v3"},
+			target:       Platform{OS: "linux", Architecture: "amd64", Variant: ""},
+			prev:         Platform{OS: "linux", Architecture: "amd64", Variant: "v2"},
+			expectMatch:  false,
+			expectCompat: true,
+			expectBetter: false,
+		},
+		{
+			name:         "windows match",
+			host:         Platform{OS: "windows", Architecture: "amd64", OSVersion: "10.0.17763.2114"},
+			target:       Platform{OS: "windows", Architecture: "amd64", OSVersion: "10.0.17763.2114"},
+			prev:         Platform{OS: "windows", Architecture: "amd64", OSVersion: "10.0.17763.1224"},
+			expectMatch:  true,
+			expectCompat: true,
+			expectBetter: true,
+		},
+		{
+			name:         "windows patch",
+			host:         Platform{OS: "windows", Architecture: "amd64", OSVersion: "10.0.17763.2014"},
+			target:       Platform{OS: "windows", Architecture: "amd64", OSVersion: "10.0.17763.2114"},
+			prev:         Platform{OS: "windows", Architecture: "amd64", OSVersion: "10.0.17763.2004"},
+			expectMatch:  true,
+			expectCompat: true,
+			expectBetter: true,
+		},
+		{
+			name:         "windows minor",
+			host:         Platform{OS: "windows", Architecture: "amd64", OSVersion: "10.0.14393.4583"},
+			target:       Platform{OS: "windows", Architecture: "amd64", OSVersion: "10.0.17763.2114"},
+			expectMatch:  false,
+			expectCompat: false,
+			expectBetter: false,
+		},
+		{
+			name:         "darwin compatible",
+			host:         Platform{OS: "darwin", Architecture: "amd64", Variant: "v2"},
+			target:       Platform{OS: "linux", Architecture: "amd64"},
+			prev:         Platform{OS: "darwin", Architecture: "amd64"},
+			expectMatch:  false,
+			expectCompat: true,
+			expectBetter: false,
+		},
+		{
+			name:         "darwin target",
+			host:         Platform{OS: "linux", Architecture: "amd64"},
+			target:       Platform{OS: "darwin", Architecture: "amd64"},
+			expectMatch:  false,
+			expectCompat: false,
+			expectBetter: false,
+		},
+		{
+			name:         "windows compatible",
+			host:         Platform{OS: "windows", Architecture: "amd64"},
+			target:       Platform{OS: "linux", Architecture: "amd64"},
+			prev:         Platform{OS: "windows", Architecture: "amd64", OSVersion: "10.0.17763.2004"},
+			expectMatch:  false,
+			expectCompat: true,
+			expectBetter: false,
+		},
+		{
+			name:         "other",
+			host:         Platform{OS: "other", Architecture: "amd64", Variant: "42"},
+			target:       Platform{OS: "other", Architecture: "amd64", Variant: "42"},
+			expectMatch:  true,
+			expectCompat: true,
+			expectBetter: true,
+		},
+		{
+			name:         "other variant",
+			host:         Platform{OS: "other", Architecture: "amd64", Variant: "42"},
+			target:       Platform{OS: "other", Architecture: "amd64", Variant: "45"},
+			expectMatch:  false,
+			expectCompat: false,
+			expectBetter: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Match(tt.host, tt.target)
+			if result != tt.expectMatch {
+				t.Errorf("unexpected match, result: %v, host: %v, target: %v", result, tt.host, tt.target)
+			}
+			result = Compatible(tt.host, tt.target)
+			if result != tt.expectCompat {
+				t.Errorf("unexpected compatible, result: %v, host: %v, target: %v", result, tt.host, tt.target)
+			}
+			comp := NewCompare(tt.host)
+			result = comp.Better(tt.target, tt.prev)
+			if result != tt.expectBetter {
+				t.Errorf("unexpected better, result: %v, host: %v, target: %v, prev: %v", result, tt.host, tt.target, tt.prev)
+			}
+		})
+	}
+}

--- a/types/platform/cpuinfo.go
+++ b/types/platform/cpuinfo.go
@@ -1,4 +1,4 @@
-// base on: <https://github.com/containerd/containerd/blob/main/platforms/cpuinfo.go>
+// base on: <https://github.com/containerd/platforms>
 /*
    Copyright The containerd Authors.
    Licensed under the Apache License, Version 2.0 (the "License");

--- a/types/platform/platform.go
+++ b/types/platform/platform.go
@@ -58,56 +58,6 @@ func (p Platform) String() string {
 	}
 }
 
-// Compatible indicates if a host can run a specified target platform image.
-// This accounts for Docker Desktop for Mac and Windows using a Linux VM.
-func Compatible(host, target Platform) bool {
-	(&host).normalize()
-	(&target).normalize()
-	if host.OS == "linux" {
-		return host.OS == target.OS && host.Architecture == target.Architecture && host.Variant == target.Variant
-	} else if host.OS == "windows" {
-		if target.OS == "windows" {
-			return host.Architecture == target.Architecture && host.Variant == target.Variant &&
-				prefix(host.OSVersion) == prefix(target.OSVersion)
-		} else if target.OS == "linux" {
-			return host.Architecture == target.Architecture && host.Variant == target.Variant
-		}
-		return false
-	} else if host.OS == "darwin" {
-		if target.OS == "darwin" || target.OS == "linux" {
-			return host.Architecture == target.Architecture && host.Variant == target.Variant
-		}
-		return false
-	} else {
-		return host.Architecture == target.Architecture &&
-			host.OSVersion == target.OSVersion &&
-			strSliceEq(host.OSFeatures, target.OSFeatures) &&
-			host.Variant == target.Variant &&
-			strSliceEq(host.Features, target.Features)
-	}
-}
-
-// Match indicates if two platforms are the same
-func Match(a, b Platform) bool {
-	(&a).normalize()
-	(&b).normalize()
-	if a.OS != b.OS {
-		return false
-	}
-	if a.OS == "linux" {
-		return a.Architecture == b.Architecture && a.Variant == b.Variant
-	} else if a.OS == "windows" {
-		return a.Architecture == b.Architecture && a.Variant == b.Variant &&
-			prefix(a.OSVersion) == prefix(b.OSVersion)
-	} else {
-		return a.Architecture == b.Architecture &&
-			a.Variant == b.Variant &&
-			a.OSVersion == b.OSVersion &&
-			strSliceEq(a.OSFeatures, b.OSFeatures) &&
-			strSliceEq(a.Features, b.Features)
-	}
-}
-
 // Parse converts a platform string into a struct
 func Parse(platStr string) (Platform, error) {
 	// split on slash, validate each component
@@ -189,24 +139,4 @@ func (p *Platform) normalize() {
 			p.Variant = "v" + p.Variant
 		}
 	}
-}
-
-func prefix(platVer string) string {
-	verParts := strings.Split(platVer, ".")
-	if len(verParts) < 4 {
-		return platVer
-	}
-	return strings.Join(verParts[0:3], ".")
-}
-
-func strSliceEq(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
 }

--- a/types/platform/platform_other.go
+++ b/types/platform/platform_other.go
@@ -7,9 +7,14 @@ import "runtime"
 
 // Local retrieves the local platform details
 func Local() Platform {
-	return Platform{
+	plat := Platform{
 		OS:           runtime.GOOS,
 		Architecture: runtime.GOARCH,
 		Variant:      cpuVariant(),
 	}
+	switch plat.OS {
+	case "macos":
+		plat.OS = "darwin"
+	}
+	return plat
 }

--- a/types/platform/platform_test.go
+++ b/types/platform/platform_test.go
@@ -2,8 +2,9 @@ package platform
 
 import (
 	"errors"
-	"fmt"
 	"testing"
+
+	"github.com/regclient/regclient/types/errs"
 )
 
 func TestPlatformParse(t *testing.T) {
@@ -28,7 +29,12 @@ func TestPlatformParse(t *testing.T) {
 		{
 			name:    "wildcard",
 			parse:   "linux/*",
-			wantErr: fmt.Errorf("invalid platform component %s in %s", "*", "linux/*"),
+			wantErr: errs.ErrParsingFailed,
+		},
+		{
+			name:    "unsupported arg",
+			parse:   "linux,amd64",
+			wantErr: errs.ErrParsingFailed,
 		},
 		{
 			name:  "linux amd64",
@@ -104,6 +110,11 @@ func TestPlatformParse(t *testing.T) {
 			name:  "darwin arm64",
 			parse: "darwin/arm64",
 			goal:  Platform{OS: "darwin", Architecture: "arm64"},
+		},
+		{
+			name:  "windows amd64 with version",
+			parse: "windows/amd64,osver=10.0.17763.4974",
+			goal:  Platform{OS: "windows", Architecture: "amd64", OSVersion: "10.0.17763.4974"},
 		},
 		{
 			name:  "windows amd64",

--- a/types/platform/platform_test.go
+++ b/types/platform/platform_test.go
@@ -112,6 +112,18 @@ func TestCompare(t *testing.T) {
 }
 
 func TestPlatformParse(t *testing.T) {
+	platLocal := Local()
+	linuxGoal := Platform{OS: "linux"}
+	if Compatible(Platform{OS: platLocal.OS}, Platform{OS: "linux"}) {
+		linuxGoal.Architecture = platLocal.Architecture
+		linuxGoal.Variant = platLocal.Variant
+	}
+	winGoal := Platform{OS: "windows"}
+	if Compatible(Platform{OS: platLocal.OS}, Platform{OS: "windows"}) {
+		winGoal.Architecture = platLocal.Architecture
+		winGoal.Variant = platLocal.Variant
+		winGoal.OSVersion = platLocal.OSVersion
+	}
 	tests := []struct {
 		name    string
 		parse   string
@@ -144,14 +156,24 @@ func TestPlatformParse(t *testing.T) {
 			goal:  Platform{OS: "linux", Architecture: "arm64", Variant: "v8"},
 		},
 		{
-			name:  "windows amd64/10.0.14393",
-			parse: "windows/amd64/10.0.14393.4583",
-			goal:  Platform{OS: "windows", Architecture: "amd64", OSVersion: "10.0.14393.4583"},
+			name:  "linux",
+			parse: "linux",
+			goal:  linuxGoal,
+		},
+		{
+			name:  "windows amd64",
+			parse: "windows/amd64/v2",
+			goal:  Platform{OS: "windows", Architecture: "amd64", Variant: "v2"},
+		},
+		{
+			name:  "windows",
+			parse: "windows",
+			goal:  winGoal,
 		},
 		{
 			name:  "local",
 			parse: "local",
-			goal:  Local(),
+			goal:  platLocal,
 		},
 	}
 	for _, tt := range tests {
@@ -180,6 +202,11 @@ func TestPlatformString(t *testing.T) {
 		p    Platform
 	}{
 		{
+			name: "empty",
+			p:    Platform{},
+			goal: "unknown",
+		},
+		{
 			name: "linux/amd64",
 			p:    Platform{OS: "linux", Architecture: "amd64"},
 			goal: "linux/amd64",
@@ -200,9 +227,9 @@ func TestPlatformString(t *testing.T) {
 			goal: "linux/arm/v7",
 		},
 		{
-			name: "windows/amd64/10.0.17763.2114",
+			name: "windows/amd64",
 			p:    Platform{OS: "windows", Architecture: "amd64", OSVersion: "10.0.17763.2114"},
-			goal: "windows/amd64/10.0.17763.2114",
+			goal: "windows/amd64",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Selecting a windows image with a different variant is not possible.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This is a refresh of the platform code to better support multiple variants (e.g. amd64 v2 and v3). Platform selection now prefers a best match rather than the first compatible match (when an exact match wasn't found).

Selecting windows OS version now depends on a comma separated key/value syntax `linux/amd64,osver=10.0.17763.4974`.

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
regctl manifest get golang --platform windows/amd64,osver=10.0.17763
```

<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Breaking: The platform string for windows images no longer includes the non-standard OS Version value.
- Fix: Platform selection now finds the best match rather than the first compatible match.
- Feature: Specifying windows OS Version now uses a comma separated syntax in the platform string.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

Because of the large number of changes, this was broken up into several commits.
<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [ ] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
