### PR TITLE
Handle nil blob reader

### DIFF
--- a/mod/mod.go
+++ b/mod/mod.go
@@ -131,10 +131,11 @@ func Apply(ctx context.Context, rc *regclient.RegClient, rSrc ref.Ref, opts ...O
 				return dl, nil
 			}
 			if len(dc.stepsLayer) > 0 {
-				rdr, err = rc.BlobGet(ctx, rSrc, dl.desc)
+				bRdr, err := rc.BlobGet(ctx, rSrc, dl.desc)
 				if err != nil {
 					return nil, err
 				}
+				rdr = bRdr
 				for _, sl := range dc.stepsLayer {
 					rdrNext, err := sl(ctx, rc, rSrc, rTgt, dl, rdr)
 					if err != nil {
@@ -148,10 +149,11 @@ func Apply(ctx context.Context, rc *regclient.RegClient, rSrc ref.Ref, opts ...O
 					return dl, nil
 				}
 				if rdr == nil {
-					rdr, err = rc.BlobGet(ctx, rSrc, dl.desc)
+					bRdr, err := rc.BlobGet(ctx, rSrc, dl.desc)
 					if err != nil {
 						return nil, err
 					}
+					rdr = bRdr
 				}
 				changed := false
 				empty := true

--- a/types/blob/blob_test.go
+++ b/types/blob/blob_test.go
@@ -227,6 +227,29 @@ func TestCommon(t *testing.T) {
 }
 
 func TestReader(t *testing.T) {
+	t.Run("nil", func(t *testing.T) {
+		var b *BReader
+		_, err := b.Read([]byte{})
+		if err == nil {
+			t.Errorf("nil read did not fail")
+		}
+		err = b.Close()
+		if err != nil {
+			t.Errorf("nil close failed: %v", err)
+		}
+		_, err = b.ToOCIConfig()
+		if err == nil {
+			t.Errorf("nil convert ot OCI did not fail")
+		}
+		_, err = b.ToTarReader()
+		if err == nil {
+			t.Errorf("nil convert to tar reader did not fail")
+		}
+		_, err = b.Seek(0, io.SeekStart)
+		if err == nil {
+			t.Errorf("nil seek did not fail")
+		}
+	})
 	t.Run("empty", func(t *testing.T) {
 		// create empty blob
 		b := NewReader()

--- a/types/blob/reader.go
+++ b/types/blob/reader.go
@@ -82,7 +82,7 @@ func NewReader(opts ...Opts) *BReader {
 
 // Close attempts to close the reader and populates/validates the digest.
 func (r *BReader) Close() error {
-	if r.origRdr == nil {
+	if r == nil || r.origRdr == nil {
 		return nil
 	}
 	// attempt to close if available in original reader
@@ -100,7 +100,7 @@ func (r *BReader) RawBody() ([]byte, error) {
 
 // Read passes through the read operation while computing the digest and tracking the size.
 func (r *BReader) Read(p []byte) (int, error) {
-	if r.reader == nil {
+	if r == nil || r.reader == nil {
 		return 0, fmt.Errorf("blob has no reader: %w", io.ErrUnexpectedEOF)
 	}
 	size, err := r.reader.Read(p)
@@ -133,6 +133,9 @@ func (r *BReader) Seek(offset int64, whence int) (int64, error) {
 	if offset != 0 || whence != io.SeekStart {
 		return r.readBytes, fmt.Errorf("unable to seek to arbitrary position")
 	}
+	if r == nil || r.origRdr == nil {
+		return 0, fmt.Errorf("blob has no reader")
+	}
 	rdrSeek, ok := r.origRdr.(io.Seeker)
 	if !ok {
 		return r.readBytes, fmt.Errorf("Seek unsupported")
@@ -159,7 +162,7 @@ func (r *BReader) Seek(offset int64, whence int) (int64, error) {
 
 // ToOCIConfig converts a BReader to a BOCIConfig.
 func (r *BReader) ToOCIConfig() (*BOCIConfig, error) {
-	if !r.blobSet {
+	if r == nil || !r.blobSet {
 		return nil, fmt.Errorf("blob is not defined")
 	}
 	if r.readBytes != 0 {
@@ -184,7 +187,7 @@ func (r *BReader) ToOCIConfig() (*BOCIConfig, error) {
 
 // ToTarReader converts a BReader to a BTarReader
 func (r *BReader) ToTarReader() (*BTarReader, error) {
-	if !r.blobSet {
+	if r == nil || !r.blobSet {
 		return nil, fmt.Errorf("blob is not defined")
 	}
 	if r.readBytes != 0 {


### PR DESCRIPTION

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Fixes #745.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Avoid updating the `rdr` value until after `err` is checked since an interface to a `nil` value is not `nil`. This also hardens the blob reader to prevent panics on a `nil` value.

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
regctl -v error image mod fluent/fluent-bit:1.8 --layer-compress none --create ocidir://fluent-bit:1.8
```
followed by pressing `cont+c` to cancel the blob read.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Fix: Prevent panic on interrupted image mod.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
