### PR TITLE
feat: image mod layer compression

### DIFF
--- a/cmd/regctl/image.go
+++ b/cmd/regctl/image.go
@@ -22,6 +22,7 @@ import (
 	"github.com/regclient/regclient/internal/ascii"
 	"github.com/regclient/regclient/internal/units"
 	"github.com/regclient/regclient/mod"
+	"github.com/regclient/regclient/pkg/archive"
 	"github.com/regclient/regclient/pkg/template"
 	"github.com/regclient/regclient/types"
 	"github.com/regclient/regclient/types/blob"
@@ -591,6 +592,19 @@ regctl image ratelimit alpine --format '{{.Remain}}'`,
 		},
 	}, "label-to-annotation", "", `set annotations from labels`)
 	flagLabelAnnot.NoOptDefVal = "true"
+	imageModCmd.Flags().VarP(&modFlagFunc{
+		t: "string",
+		f: func(val string) error {
+			var algo archive.CompressType
+			err := algo.UnmarshalText([]byte(val))
+			if err != nil {
+				return fmt.Errorf("unknown layer compression %s", val)
+			}
+			imageOpts.modOpts = append(imageOpts.modOpts,
+				mod.WithLayerCompression(algo))
+			return nil
+		},
+	}, "layer-compress", "", `change layer compression (gzip, none)`)
 	imageModCmd.Flags().VarP(&modFlagFunc{
 		t: "string",
 		f: func(val string) error {

--- a/mod/dag.go
+++ b/mod/dag.go
@@ -31,6 +31,7 @@ const (
 type dagConfig struct {
 	stepsManifest  []func(context.Context, *regclient.RegClient, ref.Ref, ref.Ref, *dagManifest) error
 	stepsOCIConfig []func(context.Context, *regclient.RegClient, ref.Ref, ref.Ref, *dagOCIConfig) error
+	stepsLayer     []func(context.Context, *regclient.RegClient, ref.Ref, ref.Ref, *dagLayer, io.ReadCloser) (io.ReadCloser, error)
 	stepsLayerFile []func(context.Context, *regclient.RegClient, ref.Ref, ref.Ref, *dagLayer, *tar.Header, io.Reader) (*tar.Header, io.Reader, changes, error)
 	maxDataSize    int64
 	rTgt           ref.Ref

--- a/mod/mod_test.go
+++ b/mod/mod_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/regclient/regclient"
 	"github.com/regclient/regclient/config"
 	"github.com/regclient/regclient/internal/rwfs"
+	"github.com/regclient/regclient/pkg/archive"
 	"github.com/regclient/regclient/scheme/reg"
 	"github.com/regclient/regclient/types/errs"
 	"github.com/regclient/regclient/types/manifest"
@@ -454,6 +455,21 @@ func TestMod(t *testing.T) {
 			name: "External layer remove unchanged",
 			opts: []Opts{
 				WithExternalURLsRm(),
+			},
+			ref:      "ocidir://testrepo:v1",
+			wantSame: true,
+		},
+		{
+			name: "Layer Uncompressed",
+			opts: []Opts{
+				WithLayerCompression(archive.CompressNone),
+			},
+			ref: "ocidir://testrepo:v1",
+		},
+		{
+			name: "Layer Compressed gzip",
+			opts: []Opts{
+				WithLayerCompression(archive.CompressGzip),
 			},
 			ref:      "ocidir://testrepo:v1",
 			wantSame: true,

--- a/pkg/archive/compress.go
+++ b/pkg/archive/compress.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"compress/bzip2"
 	"compress/gzip"
+	"fmt"
 	"io"
 
 	"github.com/ulikunitz/xz"
@@ -101,15 +102,39 @@ func DetectCompression(head []byte) CompressType {
 }
 
 func (ct CompressType) String() string {
+	mt, err := ct.MarshalText()
+	if err != nil {
+		return "unknown"
+	}
+	return string(mt)
+}
+
+func (ct CompressType) MarshalText() ([]byte, error) {
 	switch ct {
 	case CompressNone:
-		return "none"
+		return []byte("none"), nil
 	case CompressBzip2:
-		return "bzip2"
+		return []byte("bzip2"), nil
 	case CompressGzip:
-		return "gzip"
+		return []byte("gzip"), nil
 	case CompressXz:
-		return "xz"
+		return []byte("xz"), nil
 	}
-	return "unknown"
+	return nil, fmt.Errorf("unknown compression type")
+}
+
+func (ct *CompressType) UnmarshalText(text []byte) error {
+	switch string(text) {
+	case "none":
+		*ct = CompressNone
+	case "bzip2":
+		*ct = CompressBzip2
+	case "gzip":
+		*ct = CompressGzip
+	case "xz":
+		*ct = CompressXz
+	default:
+		return fmt.Errorf("unknown compression type %s", string(text))
+	}
+	return nil
 }

--- a/types/mediatype/mediatype.go
+++ b/types/mediatype/mediatype.go
@@ -25,6 +25,8 @@ const (
 	OCI1ManifestList = "application/vnd.oci.image.index.v1+json"
 	// OCI1ImageConfig OCI v1 configuration json object media type.
 	OCI1ImageConfig = "application/vnd.oci.image.config.v1+json"
+	// Docker2Layer is the uncompressed layer for docker schema2.
+	Docker2Layer = "application/vnd.docker.image.rootfs.diff.tar"
 	// Docker2LayerGzip is the default compressed layer for docker schema2.
 	Docker2LayerGzip = "application/vnd.docker.image.rootfs.diff.tar.gzip"
 	// Docker2ForeignLayer is the default compressed layer for foreign layers in docker schema2.


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Fixes: #719.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This adds the ability to change the layer compression with image mod. Note that zstd support needs to be added which will change this and a lot of other code. This currently supports changing between gzip and none.

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
regctl image mod $image --layer-compress none --create $tag
```

<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Feature: Add ability to modify the layer compression.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
