### PR TITLE
Detect variant on amd64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,9 +87,10 @@ lint-goimports: $(GOPATH)/bin/goimports
 		exit 1; \
 	fi
 
+# excluding types/platform pending resultion to https://github.com/securego/gosec/issues/1116
 .PHONY: lint-gosec
 lint-gosec: $(GOPATH)/bin/gosec .FORCE ## Run gosec
-	$(GOPATH)/bin/gosec -terse ./...
+	$(GOPATH)/bin/gosec -terse -exclude-dir types/platform ./...
 
 .PHONY: lint-md
 lint-md: .FORCE ## Run linting for markdown

--- a/types/platform/cpuinfo.go
+++ b/types/platform/cpuinfo.go
@@ -1,28 +1,19 @@
-// base on: <https://github.com/containerd/platforms>
-/*
-   Copyright The containerd Authors.
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-       http://www.apache.org/licenses/LICENSE-2.0
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-*/
+// Related implementations:
+// <https://golang.org/x/sys/cpu>
+// <https://github.com/klauspost/cpuid>
+// <https://github.com/containerd/platforms>
+// <https://github.com/tonistiigi/go-archvariant>
+// <https://tip.golang.org/wiki/MinimumRequirements#microarchitecture-support>
 
 package platform
 
 import (
-	"bufio"
-	"os"
 	"runtime"
-	"strings"
 	"sync"
 )
 
-// Present the ARM instruction set architecture, eg: v7, v8
+// cpuVariantValue is the variant of the local CPU architecture.
+// For example on ARM, v7 and v8. And on AMD64, v1 - v4.
 // Don't use this value directly; call cpuVariant() instead.
 var cpuVariantValue string
 
@@ -31,81 +22,9 @@ var cpuVariantOnce sync.Once
 func cpuVariant() string {
 	cpuVariantOnce.Do(func() {
 		switch runtime.GOARCH {
-		case "arm", "arm64":
-			cpuVariantValue = getCPUVariant()
+		case "amd64", "arm", "arm64":
+			cpuVariantValue = lookupCPUVariant()
 		}
 	})
 	return cpuVariantValue
-}
-
-// For Linux, the kernel has already detected the ABI, ISA and Features.
-// So we don't need to access the ARM registers to detect platform information
-// by ourselves. We can just parse these information from /proc/cpuinfo
-func getCPUInfo(pattern string) (info string) {
-	if runtime.GOOS != "linux" {
-		return ""
-	}
-
-	cpuinfo, err := os.Open("/proc/cpuinfo")
-	if err != nil {
-		return ""
-	}
-	defer cpuinfo.Close()
-
-	// Start to Parse the Cpuinfo line by line. For SMP SoC, we parse
-	// the first core is enough.
-	scanner := bufio.NewScanner(cpuinfo)
-	for scanner.Scan() {
-		newline := scanner.Text()
-		list := strings.Split(newline, ":")
-
-		if len(list) > 1 && strings.EqualFold(strings.TrimSpace(list[0]), pattern) {
-			return strings.TrimSpace(list[1])
-		}
-	}
-	return ""
-}
-
-func getCPUVariant() string {
-	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
-		// Windows/Darwin only supports v7 for ARM32 and v8 for ARM64 and so we can use
-		// runtime.GOARCH to determine the variants
-		switch runtime.GOARCH {
-		case "arm64":
-			return "v8"
-		case "arm":
-			return "v7"
-		}
-		return ""
-	}
-
-	variant := getCPUInfo("Cpu architecture")
-
-	// handle edge case for Raspberry Pi ARMv6 devices (which due to a kernel quirk, report "CPU architecture: 7")
-	// https://www.raspberrypi.org/forums/viewtopic.php?t=12614
-	if runtime.GOARCH == "arm" && variant == "7" {
-		model := getCPUInfo("model name")
-		if strings.HasPrefix(strings.ToLower(model), "armv6-compatible") {
-			variant = "6"
-		}
-	}
-
-	switch strings.ToLower(variant) {
-	case "8", "aarch64":
-		variant = "v8"
-	case "7", "7m", "?(12)", "?(13)", "?(14)", "?(15)", "?(16)", "?(17)":
-		variant = "v7"
-	case "6", "6tej":
-		variant = "v6"
-	case "5", "5t", "5te", "5tej":
-		variant = "v5"
-	case "4", "4t":
-		variant = "v4"
-	case "3":
-		variant = "v3"
-	default:
-		variant = ""
-	}
-
-	return variant
 }

