### PR TITLE
feat: image mod ability to add layers

### DIFF
--- a/mod/dag.go
+++ b/mod/dag.go
@@ -229,9 +229,9 @@ func dagPut(ctx context.Context, rc *regclient.RegClient, mc dagConfig, rSrc, rT
 				return fmt.Errorf("manifest does not have enough layers")
 			}
 			// keep config index aligned
-			for iConfig >= 0 && oc.History[iConfig].EmptyLayer {
+			for iConfig >= 0 && iConfig < len(oc.History) && oc.History[iConfig].EmptyLayer {
 				iConfig++
-				if iConfig >= len(oc.History) {
+				if iConfig >= len(oc.History) && layer.mod != added {
 					return fmt.Errorf("config history does not have enough entries")
 				}
 			}
@@ -283,7 +283,7 @@ func dagPut(ctx context.Context, rc *regclient.RegClient, mc dagConfig, rSrc, rT
 				}
 				if iConfig < 0 {
 					// noop
-				} else if len(oc.History) == iConfig {
+				} else if iConfig >= len(oc.History) {
 					oc.History = append(oc.History, newHistory)
 				} else {
 					oc.History = append(oc.History[:iConfig+1], oc.History[iConfig:]...)

--- a/mod/mod_test.go
+++ b/mod/mod_test.go
@@ -1,11 +1,13 @@
 package mod
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"regexp"
 	"testing"
 	"time"
@@ -76,6 +78,10 @@ func TestMod(t *testing.T) {
 		tTgt.Close()
 		_ = regTgt.Close()
 	})
+	tarBytes, err := os.ReadFile("../testdata/layer.tar")
+	if err != nil {
+		t.Fatalf("failed to read testdata/layer.tar: %v", err)
+	}
 
 	// create regclient
 	rcHosts := []config.Host{
@@ -458,6 +464,13 @@ func TestMod(t *testing.T) {
 			},
 			ref:      "ocidir://testrepo:v1",
 			wantSame: true,
+		},
+		{
+			name: "Layer Add",
+			opts: []Opts{
+				WithLayerAddTar(bytes.NewReader(tarBytes), "", nil),
+			},
+			ref: "ocidir://testrepo:v1",
 		},
 		{
 			name: "Layer Uncompressed",

--- a/mod/time.go
+++ b/mod/time.go
@@ -19,7 +19,7 @@ func timeNow() time.Time {
 	if err == nil {
 		return now
 	}
-	return time.Now()
+	return time.Now().UTC()
 }
 
 func timeEpocEnv() (time.Time, error) {


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Fixes #721.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This adds the ability to append a new layer from a tar file to an image. Note that the input must be a tar file, and by default it compresses the layer with gzip and uses the appropriate media type based on the manifest media type. It supports multi-platform images where the requested platforms are updated. The digest is computed on blob push which means the blob is always pushed to the registry even if the same tar is appended to multiple images (using `ocidir://` minimizes that overhead).

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
regctl image mod registry.example.org/repo:v1 --create v1-extended \
  --layer-add "tar=file.tar,platform=linux/amd64"
```

<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Feature: Add image mod ability to append layers to an image.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
