### PR TITLE
Add image mod options to set entrypoint and cmd

### DIFF
--- a/mod/config.go
+++ b/mod/config.go
@@ -54,6 +54,42 @@ func WithBuildArgRm(arg string, value *regexp.Regexp) Opts {
 	}
 }
 
+// WithConfigCmd sets the command in the config.
+// For running a shell command, the `cmd` value should be `[]string{"/bin/sh", "-c", command}`.
+func WithConfigCmd(cmd []string) Opts {
+	return func(dc *dagConfig, dm *dagManifest) error {
+		dc.stepsOCIConfig = append(dc.stepsOCIConfig, func(ctx context.Context, rc *regclient.RegClient, rSrc, rTgt ref.Ref, doc *dagOCIConfig) error {
+			oc := doc.oc.GetConfig()
+			if eqStrSlice(cmd, oc.Config.Cmd) {
+				return nil
+			}
+			oc.Config.Cmd = cmd
+			doc.oc.SetConfig(oc)
+			doc.modified = true
+			return nil
+		})
+		return nil
+	}
+}
+
+// WithConfigEntrypoint sets the entrypoint in the config.
+// For running a shell command, the `entrypoint` value should be `[]string{"/bin/sh", "-c", command}`.
+func WithConfigEntrypoint(entrypoint []string) Opts {
+	return func(dc *dagConfig, dm *dagManifest) error {
+		dc.stepsOCIConfig = append(dc.stepsOCIConfig, func(ctx context.Context, rc *regclient.RegClient, rSrc, rTgt ref.Ref, doc *dagOCIConfig) error {
+			oc := doc.oc.GetConfig()
+			if eqStrSlice(entrypoint, oc.Config.Entrypoint) {
+				return nil
+			}
+			oc.Config.Entrypoint = entrypoint
+			doc.oc.SetConfig(oc)
+			doc.modified = true
+			return nil
+		})
+		return nil
+	}
+}
+
 // WithConfigPlatform sets the platform in the config.
 func WithConfigPlatform(p platform.Platform) Opts {
 	return func(dc *dagConfig, dm *dagManifest) error {

--- a/mod/mod.go
+++ b/mod/mod.go
@@ -285,3 +285,15 @@ func inListStr(str string, list []string) bool {
 	}
 	return false
 }
+
+func eqStrSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/mod/mod_test.go
+++ b/mod/mod_test.go
@@ -708,6 +708,42 @@ func TestMod(t *testing.T) {
 			ref: "ocidir://testrepo:v1",
 		},
 		{
+			name: "Remove Command",
+			opts: []Opts{
+				WithConfigCmd([]string{}),
+			},
+			ref: "ocidir://testrepo:v1",
+		},
+		{
+			name: "Set Command",
+			opts: []Opts{
+				WithConfigCmd([]string{"/app", "-v"}),
+			},
+			ref: "ocidir://testrepo:v1",
+		},
+		{
+			name: "Set Command Shell",
+			opts: []Opts{
+				WithConfigCmd([]string{"/bin/sh", "-c", "/app -v"}),
+			},
+			ref: "ocidir://testrepo:v1",
+		},
+		{
+			name: "Remove Entrypoint",
+			opts: []Opts{
+				WithConfigEntrypoint([]string{}),
+			},
+			ref:      "ocidir://testrepo:v1",
+			wantSame: true,
+		},
+		{
+			name: "Set Entrypoint",
+			opts: []Opts{
+				WithConfigEntrypoint([]string{"/app", "-v"}),
+			},
+			ref: "ocidir://testrepo:v1",
+		},
+		{
 			name: "Build arg rm",
 			opts: []Opts{
 				WithBuildArgRm("arg_label", regexp.MustCompile("arg_for_[a-z]*")),


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Fixes #532.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This adds the ability to set the endpoint and cmd in an image with `regctl image mod`.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
regctl image mod registry.example.org/repo:v1 --create v1-bash \
  --config-entrypoint '["bash"]' --config-cmd ""
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Feature: Image mod support for setting the entrypoint and cmd.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