--- a/types/platform/cpuinfo_armx.go
+++ b/types/platform/cpuinfo_armx.go
@@ -1,0 +1,83 @@
+//go:build arm || arm64
+// +build arm arm64
+
+package platform
+
+import (
+	"bufio"
+	"os"
+	"runtime"
+	"strings"
+)
+
+func lookupCPUVariant() string {
+	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
+		// Windows/Darwin only supports v7 for ARM32 and v8 for ARM64 and so we can use
+		// runtime.GOARCH to determine the variants
+		switch runtime.GOARCH {
+		case "arm64":
+			return "v8"
+		case "arm":
+			return "v7"
+		}
+		return ""
+	}
+
+	variant := getCPUInfo("Cpu architecture")
+
+	// handle edge case for Raspberry Pi ARMv6 devices (which due to a kernel quirk, report "CPU architecture: 7")
+	// https://www.raspberrypi.org/forums/viewtopic.php?t=12614
+	if runtime.GOARCH == "arm" && variant == "7" {
+		model := getCPUInfo("model name")
+		if strings.HasPrefix(strings.ToLower(model), "armv6-compatible") {
+			variant = "6"
+		}
+	}
+
+	switch strings.ToLower(variant) {
+	case "8", "aarch64":
+		variant = "v8"
+	case "7", "7m", "?(12)", "?(13)", "?(14)", "?(15)", "?(16)", "?(17)":
+		variant = "v7"
+	case "6", "6tej":
+		variant = "v6"
+	case "5", "5t", "5te", "5tej":
+		variant = "v5"
+	case "4", "4t":
+		variant = "v4"
+	case "3":
+		variant = "v3"
+	default:
+		variant = ""
+	}
+
+	return variant
+}
+
+// For Linux, the kernel has already detected the ABI, ISA and Features.
+// So we don't need to access the ARM registers to detect platform information
+// by ourselves. We can just parse these information from /proc/cpuinfo
+func getCPUInfo(pattern string) (info string) {
+	if runtime.GOOS != "linux" {
+		return ""
+	}
+
+	cpuinfo, err := os.Open("/proc/cpuinfo")
+	if err != nil {
+		return ""
+	}
+	defer cpuinfo.Close()
+
+	// Start to Parse the Cpuinfo line by line. For SMP SoC, we parse
+	// the first core is enough.
+	scanner := bufio.NewScanner(cpuinfo)
+	for scanner.Scan() {
+		newline := scanner.Text()
+		list := strings.Split(newline, ":")
+
+		if len(list) > 1 && strings.EqualFold(strings.TrimSpace(list[0]), pattern) {
+			return strings.TrimSpace(list[1])
+		}
+	}
+	return ""
+}

--- a/types/platform/cpuinfo_other.go
+++ b/types/platform/cpuinfo_other.go
@@ -1,0 +1,8 @@
+//go:build !386 && !amd64 && !amd64p32 && !arm && !arm64
+// +build !386,!amd64,!amd64p32,!arm,!arm64
+
+package platform
+
+func lookupCPUVariant() string {
+	return ""
+}

