### PR TITLE
Chore: Cleanup unused params

### DIFF
--- a/cmd/regctl/image.go
+++ b/cmd/regctl/image.go
@@ -978,7 +978,7 @@ func (imageOpts *imageCmd) runImageCopy(cmd *cobra.Command, args []string) error
 					ticker.Stop()
 					return
 				case <-ticker.C:
-					progress.display(cmd.ErrOrStderr(), false)
+					progress.display(false)
 				}
 			}
 		}()
@@ -987,7 +987,7 @@ func (imageOpts *imageCmd) runImageCopy(cmd *cobra.Command, args []string) error
 	err = rc.ImageCopy(ctx, rSrc, rTgt, opts...)
 	if progress != nil {
 		close(done)
-		progress.display(cmd.ErrOrStderr(), true)
+		progress.display(true)
 	}
 	if err != nil {
 		return err
@@ -1049,7 +1049,7 @@ func (ip *imageProgress) callback(kind types.CallbackKind, instance string, stat
 	}
 }
 
-func (ip *imageProgress) display(w io.Writer, final bool) {
+func (ip *imageProgress) display(final bool) {
 	ip.mu.Lock()
 	defer ip.mu.Unlock()
 	if !ip.changed && !final {

--- a/image.go
+++ b/image.go
@@ -1583,7 +1583,7 @@ func (rc *RegClient) imageImportOCIHandleManifest(ctx context.Context, r ref.Ref
 }
 
 // imageImportOCIPushManifests uploads manifests after OCI blobs were successfully loaded.
-func (rc *RegClient) imageImportOCIPushManifests(ctx context.Context, r ref.Ref, trd *tarReadData) error {
+func (rc *RegClient) imageImportOCIPushManifests(_ context.Context, _ ref.Ref, trd *tarReadData) error {
 	// run finish handlers in reverse order to upload nested manifests
 	for i := len(trd.finish) - 1; i >= 0; i-- {
 		err := trd.finish[i]()

--- a/scheme/ocidir/manifest.go
+++ b/scheme/ocidir/manifest.go
@@ -98,7 +98,7 @@ func (o *OCIDir) ManifestGet(ctx context.Context, r ref.Ref) (manifest.Manifest,
 	return o.manifestGet(ctx, r)
 }
 
-func (o *OCIDir) manifestGet(ctx context.Context, r ref.Ref) (manifest.Manifest, error) {
+func (o *OCIDir) manifestGet(_ context.Context, r ref.Ref) (manifest.Manifest, error) {
 	index, err := o.readIndex(r, true)
 	if err != nil {
 		return nil, fmt.Errorf("unable to read oci index: %w", err)

--- a/scheme/ocidir/tag.go
+++ b/scheme/ocidir/tag.go
@@ -21,7 +21,7 @@ func (o *OCIDir) TagDelete(ctx context.Context, r ref.Ref) error {
 	return o.tagDelete(ctx, r)
 }
 
-func (o *OCIDir) tagDelete(ctx context.Context, r ref.Ref) error {
+func (o *OCIDir) tagDelete(_ context.Context, r ref.Ref) error {
 	if r.Tag == "" {
 		return errs.ErrMissingTag
 	}

--- a/scheme/reg/tag.go
+++ b/scheme/reg/tag.go
@@ -309,7 +309,7 @@ func (reg *Reg) tagListOCI(ctx context.Context, r ref.Ref, config scheme.TagConf
 	return tl, nil
 }
 
-func (reg *Reg) tagListLink(ctx context.Context, r ref.Ref, config scheme.TagConfig, link *url.URL) (*tag.List, error) {
+func (reg *Reg) tagListLink(ctx context.Context, r ref.Ref, _ scheme.TagConfig, link *url.URL) (*tag.List, error) {
 	headers := http.Header{
 		"Accept": []string{"application/json"},
 	}


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Cleanup some unused parameters on private functions. Many of these were set to `_` to make it easier to reenable later. This is now flagged by gopls, but not yet in staticcheck.

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

In the editor, `gopls` errors for unused parameters should no longer appear.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Chore: Cleanup unused parameters on private functions.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
