### PR TITLE
Feat: Return non-zero on a failed registry ping

### DIFF
--- a/cmd/regctl/registry.go
+++ b/cmd/regctl/registry.go
@@ -301,7 +301,6 @@ func (registryOpts *registryCmd) runRegistryLogin(cmd *cobra.Command, args []str
 	if err != nil {
 		return err
 	}
-
 	if !registryOpts.skipCheck {
 		r, err := ref.NewHost(args[0])
 		if err != nil {
@@ -310,9 +309,8 @@ func (registryOpts *registryCmd) runRegistryLogin(cmd *cobra.Command, args []str
 		rc := registryOpts.rootOpts.newRegClient()
 		_, err = rc.Ping(ctx, r)
 		if err != nil {
-			log.WithFields(logrus.Fields{
-				"err": err,
-			}).Warn("Failed to ping registry with credentials")
+			log.Warn("Failed to ping registry, credentials were still stored")
+			return err
 		}
 	}
 	log.WithFields(logrus.Fields{
@@ -453,9 +451,8 @@ func (registryOpts *registryCmd) runRegistrySet(cmd *cobra.Command, args []strin
 		rc := registryOpts.rootOpts.newRegClient()
 		_, err = rc.Ping(ctx, r)
 		if err != nil {
-			log.WithFields(logrus.Fields{
-				"err": err,
-			}).Warn("Failed to ping registry with settings")
+			log.Warn("Failed to ping registry, configuration still updated")
+			return err
 		}
 	}
 


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Fixes #750
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

On a `regctl registry set` or `regctl registry login`, return a non-zero if the registry ping fails. This is skipped when `--skip-check` is passed.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Perform `regctl registry set` to a non-existent registry, or `regctl registry login` with an invalid credential.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Breaking: `regctl registry set` and `regctl registry login` will return a non-zero if the ping fails.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
