### PR TITLE
Feat: Adding zstd support

### DIFF
--- a/cmd/regbot/sandbox/image.go
+++ b/cmd/regbot/sandbox/image.go
@@ -277,6 +277,7 @@ func (s *Sandbox) imageImportTar(ls *lua.LState) int {
 	if err != nil {
 		ls.RaiseError("Failed to read from \"%s\": %v", file, err)
 	}
+	defer rs.Close()
 	err = s.rc.ImageImport(s.ctx, tgt.r, rs)
 	if err != nil {
 		ls.RaiseError("Failed to import image \"%s\" from \"%s\": %v", tgt.r.CommonName(), file, err)

--- a/cmd/regctl/image.go
+++ b/cmd/regctl/image.go
@@ -604,7 +604,7 @@ regctl image ratelimit alpine --format '{{.Remain}}'`,
 				mod.WithLayerCompression(algo))
 			return nil
 		},
-	}, "layer-compress", "", `change layer compression (gzip, none)`)
+	}, "layer-compress", "", `change layer compression (gzip, none, zstd)`)
 	imageModCmd.Flags().VarP(&modFlagFunc{
 		t: "string",
 		f: func(val string) error {

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.20
 
 require (
 	github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7
+	github.com/klauspost/compress v1.17.8
 	github.com/olareg/olareg v0.1.0
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/robfig/cron/v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7 h1:UhxFibDNY/bfvqU
 github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7/go.mod h1:cyGadeNEkKy96OOhEzfZl+yxihPEzKnqJwvfuSUqbZE=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/klauspost/compress v1.17.8 h1:YcnTYrq7MikUT7k0Yb5eceMmALQPYBW/Xltxn0NAMnU=
+github.com/klauspost/compress v1.17.8/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
 github.com/olareg/olareg v0.1.0 h1:1dXBOgPrig5N7zoXyIZVQqU0QBo6sD9pbL6UYjY75CA=
 github.com/olareg/olareg v0.1.0/go.mod h1:RBuU7JW7SoIIxZKzLRhq8sVtQeAHzCAtRrXEBx2KlM4=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=

--- a/image_test.go
+++ b/image_test.go
@@ -491,6 +491,7 @@ func TestExportImport(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to open tar: %v", err)
 	}
+	defer fileIn2.Close()
 	fileIn2Seeker, ok := fileIn2.(io.ReadSeeker)
 	if !ok {
 		t.Fatalf("could not convert fileIn to io.ReadSeeker, type %T", fileIn2)
@@ -504,6 +505,7 @@ func TestExportImport(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to open tar: %v", err)
 	}
+	defer fileIn3.Close()
 	fileIn3Seeker, ok := fileIn3.(io.ReadSeeker)
 	if !ok {
 		t.Fatalf("could not convert fileIn to io.ReadSeeker, type %T", fileIn3)

--- a/mod/manifest.go
+++ b/mod/manifest.go
@@ -320,13 +320,19 @@ func WithManifestToDocker() Opts {
 					changed = true
 				}
 				for i, l := range ociM.Layers {
-					if l.MediaType == mediatype.OCI1LayerGzip {
+					switch l.MediaType {
+					case mediatype.OCI1Layer:
+						ociM.Layers[i].MediaType = mediatype.Docker2Layer
+					case mediatype.OCI1LayerGzip:
 						ociM.Layers[i].MediaType = mediatype.Docker2LayerGzip
-						changed = true
-					} else if l.MediaType == mediatype.OCI1ForeignLayerGzip {
+					case mediatype.OCI1LayerZstd:
+						ociM.Layers[i].MediaType = mediatype.Docker2LayerZstd
+					case mediatype.OCI1ForeignLayerGzip:
 						ociM.Layers[i].MediaType = mediatype.Docker2ForeignLayer
-						changed = true
+					default:
+						continue
 					}
+					changed = true
 				}
 				if changed {
 					dm := schema2.Manifest{}
@@ -384,13 +390,19 @@ func WithManifestToOCI() Opts {
 					changed = true
 				}
 				for i, l := range ociM.Layers {
-					if l.MediaType == mediatype.Docker2LayerGzip {
+					switch l.MediaType {
+					case mediatype.Docker2Layer:
+						ociM.Layers[i].MediaType = mediatype.OCI1Layer
+					case mediatype.Docker2LayerGzip:
 						ociM.Layers[i].MediaType = mediatype.OCI1LayerGzip
-						changed = true
-					} else if l.MediaType == mediatype.Docker2ForeignLayer {
+					case mediatype.Docker2LayerZstd:
+						ociM.Layers[i].MediaType = mediatype.OCI1LayerZstd
+					case mediatype.Docker2ForeignLayer:
 						ociM.Layers[i].MediaType = mediatype.OCI1ForeignLayerGzip
-						changed = true
+					default:
+						continue
 					}
+					changed = true
 				}
 				if changed {
 					om = ociM

--- a/mod/mod_test.go
+++ b/mod/mod_test.go
@@ -475,6 +475,13 @@ func TestMod(t *testing.T) {
 			wantSame: true,
 		},
 		{
+			name: "Layer Compressed zstd",
+			opts: []Opts{
+				WithLayerCompression(archive.CompressZstd),
+			},
+			ref: "ocidir://testrepo:v1",
+		},
+		{
 			name: "Layer Reproducible",
 			opts: []Opts{
 				WithLayerReproducible(),

--- a/pkg/archive/compress.go
+++ b/pkg/archive/compress.go
@@ -5,9 +5,11 @@ import (
 	"bytes"
 	"compress/bzip2"
 	"compress/gzip"
+	"errors"
 	"fmt"
 	"io"
 
+	"github.com/klauspost/compress/zstd"
 	"github.com/ulikunitz/xz"
 )
 
@@ -15,14 +17,11 @@ import (
 type CompressType int
 
 const (
-	// CompressNone detected no compression
-	CompressNone CompressType = iota
-	// CompressBzip2 compression
-	CompressBzip2
-	// CompressGzip compression
-	CompressGzip
-	// CompressXz compression
-	CompressXz
+	CompressNone  CompressType = iota // uncompressed or unable to detect compression
+	CompressBzip2                     // bzip2
+	CompressGzip                      // gzip
+	CompressXz                        // xz
+	CompressZstd                      // zstd
 )
 
 // compressHeaders are used to detect the compression type
@@ -30,43 +29,58 @@ var compressHeaders = map[CompressType][]byte{
 	CompressBzip2: []byte("\x42\x5A\x68"),
 	CompressGzip:  []byte("\x1F\x8B\x08"),
 	CompressXz:    []byte("\xFD\x37\x7A\x58\x5A\x00"),
+	CompressZstd:  []byte("\x28\xB5\x2F\xFD"),
 }
 
-func Compress(r io.Reader, oComp CompressType) (io.Reader, error) {
-	br := bufio.NewReader(r)
-	head, err := br.Peek(10)
-	if err != nil {
-		return br, err
-	}
-	rComp := DetectCompression(head)
-	if rComp == oComp {
-		return br, nil
-	}
+func Compress(r io.Reader, oComp CompressType) (io.ReadCloser, error) {
 	switch oComp {
+	// note, bzip2 compression is not supported
 	case CompressGzip:
-		switch rComp {
-		case CompressNone:
-			return compressGzip(br)
-		case CompressBzip2:
-			return compressGzip(bzip2.NewReader(br))
-		case CompressXz:
-			cbr, _ := xz.NewReader(br)
-			return compressGzip(cbr)
-		}
+		return writeToRead(r, newGzipWriter)
+	case CompressXz:
+		return writeToRead(r, xz.NewWriter)
+	case CompressZstd:
+		return writeToRead(r, newZstdWriter)
+	case CompressNone:
+		return io.NopCloser(r), nil
+	default:
+		return nil, ErrUnknownType
 	}
-	// No other types currently supported
-	return nil, ErrUnknownType
 }
 
-func compressGzip(src io.Reader) (io.Reader, error) {
-	pipeR, pipeW := io.Pipe()
+// newGzipWriter generates a writer and an always nil error.
+func newGzipWriter(w io.Writer) (io.WriteCloser, error) {
+	return gzip.NewWriter(w), nil
+}
+
+// newZstdWriter generates a writer with the default options.
+func newZstdWriter(w io.Writer) (io.WriteCloser, error) {
+	return zstd.NewWriter(w)
+}
+
+// writeToRead uses a pipe + goroutine + copy to switch from a writer to a reader.
+func writeToRead[wc io.WriteCloser](src io.Reader, newWriterFn func(io.Writer) (wc, error)) (io.ReadCloser, error) {
+	pr, pw := io.Pipe()
 	go func() {
-		defer pipeW.Close()
-		gzipW := gzip.NewWriter(pipeW)
-		defer gzipW.Close()
-		_, _ = io.Copy(gzipW, src)
+		// buffer output to avoid lots of small reads
+		bw := bufio.NewWriterSize(pw, 2<<16)
+		dest, err := newWriterFn(bw)
+		if err != nil {
+			_ = pw.CloseWithError(err)
+			return
+		}
+		if _, err := io.Copy(dest, src); err != nil {
+			_ = pw.CloseWithError(err)
+		}
+		if err := dest.Close(); err != nil {
+			_ = pw.CloseWithError(err)
+		}
+		if err := bw.Flush(); err != nil {
+			_ = pw.CloseWithError(err)
+		}
+		_ = pw.Close()
 	}()
-	return pipeR, nil
+	return pr, nil
 }
 
 // Decompress extracts gzip and bzip streams
@@ -74,8 +88,8 @@ func Decompress(r io.Reader) (io.Reader, error) {
 	// create bufio to peak on first few bytes
 	br := bufio.NewReader(r)
 	head, err := br.Peek(10)
-	if err != nil {
-		return br, err
+	if err != nil && !errors.Is(err, io.EOF) {
+		return br, fmt.Errorf("failed to detect compression: %w", err)
 	}
 
 	// compare peaked data against known compression types
@@ -86,6 +100,8 @@ func Decompress(r io.Reader) (io.Reader, error) {
 		return gzip.NewReader(br)
 	case CompressXz:
 		return xz.NewReader(br)
+	case CompressZstd:
+		return zstd.NewReader(br)
 	default:
 		return br, nil
 	}
@@ -119,6 +135,8 @@ func (ct CompressType) MarshalText() ([]byte, error) {
 		return []byte("gzip"), nil
 	case CompressXz:
 		return []byte("xz"), nil
+	case CompressZstd:
+		return []byte("zstd"), nil
 	}
 	return nil, fmt.Errorf("unknown compression type")
 }
@@ -133,6 +151,8 @@ func (ct *CompressType) UnmarshalText(text []byte) error {
 		*ct = CompressGzip
 	case "xz":
 		*ct = CompressXz
+	case "zstd":
+		*ct = CompressZstd
 	default:
 		return fmt.Errorf("unknown compression type %s", string(text))
 	}

--- a/pkg/archive/compress_test.go
+++ b/pkg/archive/compress_test.go
@@ -1,0 +1,70 @@
+package archive
+
+import (
+	"bytes"
+	"io"
+	"testing"
+)
+
+func TestMarshal(t *testing.T) {
+	for _, algo := range []CompressType{CompressNone, CompressGzip, CompressBzip2, CompressXz, CompressZstd} {
+		t.Run(algo.String(), func(t *testing.T) {
+			var newAlgo CompressType
+			b, err := algo.MarshalText()
+			if err != nil {
+				t.Fatalf("failed to marshal: %v", err)
+			}
+			err = newAlgo.UnmarshalText(b)
+			if err != nil {
+				t.Fatalf("failed to unmarshal: %v", err)
+			}
+			if algo != newAlgo {
+				t.Errorf("marshaling round trip failed for %s: %v -> %s -> %v", algo.String(), algo, string(b), newAlgo)
+			}
+		})
+	}
+}
+
+func TestRoundtrip(t *testing.T) {
+	t.Parallel()
+	tt := []struct {
+		name    string
+		content []byte
+	}{
+		{
+			name:    "empty",
+			content: []byte(``),
+		},
+		{
+			name:    "hello-world",
+			content: []byte(`hello world`),
+		},
+	}
+	for _, algo := range []CompressType{CompressNone, CompressGzip, CompressXz, CompressZstd} {
+		algo := algo
+		t.Run(algo.String(), func(t *testing.T) {
+			for _, tc := range tt {
+				tc := tc
+				t.Run(tc.name, func(t *testing.T) {
+					t.Parallel()
+					br := bytes.NewReader(tc.content)
+					cr, err := Compress(br, algo)
+					if err != nil {
+						t.Fatalf("failed to compress: %v", err)
+					}
+					dr, err := Decompress(cr)
+					if err != nil {
+						t.Fatalf("failed to decompress: %v", err)
+					}
+					out, err := io.ReadAll(dr)
+					if err != nil {
+						t.Fatalf("failed to ReadAll: %v", err)
+					}
+					if !bytes.Equal(tc.content, out) {
+						t.Errorf("output mismatch: expected %s, received %s", tc.content, out)
+					}
+				})
+			}
+		})
+	}
+}

--- a/types/descriptor/descriptor.go
+++ b/types/descriptor/descriptor.go
@@ -63,11 +63,15 @@ func init() {
 		mediatype.Docker2ManifestList: mediatype.OCI1ManifestList,
 		mediatype.Docker2Manifest:     mediatype.OCI1Manifest,
 		mediatype.Docker2ImageConfig:  mediatype.OCI1ImageConfig,
+		mediatype.Docker2Layer:        mediatype.OCI1Layer,
 		mediatype.Docker2LayerGzip:    mediatype.OCI1LayerGzip,
+		mediatype.Docker2LayerZstd:    mediatype.OCI1LayerZstd,
 		mediatype.OCI1ManifestList:    mediatype.OCI1ManifestList,
 		mediatype.OCI1Manifest:        mediatype.OCI1Manifest,
 		mediatype.OCI1ImageConfig:     mediatype.OCI1ImageConfig,
+		mediatype.OCI1Layer:           mediatype.OCI1Layer,
 		mediatype.OCI1LayerGzip:       mediatype.OCI1LayerGzip,
+		mediatype.OCI1LayerZstd:       mediatype.OCI1LayerZstd,
 	}
 }
 
@@ -143,12 +147,8 @@ func (d Descriptor) Same(d2 Descriptor) bool {
 		return false
 	}
 	// loosen the check on media type since this can be converted from a build
-	if d.MediaType != d2.MediaType {
-		if _, ok := mtToOCI[d.MediaType]; !ok {
-			return false
-		} else if mtToOCI[d.MediaType] != mtToOCI[d2.MediaType] {
-			return false
-		}
+	if d.MediaType != d2.MediaType && (mtToOCI[d.MediaType] != mtToOCI[d2.MediaType] || mtToOCI[d.MediaType] == "") {
+		return false
 	}
 	return true
 }

--- a/types/mediatype/mediatype.go
+++ b/types/mediatype/mediatype.go
@@ -29,6 +29,8 @@ const (
 	Docker2Layer = "application/vnd.docker.image.rootfs.diff.tar"
 	// Docker2LayerGzip is the default compressed layer for docker schema2.
 	Docker2LayerGzip = "application/vnd.docker.image.rootfs.diff.tar.gzip"
+	// Docker2LayerZstd is the default compressed layer for docker schema2.
+	Docker2LayerZstd = "application/vnd.docker.image.rootfs.diff.tar.zstd"
 	// Docker2ForeignLayer is the default compressed layer for foreign layers in docker schema2.
 	Docker2ForeignLayer = "application/vnd.docker.image.rootfs.foreign.diff.tar.gzip"
 	// OCI1Layer is the uncompressed layer for OCIv1.


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This adds support for zstd compressed layers. It can be used with `regctl image mod`, `regctl image get-file`, and similar commands.

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
regctl image mod alpine --create localhost:5000/library/alpine:zstd --layer-compress zstd --to-oci
regctl manifest get localhost:5000/library/alpine:zstd --platform linux/amd64
regctl image get-file localhost:5000/library/alpine:zstd /etc/alpine-release
```

<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Feature: Add support for zstd compressed layers.
- Breaking: pkg/archive.Compress no longer decompresses the input.

<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