--- a/types/platform/cpuinfo_x86.go
+++ b/types/platform/cpuinfo_x86.go
@@ -1,0 +1,100 @@
+//go:build 386 || amd64 || amd64p32
+// +build 386 amd64 amd64p32
+
+package platform
+
+const (
+	ecx1SSE3    = 0
+	ecx1SSSE3   = 9
+	ecx1FMA     = 12
+	ecx1CX16    = 13
+	ecx1SSE4_1  = 19
+	ecx1SSE4_2  = 20
+	ecx1MOVBE   = 22
+	ecx1POPCNT  = 23
+	ecx1XSAVE   = 26
+	ecx1OSXSAVE = 27
+	ecx1AVX     = 28
+	ecx1F16C    = 29
+
+	ebx7BMI1     = 3
+	ebx7AVX2     = 5
+	ebx7BMI2     = 8
+	ebx7AVX512F  = 16
+	ebx7AVX512DQ = 17
+	ebx7AVX512CD = 28
+	ebx7AVX512BW = 30
+	ebx7AVX512VL = 31
+
+	ecxxLAHF  = 0
+	ecxxLZCNT = 5
+
+	eaxOSXMM      = 1
+	eaxOSYMM      = 2
+	eaxOSOpMask   = 5
+	eaxOSZMMHi16  = 6
+	eaxOSZMMHi256 = 7
+)
+
+var (
+	// GOAMD64=v1 (default): The baseline. Exclusively generates instructions that all 64-bit x86 processors can execute.
+	// GOAMD64=v2: all v1 instructions, plus CX16, LAHF-SAHF, POPCNT, SSE3, SSE4.1, SSE4.2, SSSE3.
+	// GOAMD64=v3: all v2 instructions, plus AVX, AVX2, BMI1, BMI2, F16C, FMA, LZCNT, MOVBE, OSXSAVE.
+	// GOAMD64=v4: all v3 instructions, plus AVX512F, AVX512BW, AVX512CD, AVX512DQ, AVX512VL.
+	ecx1FeaturesV2  = bitSet(ecx1CX16) | bitSet(ecx1POPCNT) | bitSet(ecx1SSE3) | bitSet(ecx1SSE4_1) | bitSet(ecx1SSE4_2) | bitSet(ecx1SSSE3)
+	ecx1FeaturesV3  = ecx1FeaturesV2 | bitSet(ecx1AVX) | bitSet(ecx1F16C) | bitSet(ecx1FMA) | bitSet(ecx1MOVBE) | bitSet(ecx1OSXSAVE)
+	ebx7FeaturesV3  = bitSet(ebx7AVX2) | bitSet(ebx7BMI1) | bitSet(ebx7BMI2)
+	ebx7FeaturesV4  = ebx7FeaturesV3 | bitSet(ebx7AVX512F) | bitSet(ebx7AVX512BW) | bitSet(ebx7AVX512CD) | bitSet(ebx7AVX512DQ) | bitSet(ebx7AVX512VL)
+	ecxxFeaturesV2  = bitSet(ecxxLAHF)
+	ecxxFeaturesV3  = ecxxFeaturesV2 | bitSet(ecxxLZCNT)
+	eaxOSFeaturesV3 = bitSet(eaxOSXMM) | bitSet(eaxOSYMM)
+	eaxOSFeaturesV4 = eaxOSFeaturesV3 | bitSet(eaxOSOpMask) | bitSet(eaxOSZMMHi16) | bitSet(eaxOSZMMHi256)
+)
+
+// cpuid is implemented in cpuinfo_x86.s.
+func cpuid(eaxArg, ecxArg uint32) (eax, ebx, ecx, edx uint32)
+
+// xgetbv with ecx = 0 is implemented in cpu_x86.s.
+func xgetbv() (eax, edx uint32)
+
+func lookupCPUVariant() string {
+	variant := "v1"
+	maxID, _, _, _ := cpuid(0, 0)
+	if maxID < 7 {
+		return variant
+	}
+	_, _, ecx1, _ := cpuid(1, 0)
+	_, ebx7, _, _ := cpuid(7, 0)
+	maxX, _, _, _ := cpuid(0x80000000, 0)
+	_, _, ecxx, _ := cpuid(0x80000001, 0)
+
+	if maxX < 0x80000001 || !bitIsSet(ecx1FeaturesV2, ecx1) || !bitIsSet(ecxxFeaturesV2, ecxx) {
+		return variant
+	}
+	variant = "v2"
+
+	if !bitIsSet(ecx1FeaturesV3, ecx1) || !bitIsSet(ebx7FeaturesV3, ebx7) || !bitIsSet(ecxxFeaturesV3, ecxx) {
+		return variant
+	}
+	// For XGETBV, OSXSAVE bit is required and verified by ecx1FeaturesV3.
+	eaxOS, _ := xgetbv()
+	if !bitIsSet(eaxOSFeaturesV3, eaxOS) {
+		return variant
+	}
+	variant = "v3"
+
+	// Darwin support for AVX-512 appears to have issues.
+	if isDarwin || !bitIsSet(ebx7FeaturesV4, ebx7) || !bitIsSet(eaxOSFeaturesV4, eaxOS) {
+		return variant
+	}
+	variant = "v4"
+
+	return variant
+}
+
+func bitSet(bitpos uint) uint32 {
+	return 1 << bitpos
+}
+func bitIsSet(bits, value uint32) bool {
+	return (value & bits) == value
+}

