### PR TITLE
Fix: Enable deletion on olareg tests

### DIFF
--- a/tag_test.go
+++ b/tag_test.go
@@ -22,11 +22,15 @@ func TestTag(t *testing.T) {
 	existingRepo := "testrepo"
 	existingTag := "v2"
 	ctx := context.Background()
+	trueV := true
 	falseV := false
 	regRWHandler := olareg.New(oConfig.Config{
 		Storage: oConfig.ConfigStorage{
 			StoreType: oConfig.StoreMem,
 			RootDir:   "./testdata",
+		},
+		API: oConfig.ConfigAPI{
+			DeleteEnabled: &trueV,
 		},
 	})
 	regROHandler := olareg.New(oConfig.Config{
@@ -38,7 +42,6 @@ func TestTag(t *testing.T) {
 			DeleteEnabled: &falseV,
 		},
 	})
-	// TODO: test with a registry without the delete APIs
 	tsRW := httptest.NewServer(regRWHandler)
 	tsRWURL, _ := url.Parse(tsRW.URL)
 	tsRWHost := tsRWURL.Host


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Enable deletion on olareg tests. While not needed yet, olareg has a breaking change to disable deletions by default in the next release.

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
make test
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Fix: Enable deletion on olareg tests
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
