### PR TITLE
feat: Add regctl image create command

### DIFF
--- a/cmd/regctl/image_test.go
+++ b/cmd/regctl/image_test.go
@@ -6,6 +6,19 @@ import (
 	"testing"
 )
 
+func TestImageCreate(t *testing.T) {
+	tmpDir := t.TempDir()
+	imageRef := fmt.Sprintf("ocidir://%s/repo:scratch", tmpDir)
+
+	out, err := cobraTest(t, nil, "image", "create", imageRef)
+	if err != nil {
+		t.Fatalf("failed to run image create: %v", err)
+	}
+	if out != "" {
+		t.Errorf("unexpected output: %v", out)
+	}
+}
+
 func TestImageExportImport(t *testing.T) {
 	tmpDir := t.TempDir()
 	srcRef := "ocidir://../../testdata/testrepo:v2"

--- a/docs/regctl.md
+++ b/docs/regctl.md
@@ -138,6 +138,7 @@ Usage:
 Available Commands:
   check-base  check if the base image has changed
   copy        copy or retag image
+  create      create a new image manifest
   delete      delete image
   digest      show digest for pinning
   export      export image
@@ -155,6 +156,8 @@ Otherwise this compares the image layers and build history steps to verify no ch
 The OCI annotations used to automatically detect the base image are `org.opencontainers.image.base.name` and `org.opencontainers.image.base.digest`.
 
 The `copy` command allows images to be copied between registries, between repositories on the same registry, or retag an image within the same repository, and only pulls the layers when needed (typically not needed with the same registry server).
+
+The `create` command creates a new image manifest and config, starting from scratch.
 
 The `delete` command removes the image manifest from the server.
 This will impact all tags pointing to the same manifest and requires a digest to be included in the image reference to be deleted (e.g. `myimage@sha256:abcd...`).


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Fixes #722.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This adds a `regctl image create` command that outputs a scratch manifest and image config.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
regctl image create localhost:5000/library/scratch
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
