### PR TITLE
Support changing digest algorithm

### DIFF
--- a/cmd/regctl/image.go
+++ b/cmd/regctl/image.go
@@ -546,6 +546,13 @@ regctl image ratelimit alpine --format '{{.Remain}}'`,
 	imageModCmd.Flags().VarP(&modFlagFunc{
 		t: "stringArray",
 		f: func(val string) error {
+			imageOpts.modOpts = append(imageOpts.modOpts, mod.WithDigestAlgo(digest.Algorithm(val)))
+			return nil
+		},
+	}, "digest-algo", "", `change the digest algorithm (sha256, sha512)`)
+	imageModCmd.Flags().VarP(&modFlagFunc{
+		t: "stringArray",
+		f: func(val string) error {
 			imageOpts.modOpts = append(imageOpts.modOpts, mod.WithExposeAdd(val))
 			return nil
 		},

--- a/image.go
+++ b/image.go
@@ -1092,6 +1092,9 @@ func (rc *RegClient) ImageExport(ctx context.Context, r ref.Ref, outStream io.Wr
 		if err != nil {
 			return err
 		}
+		if err = conf.Digest.Validate(); err != nil {
+			return err
+		}
 		refTag := opt.exportRef.ToReg()
 		if refTag.Digest != "" {
 			refTag.Digest = ""
@@ -1110,6 +1113,9 @@ func (rc *RegClient) ImageExport(ctx context.Context, r ref.Ref, outStream io.Wr
 			return err
 		}
 		for _, d := range dl {
+			if err = d.Digest.Validate(); err != nil {
+				return err
+			}
 			dockerManifest.Layers = append(dockerManifest.Layers, tarOCILayoutDescPath(d))
 			dockerManifest.LayerSources[d.Digest] = d
 		}
@@ -1132,6 +1138,9 @@ func (rc *RegClient) ImageExport(ctx context.Context, r ref.Ref, outStream io.Wr
 
 // imageExportDescriptor pulls a manifest or blob, outputs to a tar file, and recursively processes any nested manifests or blobs
 func (rc *RegClient) imageExportDescriptor(ctx context.Context, r ref.Ref, desc descriptor.Descriptor, twd *tarWriteData) error {
+	if err := desc.Digest.Validate(); err != nil {
+		return err
+	}
 	tarFilename := tarOCILayoutDescPath(desc)
 	if twd.files[tarFilename] {
 		// blob has already been imported into tar, skip
@@ -1486,7 +1495,10 @@ func (rc *RegClient) imageImportOCIHandleManifest(ctx context.Context, r ref.Ref
 	// cache the manifest to avoid needing to pull again later, this is used if index.json is a wrapper around some other manifest
 	trd.manifests[m.GetDescriptor().Digest] = m
 
-	handleManifest := func(d descriptor.Descriptor, child bool) {
+	handleManifest := func(d descriptor.Descriptor, child bool) error {
+		if err := d.Digest.Validate(); err != nil {
+			return err
+		}
 		filename := tarOCILayoutDescPath(d)
 		if !trd.processed[filename] && trd.handlers[filename] == nil {
 			trd.handlers[filename] = func(header *tar.Header, trd *tarReadData) error {
@@ -1520,6 +1532,7 @@ func (rc *RegClient) imageImportOCIHandleManifest(ctx context.Context, r ref.Ref
 				}
 			}
 		}
+		return nil
 	}
 
 	if !push {
@@ -1563,7 +1576,10 @@ func (rc *RegClient) imageImportOCIHandleManifest(ctx context.Context, r ref.Ref
 				return fmt.Errorf("could not find requested tag in index.json, %s", r.Tag)
 			}
 		}
-		handleManifest(d, false)
+		err = handleManifest(d, false)
+		if err != nil {
+			return err
+		}
 		// add a finish step to tag the selected digest
 		trd.finish = append(trd.finish, func() error {
 			mRef, ok := trd.manifests[d.Digest]
@@ -1583,7 +1599,10 @@ func (rc *RegClient) imageImportOCIHandleManifest(ctx context.Context, r ref.Ref
 			return err
 		}
 		for _, d := range dl {
-			handleManifest(d, true)
+			err = handleManifest(d, true)
+			if err != nil {
+				return err
+			}
 		}
 	} else {
 		// else if a single image/manifest
@@ -1594,6 +1613,9 @@ func (rc *RegClient) imageImportOCIHandleManifest(ctx context.Context, r ref.Ref
 		// add handler for the config descriptor if it's defined
 		cd, err := mi.GetConfig()
 		if err == nil {
+			if err = cd.Digest.Validate(); err != nil {
+				return err
+			}
 			filename := tarOCILayoutDescPath(cd)
 			if !trd.processed[filename] && trd.handlers[filename] == nil {
 				func(cd descriptor.Descriptor) {
@@ -1609,6 +1631,9 @@ func (rc *RegClient) imageImportOCIHandleManifest(ctx context.Context, r ref.Ref
 			return err
 		}
 		for _, d := range layers {
+			if err = d.Digest.Validate(); err != nil {
+				return err
+			}
 			filename := tarOCILayoutDescPath(d)
 			if !trd.processed[filename] && trd.handlers[filename] == nil {
 				func(d descriptor.Descriptor) {

--- a/internal/reqresp/reqresp.go
+++ b/internal/reqresp/reqresp.go
@@ -173,7 +173,7 @@ func NewRandomBlob(size int, seed int64) (digest.Digest, []byte) {
 	} else if n != size {
 		panic("unable to read enough bytes")
 	}
-	return digest.FromBytes(b), b
+	return digest.Canonical.FromBytes(b), b
 }
 
 // NewRandomID outputs a reproducible random ID (based on the seed) appropriate for blob upload URLs.

--- a/mod/mod.go
+++ b/mod/mod.go
@@ -157,12 +157,12 @@ func Apply(ctx context.Context, rc *regclient.RegClient, rSrc ref.Ref, opts ...O
 				}
 				changed := false
 				empty := true
-				mt := dl.desc.MediaType
+				desc := dl.desc
 				if dl.newDesc.MediaType != "" {
-					mt = dl.newDesc.MediaType
+					desc = dl.newDesc
 				}
 				// if compressed, setup a decompressing reader that passes through the close
-				if mt != mediatype.OCI1Layer && mt != mediatype.Docker2Layer {
+				if desc.MediaType != mediatype.OCI1Layer && desc.MediaType != mediatype.Docker2Layer {
 					dr, err := archive.Decompress(rdr)
 					if err != nil {
 						_ = rdr.Close()
@@ -185,8 +185,8 @@ func Apply(ctx context.Context, rc *regclient.RegClient, rSrc ref.Ref, opts ...O
 				var tw *tar.Writer
 				var gw *gzip.Writer
 				var zw *zstd.Encoder
-				digRaw := digest.Canonical.Digester() // raw/compressed digest
-				digUC := digest.Canonical.Digester()  // uncompressed digest
+				digRaw := desc.DigestAlgo().Digester() // raw/compressed digest
+				digUC := desc.DigestAlgo().Digester()  // uncompressed digest
 				if dl.desc.MediaType == mediatype.Docker2LayerGzip || dl.desc.MediaType == mediatype.OCI1LayerGzip {
 					cw := io.MultiWriter(fh, digRaw.Hash())
 					gw = gzip.NewWriter(cw)
@@ -290,11 +290,9 @@ func Apply(ctx context.Context, rc *regclient.RegClient, rSrc ref.Ref, opts ...O
 						return nil, err
 					}
 					rdr = fh
-					dl.newDesc = descriptor.Descriptor{
-						MediaType: mt,
-						Digest:    digRaw.Digest(),
-						Size:      l,
-					}
+					desc.Digest = digRaw.Digest()
+					desc.Size = l
+					dl.newDesc = desc
 					dl.ucDigest = digUC.Digest()
 					if dl.mod == unchanged {
 						dl.mod = replaced
@@ -304,7 +302,7 @@ func Apply(ctx context.Context, rc *regclient.RegClient, rSrc ref.Ref, opts ...O
 			// if added or replaced, and reader not nil, push blob
 			if (dl.mod == added || dl.mod == replaced) && rdr != nil {
 				// push the blob and verify the results
-				dNew, err := rc.BlobPut(ctx, rTgt, descriptor.Descriptor{}, rdr)
+				dNew, err := rc.BlobPut(ctx, rTgt, dl.newDesc, rdr)
 				if err != nil {
 					return nil, err
 				}
@@ -360,6 +358,28 @@ func WithRefTgt(rTgt ref.Ref) Opts {
 func WithData(maxDataSize int64) Opts {
 	return func(dc *dagConfig, dm *dagManifest) error {
 		dc.maxDataSize = maxDataSize
+		return nil
+	}
+}
+
+// WithDigestAlgo sets the digest algorithm for both manifests and layers.
+func WithDigestAlgo(algo digest.Algorithm) Opts {
+	layerOpt := WithLayerDigestAlgo(algo)
+	configOpt := WithConfigDigestAlgo(algo)
+	manOpt := WithManifestDigestAlgo(algo)
+	return func(dc *dagConfig, dm *dagManifest) error {
+		err := layerOpt(dc, dm)
+		if err != nil {
+			return err
+		}
+		err = configOpt(dc, dm)
+		if err != nil {
+			return err
+		}
+		err = manOpt(dc, dm)
+		if err != nil {
+			return err
+		}
 		return nil
 	}
 }

--- a/mod/mod_test.go
+++ b/mod/mod_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"path/filepath"
 	"regexp"
 	"testing"
 	"time"
@@ -18,6 +19,7 @@ import (
 
 	"github.com/regclient/regclient"
 	"github.com/regclient/regclient/config"
+	"github.com/regclient/regclient/internal/copyfs"
 	"github.com/regclient/regclient/pkg/archive"
 	"github.com/regclient/regclient/scheme/reg"
 	"github.com/regclient/regclient/types/errs"
@@ -73,6 +75,11 @@ func TestMod(t *testing.T) {
 		tTgt.Close()
 		_ = regTgt.Close()
 	})
+	tempDir := t.TempDir()
+	err = copyfs.Copy(filepath.Join(tempDir, "testrepo"), "../testdata/testrepo")
+	if err != nil {
+		t.Fatalf("failed to setup tempDir: %v", err)
+	}
 
 	// create regclient
 	rcHosts := []config.Host{
@@ -333,6 +340,21 @@ func TestMod(t *testing.T) {
 			wantErr: fmt.Errorf("label not found: org.opencontainers.image.created"),
 		},
 		{
+			name: "Config Digest sha256",
+			opts: []Opts{
+				WithConfigDigestAlgo(digest.SHA256),
+			},
+			ref:      tTgtHost + "/testrepo:v1",
+			wantSame: true,
+		},
+		{
+			name: "Config Digest sha512 ocidir",
+			opts: []Opts{
+				WithConfigDigestAlgo(digest.SHA512),
+			},
+			ref: "ocidir://" + tempDir + "/testrepo:v1",
+		},
+		{
 			name: "Config Time",
 			opts: []Opts{
 				WithConfigTimestampMax(baseTime),
@@ -431,6 +453,21 @@ func TestMod(t *testing.T) {
 			ref: tTgtHost + "/testrepo:v1",
 		},
 		{
+			name: "Digest sha256",
+			opts: []Opts{
+				WithDigestAlgo(digest.SHA256),
+			},
+			ref:      tTgtHost + "/testrepo:v1",
+			wantSame: true,
+		},
+		{
+			name: "Digest sha512 ocidir",
+			opts: []Opts{
+				WithDigestAlgo(digest.SHA512),
+			},
+			ref: "ocidir://" + tempDir + "/testrepo:v1",
+		},
+		{
 			name: "Expose Port",
 			opts: []Opts{
 				WithExposeAdd("8080"),
@@ -490,6 +527,29 @@ func TestMod(t *testing.T) {
 			},
 			ref: tTgtHost + "/testrepo:v1",
 		},
+		{
+			name: "Layer Digest sha256",
+			opts: []Opts{
+				WithLayerDigestAlgo(digest.SHA256),
+			},
+			ref:      tTgtHost + "/testrepo:v1",
+			wantSame: true,
+		},
+		{
+			name: "Layer Digest sha512 ocidir",
+			opts: []Opts{
+				WithLayerDigestAlgo(digest.SHA512),
+			},
+			ref: "ocidir://" + tempDir + "/testrepo:v1",
+		},
+		// TODO(bmitch): enable when registry support is added
+		// {
+		// 	name: "Layer Digest sha512 registry",
+		// 	opts: []Opts{
+		// 		WithLayerDigestAlgo(digest.SHA512),
+		// 	},
+		// 	ref: tTgtHost + "/testrepo:v1",
+		// },
 		{
 			name: "Layer Reproducible",
 			opts: []Opts{
@@ -702,6 +762,21 @@ func TestMod(t *testing.T) {
 			},
 			ref:     r3amd.CommonName(),
 			wantErr: fmt.Errorf("layer not found"),
+		},
+		{
+			name: "Manifest Digest sha256",
+			opts: []Opts{
+				WithManifestDigestAlgo(digest.SHA256),
+			},
+			ref:      tTgtHost + "/testrepo:v1",
+			wantSame: true,
+		},
+		{
+			name: "Manifest Digest sha512 ocidir",
+			opts: []Opts{
+				WithManifestDigestAlgo(digest.SHA512),
+			},
+			ref: "ocidir://" + tempDir + "/testrepo:v1",
 		},
 		{
 			name: "Add volume",

--- a/scheme/ocidir/manifest.go
+++ b/scheme/ocidir/manifest.go
@@ -117,6 +117,9 @@ func (o *OCIDir) manifestGet(_ context.Context, r ref.Ref) (manifest.Manifest, e
 	if desc.Digest == "" {
 		return nil, errs.ErrNotFound
 	}
+	if err = desc.Digest.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid digest in index: %s: %w", string(desc.Digest), err)
+	}
 	file := path.Join(r.Path, "blobs", desc.Digest.Algorithm().String(), desc.Digest.Encoded())
 	//#nosec G304 users should validate references they attempt to open
 	fd, err := os.Open(file)
@@ -161,6 +164,9 @@ func (o *OCIDir) ManifestHead(ctx context.Context, r ref.Ref) (manifest.Manifest
 	}
 	if desc.Digest == "" {
 		return nil, errs.ErrNotFound
+	}
+	if err = desc.Digest.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid digest in index: %s: %w", string(desc.Digest), err)
 	}
 	// verify underlying file exists
 	file := path.Join(r.Path, "blobs", desc.Digest.Algorithm().String(), desc.Digest.Encoded())
@@ -220,6 +226,9 @@ func (o *OCIDir) manifestPut(ctx context.Context, r ref.Ref, m manifest.Manifest
 		return err
 	}
 	desc := m.GetDescriptor()
+	if err = desc.Digest.Validate(); err != nil {
+		return fmt.Errorf("invalid digest for manifest: %s: %w", string(desc.Digest), err)
+	}
 	b, err := m.RawBody()
 	if err != nil {
 		return fmt.Errorf("could not serialize manifest: %w", err)

--- a/scheme/reg/blob_test.go
+++ b/scheme/reg/blob_test.go
@@ -419,12 +419,12 @@ func TestBlobPut(t *testing.T) {
 	blobLen5 := 500  // single chunk
 	d1, blob1 := reqresp.NewRandomBlob(blobLen, seed)
 	d2, blob2 := reqresp.NewRandomBlob(blobLen, seed+1)
-	d2Bad := digest.Canonical.FromString("digest 2 bad")
+	d2Bad := digest.SHA256.FromString("digest 2 bad")
 	d3, blob3 := reqresp.NewRandomBlob(blobLen3, seed+2)
 	d4, blob4 := reqresp.NewRandomBlob(blobLen4, seed+3)
 	d5, blob5 := reqresp.NewRandomBlob(blobLen5, seed+4)
 	blob6 := []byte{}
-	d6 := digest.Canonical.FromBytes(blob6)
+	d6 := digest.SHA256.FromBytes(blob6)
 	uuid1 := reqresp.NewRandomID(seed + 10)
 	uuid2 := reqresp.NewRandomID(seed + 11)
 	uuid2Bad := reqresp.NewRandomID(seed + 12)

--- a/scheme/reg/reg.go
+++ b/scheme/reg/reg.go
@@ -30,6 +30,9 @@ const (
 	defaultManifestMaxPull = 1024 * 1024 * 8
 	// defaultManifestMaxPush limits the largest manifest that will be pushed
 	defaultManifestMaxPush = 1024 * 1024 * 4
+	// paramDigestAlgo specifies the query parameter to request a specific digest algorithm.
+	// TODO(bmitch): EXPERIMENTAL field, registry support and OCI spec update needed
+	paramDigestAlgo = "digest-algorithm"
 )
 
 // Reg is used for interacting with remote registry servers

--- a/types/blob/ociconfig.go
+++ b/types/blob/ociconfig.go
@@ -8,8 +8,6 @@ import (
 	_ "crypto/sha256"
 	_ "crypto/sha512"
 
-	"github.com/opencontainers/go-digest"
-
 	"github.com/regclient/regclient/types/mediatype"
 	v1 "github.com/regclient/regclient/types/oci/v1"
 )
@@ -47,7 +45,7 @@ func NewOCIConfig(opts ...Opts) *BOCIConfig {
 			}
 		}
 		// force descriptor to match raw body, even if we generated the raw body
-		bc.desc.Digest = digest.FromBytes(bc.rawBody)
+		bc.desc.Digest = bc.desc.DigestAlgo().FromBytes(bc.rawBody)
 		bc.desc.Size = int64(len(bc.rawBody))
 		if bc.desc.MediaType == "" {
 			bc.desc.MediaType = mediatype.OCI1ImageConfig
@@ -93,7 +91,7 @@ func (oc *BOCIConfig) SetConfig(image v1.Image) {
 	if oc.desc.MediaType == "" {
 		oc.desc.MediaType = mediatype.OCI1ImageConfig
 	}
-	oc.desc.Digest = digest.FromBytes(oc.rawBody)
+	oc.desc.Digest = oc.desc.DigestAlgo().FromBytes(oc.rawBody)
 	oc.desc.Size = int64(len(oc.rawBody))
 	oc.blobSet = true
 }
@@ -116,12 +114,13 @@ func (oc *BOCIConfig) UnmarshalJSON(data []byte) error {
 	if err != nil {
 		return err
 	}
+	oc.image = image
 	oc.rawBody = make([]byte, len(data))
 	copy(oc.rawBody, data)
 	if oc.desc.MediaType == "" {
 		oc.desc.MediaType = mediatype.OCI1ImageConfig
 	}
-	oc.desc.Digest = digest.FromBytes(oc.rawBody)
+	oc.desc.Digest = oc.desc.DigestAlgo().FromBytes(oc.rawBody)
 	oc.desc.Size = int64(len(oc.rawBody))
 	oc.blobSet = true
 	return nil

--- a/types/blob/tar.go
+++ b/types/blob/tar.go
@@ -45,7 +45,7 @@ func NewTarReader(opts ...Opts) *BTarReader {
 	}
 	if bc.rdr != nil {
 		tr.blobSet = true
-		tr.digester = digest.Canonical.Digester()
+		tr.digester = tr.desc.DigestAlgo().Digester()
 		rdr := bc.rdr
 		if tr.desc.Size > 0 {
 			rdr = &limitread.LimitRead{

--- a/types/manifest/docker1.go
+++ b/types/manifest/docker1.go
@@ -203,7 +203,7 @@ func (m *docker1Manifest) SetOrig(origIn interface{}) error {
 	m.rawBody = mj
 	m.desc = descriptor.Descriptor{
 		MediaType: mediatype.Docker1Manifest,
-		Digest:    digest.FromBytes(mj),
+		Digest:    m.desc.DigestAlgo().FromBytes(mj),
 		Size:      int64(len(mj)),
 	}
 	m.Manifest = orig
@@ -228,8 +228,8 @@ func (m *docker1SignedManifest) SetOrig(origIn interface{}) error {
 	m.rawBody = mj
 	m.desc = descriptor.Descriptor{
 		MediaType: mediatype.Docker1ManifestSigned,
-		Digest:    digest.FromBytes(mj),
-		Size:      int64(len(mj)),
+		Digest:    m.desc.DigestAlgo().FromBytes(orig.Canonical),
+		Size:      int64(len(orig.Canonical)),
 	}
 	m.SignedManifest = orig
 

--- a/types/manifest/docker2.go
+++ b/types/manifest/docker2.go
@@ -330,7 +330,7 @@ func (m *docker2Manifest) updateDesc() error {
 	m.rawBody = mj
 	m.desc = descriptor.Descriptor{
 		MediaType: mediatype.Docker2Manifest,
-		Digest:    digest.FromBytes(mj),
+		Digest:    m.desc.DigestAlgo().FromBytes(mj),
 		Size:      int64(len(mj)),
 	}
 	return nil
@@ -343,7 +343,7 @@ func (m *docker2ManifestList) updateDesc() error {
 	m.rawBody = mj
 	m.desc = descriptor.Descriptor{
 		MediaType: mediatype.Docker2ManifestList,
-		Digest:    digest.FromBytes(mj),
+		Digest:    m.desc.DigestAlgo().FromBytes(mj),
 		Size:      int64(len(mj)),
 	}
 	return nil

--- a/types/manifest/manifest.go
+++ b/types/manifest/manifest.go
@@ -378,7 +378,7 @@ func fromOrig(c common, orig interface{}) (Manifest, error) {
 		c.rawBody = mj
 	}
 	if _, ok := orig.(schema1.SignedManifest); !ok {
-		c.desc.Digest = digest.FromBytes(mj)
+		c.desc.Digest = c.desc.DigestAlgo().FromBytes(mj)
 	}
 	if c.desc.Size == 0 {
 		c.desc.Size = int64(len(mj))
@@ -396,7 +396,7 @@ func fromOrig(c common, orig interface{}) (Manifest, error) {
 		mt = mOrig.MediaType
 		c.desc.MediaType = mediatype.Docker1ManifestSigned
 		// recompute digest on the canonical data
-		c.desc.Digest = digest.FromBytes(mOrig.Canonical)
+		c.desc.Digest = c.desc.DigestAlgo().FromBytes(mOrig.Canonical)
 		m = &docker1SignedManifest{
 			common:         c,
 			SignedManifest: mOrig,
@@ -492,7 +492,7 @@ func fromCommon(c common) (Manifest, error) {
 		}
 		// compute digest
 		if c.desc.MediaType != mediatype.Docker1ManifestSigned {
-			d := digest.FromBytes(c.rawBody)
+			d := c.desc.DigestAlgo().FromBytes(c.rawBody)
 			c.desc.Digest = d
 			c.desc.Size = int64(len(c.rawBody))
 		}
@@ -510,7 +510,7 @@ func fromCommon(c common) (Manifest, error) {
 		if len(c.rawBody) > 0 {
 			err = json.Unmarshal(c.rawBody, &mOrig)
 			mt = mOrig.MediaType
-			d := digest.FromBytes(mOrig.Canonical)
+			d := c.desc.DigestAlgo().FromBytes(mOrig.Canonical)
 			c.desc.Digest = d
 			c.desc.Size = int64(len(mOrig.Canonical))
 		}

--- a/types/manifest/manifest_test.go
+++ b/types/manifest/manifest_test.go
@@ -391,15 +391,16 @@ var (
 )
 
 var (
-	digestDockerSchema2          = digest.FromBytes(rawDockerSchema2)
-	digestDockerSchema2List      = digest.FromBytes(rawDockerSchema2List)
-	digestInvalid                = digest.FromString("invalid")
+	digestDockerSchema2          = digest.SHA256.FromBytes(rawDockerSchema2)
+	digestDockerSchema2List      = digest.SHA256.FromBytes(rawDockerSchema2List)
+	digestInvalid                = digest.SHA256.FromString("invalid")
 	digestDockerSchema1Signed, _ = digest.Parse("sha256:f3ef067962554c3352dc0c659ca563f73cc396fe0dea2a2c23a7964c6290f782")
-	digestOCIImage               = digest.FromBytes(rawOCIImage)
-	digestOCIIndex               = digest.FromBytes(rawOCIIndex)
-	digestOCIImageDuck           = digest.FromBytes(rawOCIImageDuck)
-	digestOCIIndexDuck           = digest.FromBytes(rawOCIIndexDuck)
-	digestOCIArtifact            = digest.FromBytes(rawOCI1Artifact)
+	digestOCIImage               = digest.SHA256.FromBytes(rawOCIImage)
+	digestOCIImage512            = digest.SHA512.FromBytes(rawOCIImage)
+	digestOCIIndex               = digest.SHA256.FromBytes(rawOCIIndex)
+	digestOCIImageDuck           = digest.SHA256.FromBytes(rawOCIImageDuck)
+	digestOCIIndexDuck           = digest.SHA256.FromBytes(rawOCIIndexDuck)
+	digestOCIArtifact            = digest.SHA256.FromBytes(rawOCI1Artifact)
 )
 
 func TestNew(t *testing.T) {
@@ -424,6 +425,11 @@ func TestNew(t *testing.T) {
 	err = json.Unmarshal(rawDockerSchema1Signed, &manifestDockerSchema1Signed)
 	if err != nil {
 		t.Fatalf("failed to unmarshal docker schema1 signed json: %v", err)
+	}
+	desc512 := descriptor.Descriptor{}
+	err = desc512.DigestAlgoPrefer(digest.SHA512)
+	if err != nil {
+		t.Fatalf("failed to setup preferred digest algorithm to sha512: %v", err)
 	}
 	var tt = []struct {
 		name        string
@@ -554,6 +560,27 @@ func TestNew(t *testing.T) {
 				MediaType: mediatype.OCI1Manifest,
 				Size:      int64(len(rawOCIImage)),
 				Digest:    digestOCIImage,
+			},
+			wantE:       nil,
+			isSet:       true,
+			testAnnot:   true,
+			testSubject: true,
+			hasAnnot:    true,
+			hasSubject:  true,
+			wantSize:    1794499,
+		},
+		{
+			name: "OCI 1 Manifest 512",
+			opts: []Opts{
+				WithRef(r),
+				WithRaw(rawOCIImage),
+				WithDesc(desc512),
+			},
+			wantR: r,
+			wantDesc: descriptor.Descriptor{
+				MediaType: mediatype.OCI1Manifest,
+				Size:      int64(len(rawOCIImage)),
+				Digest:    digestOCIImage512,
 			},
 			wantE:       nil,
 			isSet:       true,

--- a/types/manifest/oci1.go
+++ b/types/manifest/oci1.go
@@ -548,7 +548,7 @@ func (m *oci1Manifest) updateDesc() error {
 	m.rawBody = mj
 	m.desc = descriptor.Descriptor{
 		MediaType: mediatype.OCI1Manifest,
-		Digest:    digest.FromBytes(mj),
+		Digest:    m.desc.DigestAlgo().FromBytes(mj),
 		Size:      int64(len(mj)),
 	}
 	return nil
@@ -561,7 +561,7 @@ func (m *oci1Index) updateDesc() error {
 	m.rawBody = mj
 	m.desc = descriptor.Descriptor{
 		MediaType: mediatype.OCI1ManifestList,
-		Digest:    digest.FromBytes(mj),
+		Digest:    m.desc.DigestAlgo().FromBytes(mj),
 		Size:      int64(len(mj)),
 	}
 	return nil
@@ -574,7 +574,7 @@ func (m *oci1Artifact) updateDesc() error {
 	m.rawBody = mj
 	m.desc = descriptor.Descriptor{
 		MediaType: mediatype.OCI1Artifact,
-		Digest:    digest.FromBytes(mj),
+		Digest:    m.desc.DigestAlgo().FromBytes(mj),
 		Size:      int64(len(mj)),
 	}
 	return nil


### PR DESCRIPTION

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Other digest algorithms are not supported.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Support changing digest algorithm using methods in the descriptor. This also adds validation (to avoid panics from go-digest) and the ability to modify the digest (to make testing easier).
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
regctl image mod --digest-algo sha512 ocidir://path:tag --create sha512
regctl manfiest get ocidir://path:sha512
```

<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Feature: Support digest algorithms beyond sha256.
- Feature: Support modifying the digest algorithm on an image.
- Fix: Validate digests before calling methods that could panic.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
