### PR TITLE
Update GHA registry push and sign steps

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -194,29 +194,20 @@ jobs:
           rm -r output/${{matrix.image}}-sbom
         done
 
-    - name: Push
+    - name: Push and Sign
       if: github.event_name != 'pull_request' && github.repository_owner == 'regclient'
       id: push
       run: |
         # loop over the tags
         image_hub="${{ steps.prep.outputs.image_hub }}"
         for tag in $(echo ${{ steps.prep.outputs.tags }} | tr , ' '); do
-          if [ "$(regctl image digest "ocidir://output/${{matrix.image}}:${{matrix.type}}")" = "$(regctl image digest "${tag}" 2>/dev/null || true)" ]; then
+          digest="$(regctl image digest "ocidir://output/${{matrix.image}}:${{matrix.type}}")"
+          if [ "${digest}" = "$(regctl image digest "${tag}" 2>/dev/null || true)" ]; then
             # image already pushed, don't add referrers to reproducible builds
             echo "Skipping ${tag}"
           else
             echo "Pushing ${tag}"
-            # TODO: push referrers to Hub once this is fixed: https://github.com/docker/hub-feedback/issues/2307
-            if [ "$tag" != "${tag#$image_hub}" ]; then
-              regctl image copy "ocidir://output/${{matrix.image}}:${{matrix.type}}" "${tag}"
-            else
-              regctl image copy --referrers "ocidir://output/${{matrix.image}}:${{matrix.type}}" "${tag}"
-            fi
+            regctl image copy --referrers "ocidir://output/${{matrix.image}}:${{matrix.type}}@${digest}" "${tag}"
+            cosign sign -y -r "${tag}@${digest}"
           fi
         done
-
-    - name: Sign the container image
-      if: github.event_name != 'pull_request' && github.repository_owner == 'regclient'
-      run: |
-        cosign sign -y -r ${{ steps.prep.outputs.image_hub }}@${{ steps.mutate.outputs.digest }}
-        cosign sign -y -r ${{ steps.prep.outputs.image_ghcr }}@${{ steps.mutate.outputs.digest }}


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Docker Hub no longer blocks the push of images with a subject, so the SBOM push is reenabled. This also moves the signing step to the push to use the digest variable and skip signing of reproducible builds.

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

GHA should not fail, and on success, checking signatures and referrers should work:

```shell
regctl artifact list regclient/regctl:edge --platform linux/amd64
```

<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Chore: Resume push of SBOMs to Docker Hub.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