--- a/types/platform/cpuinfo_x86.s
+++ b/types/platform/cpuinfo_x86.s
@@ -1,0 +1,26 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build (386 || amd64 || amd64p32) && gc
+
+#include "textflag.h"
+
+// func cpuid(eaxArg, ecxArg uint32) (eax, ebx, ecx, edx uint32)
+TEXT ·cpuid(SB), NOSPLIT, $0-24
+	MOVL eaxArg+0(FP), AX
+	MOVL ecxArg+4(FP), CX
+	CPUID
+	MOVL AX, eax+8(FP)
+	MOVL BX, ebx+12(FP)
+	MOVL CX, ecx+16(FP)
+	MOVL DX, edx+20(FP)
+	RET
+
+// func xgetbv() (eax, edx uint32)
+TEXT ·xgetbv(SB),NOSPLIT,$0-8
+	MOVL $0, CX
+	XGETBV
+	MOVL AX, eax+0(FP)
+	MOVL DX, edx+4(FP)
+	RET

--- a/types/platform/os_darwin.go
+++ b/types/platform/os_darwin.go
@@ -1,0 +1,8 @@
+//go:build darwin
+// +build darwin
+
+package platform
+
+const isDarwin = true
+
+var _ = isDarwin

--- a/types/platform/os_other.go
+++ b/types/platform/os_other.go
@@ -1,0 +1,8 @@
+//go:build !darwin
+// +build !darwin
+
+package platform
+
+const isDarwin = false
+
+var _ = isDarwin

--- a/types/platform/platform.go
+++ b/types/platform/platform.go
@@ -101,7 +101,6 @@ func Parse(platStr string) (Platform, error) {
 	}
 	// gather local platform details
 	platLocal := Local()
-	platLocal.normalize()
 	// normalize and extrapolate missing fields
 	switch plat.OS {
 	case "local", "":

--- a/types/platform/platform_other.go
+++ b/types/platform/platform_other.go
@@ -12,9 +12,6 @@ func Local() Platform {
 		Architecture: runtime.GOARCH,
 		Variant:      cpuVariant(),
 	}
-	switch plat.OS {
-	case "macos":
-		plat.OS = "darwin"
-	}
+	plat.normalize()
 	return plat
 }

--- a/types/platform/platform_windows.go
+++ b/types/platform/platform_windows.go
@@ -13,10 +13,12 @@ import (
 // Local retrieves the local platform details
 func Local() Platform {
 	major, minor, build := windows.RtlGetNtVersionNumbers()
-	return Platform{
+	plat := Platform{
 		OS:           runtime.GOOS,
 		Architecture: runtime.GOARCH,
 		Variant:      cpuVariant(),
 		OSVersion:    fmt.Sprintf("%d.%d.%d", major, minor, build),
 	}
+	plat.normalize()
+	return plat
 }


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Update platform detection to support AMD64 variants.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Actions that lookup the local platform can now detect AMD64 v1-v4 variants in a manifest list. At present, this is rarely seen.

<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Feature: Detect AMD64 variant when looking up local platform.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

Testing is minimal since it depends on the local CPU.
<!-- Mark the following with an [X] to verify they are included -->

- [ ] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
