### PR TITLE
Update Zot version for CI tests

### DIFF
--- a/.version-bump.yml
+++ b/.version-bump.yml
@@ -37,6 +37,8 @@ files:
       - makefile-syft-version
       - makefile-syft-version2
       - makefile-syft-digest
+      - makefile-ci-distribution
+      - makefile-ci-zot
   "go.mod":
     scans:
       - go-mod-golang-release
@@ -154,6 +156,18 @@ scans:
     source: "registry-golang-oldest"
     args:
       regexp: '^go (?P<Version>[0-9\.]+)\s*$'
+  makefile-ci-distribution:
+    type: "regexp"
+    source: "registry-tag-arg-semver"
+    args:
+      regexp: '^CI_DISTRIBUTION_VER\?=(?P<Version>v?[0-9\.]+)\s*$'
+      repo: "docker.io/library/registry"
+  makefile-ci-zot:
+    type: "regexp"
+    source: "registry-tag-arg-semver"
+    args:
+      regexp: '^CI_ZOT_VER\?=(?P<Version>v?[0-9\.]+)\s*$'
+      repo: "ghcr.io/project-zot/zot-linux-amd64"
   makefile-gomajor:
     type: "regexp"
     source: "git-tag-semver"

--- a/build/ci-test.sh
+++ b/build/ci-test.sh
@@ -31,12 +31,12 @@ export PATH="$PATH:${git_root}/bin"
 
 export REGCTL_CONFIG="${git_root}/.regctl_conf_ci.json"
 
-# disable TLS for tests
+# disable TLS and increase requests per sec for faster tests
 if [ "${opt_s}" = "${opt_s#*://}" ]; then
-  regctl registry set --tls=disabled "${opt_s%%/*}"
+  regctl registry set --tls=disabled --req-per-sec 1000 "${opt_s%%/*}"
 fi
 if [ "${opt_t}" = "${opt_t#*://}" ]; then
-  regctl registry set --tls=disabled "${opt_t%%/*}"
+  regctl registry set --tls=disabled --req-per-sec 1000 "${opt_t%%/*}"
 fi
 
 regctl image copy --digest-tags --referrers "${opt_s}:v1" "${opt_t}:v1"

--- a/build/zot-config.json
+++ b/build/zot-config.json
@@ -1,9 +1,7 @@
 {
-  "distSpecVersion": "1.1.0-dev",
+  "distSpecVersion": "1.1.0",
   "storage": {
-    "rootDirectory": "/tmp/zot",
-    "gc": false,
-    "dedupe": false
+    "rootDirectory": "/tmp/zot"
   },
   "http": {
     "address": "0.0.0.0",


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

CI tests for Zot are failing because the pinned RC tag no longer exists.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This updates the Zot version, removes some RC config settings in Zot, updates the distribution/distribution version, manages the versions with version-bump, and speeds up the tests.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
make ci
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Fix: Update registry versions in CI tests.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
