### PR TITLE
feat: allow ~ (tilde) in reference paths

### DIFF
--- a/types/ref/ref.go
+++ b/types/ref/ref.go
@@ -29,7 +29,7 @@ var (
 	hostUpperS  = `(?:[a-zA-Z0-9]*[A-Z][a-zA-Z0-9-]*[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[A-Z][a-zA-Z0-9]*)`
 	registryS   = `(?:` + hostDomainS + `|` + hostPortS + `|` + hostUpperS + `|localhost(?:` + regexp.QuoteMeta(`:`) + `[0-9]+)?)`
 	repoPartS   = `[a-z0-9]+(?:(?:\.|_|__|-+)[a-z0-9]+)*`
-	pathS       = `[/a-zA-Z0-9_\-. ]+`
+	pathS       = `[/a-zA-Z0-9_\-. ~]+`
 	tagS        = `[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}`
 	digestS     = `[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,}`
 	schemeRE    = regexp.MustCompile(`^([a-z]+)://(.+)$`)

--- a/types/ref/ref_test.go
+++ b/types/ref/ref_test.go
@@ -304,6 +304,17 @@ func TestNew(t *testing.T) {
 			wantE:      nil,
 		},
 		{
+			name:       "OCI dir with tilde",
+			ref:        "ocidir://path/2/~dir~/rules_oci~/examples:latest",
+			scheme:     "ocidir",
+			registry:   "",
+			repository: "",
+			tag:        "latest",
+			digest:     "",
+			path:       "path/2/~dir~/rules_oci~/examples",
+			wantE:      nil,
+		},
+		{
 			name:  "invalid scheme",
 			ref:   "unknown://repo:tag",
 			wantE: errs.ErrInvalidReference,


### PR DESCRIPTION
### Fixes issue

https://github.com/bazel-contrib/rules_oci/issues/588

### Describe the change

Allows `~` tilde in reference paths such as `ocidir://`, this needed because Bazel adds tildes to namespace dependencies. 

### How to verify it

Added tests 

### Changelog text

Allow `~` tilde in reference paths

### Please verify and check that the pull request fulfills the following requirements

- [x] Tests have been added or not applicable
- [x] Documentation has been added, updated, or not applicable
- [x] Changes have been rebased to main
- [x] Multiple commits to the same code have been squashed

