### PR TITLE
Use the full descriptor on a blob get response

### DIFF
--- a/scheme/reg/blob.go
+++ b/scheme/reg/blob.go
@@ -100,9 +100,7 @@ func (reg *Reg) BlobGet(ctx context.Context, r ref.Ref, d descriptor.Descriptor)
 	b := blob.NewReader(
 		blob.WithRef(r),
 		blob.WithReader(resp),
-		blob.WithDesc(descriptor.Descriptor{
-			Digest: d.Digest,
-		}),
+		blob.WithDesc(d),
 		blob.WithResp(resp.HTTPResponse()),
 	)
 	return b, nil
@@ -157,9 +155,7 @@ func (reg *Reg) BlobHead(ctx context.Context, r ref.Ref, d descriptor.Descriptor
 
 	b := blob.NewReader(
 		blob.WithRef(r),
-		blob.WithDesc(descriptor.Descriptor{
-			Digest: d.Digest,
-		}),
+		blob.WithDesc(d),
 		blob.WithResp(resp.HTTPResponse()),
 	)
 	return b, nil


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Fixes #723 
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

When pulling a blob from a registry, the original descriptor should be used, and not only the digest. This makes future calls to return the descriptor correctly return the media type and any other associated fields.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
regctl image copy alpine localhost:5000/library/alpine
regctl image mod --label test=label --create label localhost:5000/library/alpine
regctl manifest get --platform linux/amd64 localhost:5000/library/alpine:label
# note the digest of the config descriptor
```

<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Fix: Use the provided descriptor in the BlobGet/Head to a registry.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
