### PR TITLE
Add image mod option to set config platform

### DIFF
--- a/cmd/regctl/image.go
+++ b/cmd/regctl/image.go
@@ -405,6 +405,19 @@ regctl image ratelimit alpine --format '{{.Remain}}'`,
 	imageModCmd.Flags().VarP(&modFlagFunc{
 		t: "string",
 		f: func(val string) error {
+			p, err := platform.Parse(val)
+			if err != nil {
+				return err
+			}
+			imageOpts.modOpts = append(imageOpts.modOpts,
+				mod.WithConfigPlatform(p),
+			)
+			return nil
+		},
+	}, "config-platform", "", `set platform on the config (not recommended for an index of multiple images)`)
+	imageModCmd.Flags().VarP(&modFlagFunc{
+		t: "string",
+		f: func(val string) error {
 			ot, otherFields, err := imageParseOptTime(val)
 			if err != nil {
 				return err

--- a/mod/config.go
+++ b/mod/config.go
@@ -54,6 +54,23 @@ func WithBuildArgRm(arg string, value *regexp.Regexp) Opts {
 	}
 }
 
+// WithConfigPlatform sets the platform in the config.
+func WithConfigPlatform(p platform.Platform) Opts {
+	return func(dc *dagConfig, dm *dagManifest) error {
+		dc.stepsOCIConfig = append(dc.stepsOCIConfig, func(ctx context.Context, rc *regclient.RegClient, rSrc, rTgt ref.Ref, doc *dagOCIConfig) error {
+			oc := doc.oc.GetConfig()
+			if platform.Match(oc.Platform, p) {
+				return nil
+			}
+			oc.Platform = p
+			doc.oc.SetConfig(oc)
+			doc.modified = true
+			return nil
+		})
+		return nil
+	}
+}
+
 // WithConfigTimestamp sets the timestamp on the config entries based on options.
 func WithConfigTimestamp(optTime OptTime) Opts {
 	return func(dc *dagConfig, dm *dagManifest) error {

--- a/mod/mod_test.go
+++ b/mod/mod_test.go
@@ -151,6 +151,10 @@ func TestMod(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to parse platform specific descriptor: %v", err)
 	}
+	plat, err := platform.Parse("linux/amd64/v3")
+	if err != nil {
+		t.Fatalf("failed to parse the platform: %v", err)
+	}
 
 	// define tests
 	tests := []struct {
@@ -415,6 +419,13 @@ func TestMod(t *testing.T) {
 			},
 			ref:      "ocidir://testrepo:v1",
 			wantSame: true,
+		},
+		{
+			name: "Config Platform",
+			opts: []Opts{
+				WithConfigPlatform(plat),
+			},
+			ref: "ocidir://testrepo:v1",
 		},
 		{
 			name: "Expose Port",


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Fixes #690 
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This adds the ability to set the platform in the image config.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
regctl image mod --config-platform linux/amd64 $src --create amd64
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Feature: Add ability to set the config platform setting with `regctl image mod`.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
