### PR TITLE
Add experimental platform prefer field

### DIFF
--- a/types/platform/platform.go
+++ b/types/platform/platform.go
@@ -49,9 +49,13 @@ type Platform struct {
 
 	// Features is an optional field specifying an array of strings, each listing a required CPU feature (for example `sse4` or `aes`).
 	Features []string `json:"features,omitempty"`
+
+	// Prefer indicates additional capabilities of a platform that may be preferred by some hosts.
+	// This field is EXPERIMENTAL.
+	Prefer map[string]string `json:"prefer,omitempty"`
 }
 
-// String outputs the platform in the <os>/<arch>/<variant> notation
+// String outputs the platform in the <os>/<arch>/<variant> notation.
 func (p Platform) String() string {
 	(&p).normalize()
 	if p.OS == "" {
@@ -61,7 +65,14 @@ func (p Platform) String() string {
 	}
 }
 
-// Parse converts a platform string into a struct
+// Parse converts a platform string into a struct.
+// The typical parsing is for the <os>/<arch>/<variant> input, where variant is optional depending on the arch.
+// Values that are not provided will be interpreted from the host, e.g. an input of "linux" will populate the other fields from the host.
+// To align with other implementations, <arch> may be passed alone for well known architectures.
+// regclient specific features include the ability to pass the string "local" to return the local platform, and additional comma separated key=value arguments.
+// Supported key=value fields include:
+//   - "osver" for windows, e.g. windows/amd64,osver=10.0.17763.5820.
+//   - "prefer" for indicating preferences, EXPERIMENTAL, e.g. linux/arm64,prefer="com.example.gpu=model-123,org.example.runtime=sandbox-x".
 func Parse(platStr string) (Platform, error) {
 	// args are a regclient specific way to extend the platform string
 	platArgs := strings.SplitN(platStr, ",", 2)
@@ -97,6 +108,12 @@ func Parse(platStr string) (Platform, error) {
 			switch strings.ToLower(k) {
 			case "osver", "osversion":
 				plat.OSVersion = v
+			case "prefer":
+				prefMap, err := strparse.SplitCSKV(v)
+				if err != nil {
+					return Platform{}, fmt.Errorf("failed to parse prefer arg in %s: %w", platStr, err)
+				}
+				plat.Prefer = prefMap
 			default:
 				return Platform{}, fmt.Errorf("unsupported platform arg type, %s in %s%.0w", k, platStr, errs.ErrParsingFailed)
 			}

--- a/types/platform/platform_test.go
+++ b/types/platform/platform_test.go
@@ -132,6 +132,11 @@ func TestPlatformParse(t *testing.T) {
 			goal:  Platform{OS: "windows", Architecture: "amd64", Variant: "v2"},
 		},
 		{
+			name:  "linux-with-prefers",
+			parse: "linux/arm64,prefer=\"com.example.gpu=model-123,org.example.runtime=sandbox-x\"",
+			goal:  Platform{OS: "linux", Architecture: "arm64", Prefer: map[string]string{"com.example.gpu": "model-123", "org.example.runtime": "sandbox-x"}},
+		},
+		{
 			name:  "windows",
 			parse: "windows",
 			goal:  winGoal,
@@ -166,6 +171,9 @@ func TestPlatformParse(t *testing.T) {
 			}
 			if p.OS != tt.goal.OS || p.Architecture != tt.goal.Architecture || p.Variant != tt.goal.Variant || p.OSVersion != tt.goal.OSVersion {
 				t.Errorf("platform did not match, want %v, received %v", tt.goal, p)
+			}
+			if !mapStrStrEq(p.Prefer, tt.goal.Prefer) {
+				t.Errorf("prefer list mismatch, want %v, received %v", tt.goal.Prefer, p.Prefer)
 			}
 		})
 	}
@@ -216,4 +224,16 @@ func TestPlatformString(t *testing.T) {
 			}
 		})
 	}
+}
+
+func mapStrStrEq(m1, m2 map[string]string) bool {
+	if len(m1) != len(m2) {
+		return false
+	}
+	for k, v := range m1 {
+		if v2, ok := m2[k]; !ok || v != v2 {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This is an experimental feature being tested for the OCI image compatibility working group.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

The platform parser now accepts prefers using the syntax "linux/amd64,prefer=\"key1=val1,key2=val2\"" 
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Feat: Adding an experimental prefer field in platform.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [ ] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
