### PR TITLE
feat: implement digest --decompress

### DIFF
--- a/cmd/regctl/digest_test.go
+++ b/cmd/regctl/digest_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/regclient/regclient/pkg/archive"
+)
+
+func TestDigestDecompress(t *testing.T) {
+	// Run to confirm:  echo -n "hello" | gzip | gzcat | shasum -a 256
+	expectedChecksum := "sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+	compressionTypes := []archive.CompressType{
+		// archive.CompressBzip2,
+		archive.CompressZstd,
+		archive.CompressGzip,
+		archive.CompressXz,
+	}
+	for _, compressionType := range compressionTypes {
+		reader, err := archive.Compress(strings.NewReader("hello"), compressionType)
+		if err != nil {
+			t.Fatalf("failed to compress test data: %v", err)
+		}
+		checksum, err := cobraTest(t, &cobraTestOpts{
+			stdin: reader,
+		}, "digest", "--decompress")
+		if err != nil {
+			t.Fatalf("failed to run digest: %v", err)
+		}
+		if checksum != expectedChecksum {
+			t.Errorf("unexpected output: %v %v", checksum, expectedChecksum)
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -18,5 +18,6 @@ require (
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/klauspost/compress v1.17.8 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7 h1:UhxFibDNY/bfvqU
 github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7/go.mod h1:cyGadeNEkKy96OOhEzfZl+yxihPEzKnqJwvfuSUqbZE=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/klauspost/compress v1.17.8 h1:YcnTYrq7MikUT7k0Yb5eceMmALQPYBW/Xltxn0NAMnU=
+github.com/klauspost/compress v1.17.8/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
 github.com/olareg/olareg v0.1.0 h1:1dXBOgPrig5N7zoXyIZVQqU0QBo6sD9pbL6UYjY75CA=
 github.com/olareg/olareg v0.1.0/go.mod h1:RBuU7JW7SoIIxZKzLRhq8sVtQeAHzCAtRrXEBx2KlM4=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=

--- a/pkg/archive/compress.go
+++ b/pkg/archive/compress.go
@@ -7,6 +7,7 @@ import (
 	"compress/gzip"
 	"io"
 
+	"github.com/klauspost/compress/zstd"
 	"github.com/ulikunitz/xz"
 )
 
@@ -22,6 +23,8 @@ const (
 	CompressGzip
 	// CompressXz compression
 	CompressXz
+	// CompressZstd compression
+	CompressZstd
 )
 
 // compressHeaders are used to detect the compression type
@@ -29,32 +32,80 @@ var compressHeaders = map[CompressType][]byte{
 	CompressBzip2: []byte("\x42\x5A\x68"),
 	CompressGzip:  []byte("\x1F\x8B\x08"),
 	CompressXz:    []byte("\xFD\x37\x7A\x58\x5A\x00"),
+	CompressZstd:  []byte("\x28\xB5\x2F\xFD"),
 }
 
 func Compress(r io.Reader, oComp CompressType) (io.Reader, error) {
 	br := bufio.NewReader(r)
-	head, err := br.Peek(10)
+
+	var rComp CompressType
+
+	// Peek length of the magic header for the given compression into the stream
+	head, err := br.Peek(len(compressHeaders[oComp]))
 	if err != nil {
-		return br, err
+		if err == io.EOF {
+			// Not enough bytes to peek, that usually means the stream is shorter than
+			// length of the magic bytes header which is a sign of uncompressed stream.
+			rComp = CompressNone
+		} else {
+			return br, err
+		}
+	} else {
+		// Detect the compression type
+		rComp = DetectCompression(head)
 	}
-	rComp := DetectCompression(head)
+
+	// If the detected compression matches the requested compression, then return.
 	if rComp == oComp {
 		return br, nil
 	}
+
+	var dbr io.Reader = br
+	// If the stream is already compressed, then decompress it first
+	if oComp != CompressNone {
+		dbr, err = Decompress(br)
+		if err != nil {
+			println("here")
+			return nil, err
+		}
+	}
+
 	switch oComp {
 	case CompressGzip:
-		switch rComp {
-		case CompressNone:
-			return compressGzip(br)
-		case CompressBzip2:
-			return compressGzip(bzip2.NewReader(br))
-		case CompressXz:
-			cbr, _ := xz.NewReader(br)
-			return compressGzip(cbr)
-		}
+		return compressGzip(dbr)
+	case CompressBzip2:
+		// https://github.com/golang/go/issues/4828
+		return nil, ErrNotImplemented
+	case CompressXz:
+		return compressXz(br)
+	case CompressZstd:
+		return compressZstd(br)
+
 	}
 	// No other types currently supported
 	return nil, ErrUnknownType
+}
+
+func compressXz(src io.Reader) (io.Reader, error) {
+	pipeR, pipeW := io.Pipe()
+	go func() {
+		defer pipeW.Close()
+		xzW, _ := xz.NewWriter(pipeW)
+		defer xzW.Close()
+		_, _ = io.Copy(xzW, src)
+	}()
+	return pipeR, nil
+}
+
+func compressZstd(src io.Reader) (io.Reader, error) {
+	pipeR, pipeW := io.Pipe()
+	go func() {
+		defer pipeW.Close()
+		zstdW, _ := zstd.ZipCompressor()(pipeW)
+		defer zstdW.Close()
+		_, _ = io.Copy(zstdW, src)
+	}()
+	return pipeR, nil
 }
 
 func compressGzip(src io.Reader) (io.Reader, error) {
@@ -72,19 +123,30 @@ func compressGzip(src io.Reader) (io.Reader, error) {
 func Decompress(r io.Reader) (io.Reader, error) {
 	// create bufio to peak on first few bytes
 	br := bufio.NewReader(r)
+	var comp CompressType
 	head, err := br.Peek(10)
 	if err != nil {
-		return br, err
+		if err == io.EOF {
+			// Not enough bytes to peek, that usually means the stream is shorter than
+			// length of the magic bytes header which is a sign of uncompressed stream.
+			comp = CompressNone
+		} else {
+			return br, err
+		}
+	} else {
+		comp = DetectCompression(head)
 	}
 
 	// compare peaked data against known compression types
-	switch DetectCompression(head) {
+	switch comp {
 	case CompressBzip2:
 		return bzip2.NewReader(br), nil
 	case CompressGzip:
 		return gzip.NewReader(br)
 	case CompressXz:
 		return xz.NewReader(br)
+	case CompressZstd:
+		return zstd.ZipDecompressor()(br), nil
 	default:
 		return br, nil
 	}
@@ -110,6 +172,8 @@ func (ct CompressType) String() string {
 		return "gzip"
 	case CompressXz:
 		return "xz"
+	case CompressZstd:
+		return "zstd"
 	}
 	return "unknown"
 }


### PR DESCRIPTION
### Fixes issue

#727 

### Describe the change

This change add a new flag to `regctl digest` to decompress what's in the stdin before calculating the digest, by passing `--decompress` flag where the compression algorithm is determined using the standard magic header bytes.

### How to verify it

Run `regctl digest --decompress < testdata/metadata.tar.gz`

### Changelog text

regctl digest now supports decompression before digest calculation via `--decompress` flag.

### Please verify and check that the pull request fulfills the following requirements

- [x] Tests have been added or not applicable
- [x] Documentation has been added, updated, or not applicable
- [x] Changes have been rebased to main
- [x] Multiple commits to the same code have been squashed

