### PR TITLE
Fix: Handle nil pointer when config file is a dir

### DIFF
--- a/cmd/regctl/root.go
+++ b/cmd/regctl/root.go
@@ -143,6 +143,9 @@ func (rootOpts *rootCmd) newRegClient() *regclient.RegClient {
 		log.WithFields(logrus.Fields{
 			"err": err,
 		}).Warn("Failed to load default config")
+		if conf == nil {
+			conf = ConfigNew()
+		}
 	}
 
 	rcOpts := []regclient.Opt{

--- a/cmd/regctl/root_test.go
+++ b/cmd/regctl/root_test.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestRootConfigDir(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// This is invalid but should gracefully degrade and not crash
+	t.Setenv("REGCTL_CONFIG", tmpDir)
+
+	out, err := cobraTest(t, nil, "tag", "ls", "ocidir://../../testdata/testrepo")
+	if err != nil {
+		t.Fatalf("failed to list tags: %v", err)
+	}
+	if out == "" {
+		t.Errorf("missing output")
+	}
+}


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Fixes #737.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Most of the code immediately returns when `ConfigLoadDefault` errors. For the one place that doesn't, it needs to initialize the config with a default value instead of leaving a nil pointer.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
REGCTL_CONFIG=. regctl manifest get ghcr.io/regclient/regctl
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Fix: Handle nil pointer when config file is a directory.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
