### PR TITLE
Support pushing tagged manifests with different digest algorithms

### DIFF
--- a/scheme/reg/blob.go
+++ b/scheme/reg/blob.go
@@ -238,6 +238,11 @@ func (reg *Reg) BlobPut(ctx context.Context, r ref.Ref, d descriptor.Descriptor,
 }
 
 func (reg *Reg) blobGetUploadURL(ctx context.Context, r ref.Ref, d descriptor.Descriptor) (*url.URL, error) {
+	q := url.Values{}
+	if d.DigestAlgo() != digest.Canonical {
+		// TODO(bmitch): EXPERIMENTAL parameter, registry support and OCI spec change needed
+		q.Add(paramBlobDigestAlgo, d.DigestAlgo().String())
+	}
 	// request an upload location
 	req := &reghttp.Req{
 		Host:      r.Registry,
@@ -247,10 +252,7 @@ func (reg *Reg) blobGetUploadURL(ctx context.Context, r ref.Ref, d descriptor.De
 				Method:     "POST",
 				Repository: r.Repository,
 				Path:       "blobs/uploads/",
-				// TODO(bmitch): EXPERIMENTAL parameter, registry support and OCI spec change needed
-				Query: url.Values{
-					paramDigestAlgo: []string{d.DigestAlgo().String()},
-				},
+				Query:      q,
 			},
 		},
 	}

--- a/scheme/reg/blob_test.go
+++ b/scheme/reg/blob_test.go
@@ -407,6 +407,8 @@ func TestBlobPut(t *testing.T) {
 	blobRepo := "/proj/repo"
 	blobRepo5 := "/proj/repo5"
 	blobRepo6 := "/proj/repo6"
+	blobRepo1sha512 := "/proj/repo1-sha512"
+	blobRepo5sha512 := "/proj/repo5-sha512"
 	// privateRepo := "/proj/private"
 	ctx := context.Background()
 	// include a random blob
@@ -425,6 +427,8 @@ func TestBlobPut(t *testing.T) {
 	d5, blob5 := reqresp.NewRandomBlob(blobLen5, seed+4)
 	blob6 := []byte{}
 	d6 := digest.SHA256.FromBytes(blob6)
+	d1sha512 := digest.SHA512.FromBytes(blob1)
+	d5sha512 := digest.SHA512.FromBytes(blob5)
 	uuid1 := reqresp.NewRandomID(seed + 10)
 	uuid2 := reqresp.NewRandomID(seed + 11)
 	uuid2Bad := reqresp.NewRandomID(seed + 12)
@@ -483,6 +487,51 @@ func TestBlobPut(t *testing.T) {
 				},
 			},
 		},
+		{
+			ReqEntry: reqresp.ReqEntry{
+				Name:   "PUT for d1 sha512",
+				Method: "PUT",
+				Path:   "/v2" + blobRepo1sha512 + "/blobs/uploads/" + uuid1,
+				Query: map[string][]string{
+					"digest": {d1sha512.String()},
+				},
+				Headers: http.Header{
+					"Content-Length": {fmt.Sprintf("%d", len(blob1))},
+					"Content-Type":   {"application/octet-stream"},
+					"Authorization":  {fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(user+":"+pass)))},
+				},
+				Body: blob1,
+			},
+			RespEntry: reqresp.RespEntry{
+				Status: http.StatusCreated,
+				Headers: http.Header{
+					"Content-Length":        {"0"},
+					"Location":              {"/v2" + blobRepo + "/blobs/" + d1.String()},
+					"Docker-Content-Digest": {d1sha512.String()},
+				},
+			},
+		},
+		{
+			ReqEntry: reqresp.ReqEntry{
+				Name:   "PUT for d1 sha512 unauth",
+				Method: "PUT",
+				Path:   "/v2" + blobRepo1sha512 + "/blobs/uploads/" + uuid1,
+				Query: map[string][]string{
+					"digest": {d1sha512.String()},
+				},
+				Headers: http.Header{
+					"Content-Length": {fmt.Sprintf("%d", len(blob1))},
+					"Content-Type":   {"application/octet-stream"},
+				},
+				Body: blob1,
+			},
+			RespEntry: reqresp.RespEntry{
+				Status: http.StatusUnauthorized,
+				Headers: http.Header{
+					"WWW-Authenticate": {"Basic realm=\"testing\""},
+				},
+			},
+		},
 	}
 	blobTS := httptest.NewServer(reqresp.NewHandler(t, blobRRS))
 	defer blobTS.Close()
@@ -519,6 +568,43 @@ func TestBlobPut(t *testing.T) {
 				Path:   "/v2" + blobRepo + "/blobs/uploads/",
 				Query: map[string][]string{
 					"mount": {d1.String()},
+				},
+			},
+			RespEntry: reqresp.RespEntry{
+				Status: http.StatusUnauthorized,
+				Headers: http.Header{
+					"Content-Length":   {"0"},
+					"WWW-Authenticate": {"Basic realm=\"testing\""},
+				},
+			},
+		},
+		{
+			ReqEntry: reqresp.ReqEntry{
+				Name:   "POST for d1 sha512",
+				Method: "POST",
+				Path:   "/v2" + blobRepo1sha512 + "/blobs/uploads/",
+				Query: map[string][]string{
+					"mount": {d1sha512.String()},
+				},
+				Headers: http.Header{
+					"Authorization": {fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(user+":"+pass)))},
+				},
+			},
+			RespEntry: reqresp.RespEntry{
+				Status: http.StatusAccepted,
+				Headers: http.Header{
+					"Content-Length": {"0"},
+					"Location":       {fmt.Sprintf("http://%s/v2%s/blobs/uploads/%s", blobHost, blobRepo1sha512, uuid1)},
+				},
+			},
+		},
+		{
+			ReqEntry: reqresp.ReqEntry{
+				Name:   "POST for d1  sha512 unauth",
+				Method: "POST",
+				Path:   "/v2" + blobRepo1sha512 + "/blobs/uploads/",
+				Query: map[string][]string{
+					"mount": {d1sha512.String()},
 				},
 			},
 			RespEntry: reqresp.RespEntry{
@@ -1152,7 +1238,72 @@ func TestBlobPut(t *testing.T) {
 				},
 			},
 		},
-		// get upload6 location
+		// get upload5 location
+		{
+			ReqEntry: reqresp.ReqEntry{
+				Name:   "POST for d5 sha512",
+				Method: "POST",
+				Path:   "/v2" + blobRepo5sha512 + "/blobs/uploads/",
+				Query: map[string][]string{
+					"digest-algorithm": {digest.SHA512.String()},
+				},
+			},
+			RespEntry: reqresp.RespEntry{
+				Status: http.StatusAccepted,
+				Headers: http.Header{
+					"Content-Length": {"0"},
+					"Location":       {uuid5},
+				},
+			},
+		},
+		// upload put for d5
+		{
+			ReqEntry: reqresp.ReqEntry{
+				DelOnUse: false,
+				Name:     "PUT for chunked d5 sha512",
+				Method:   "PUT",
+				Path:     "/v2" + blobRepo5sha512 + "/blobs/uploads/" + uuid5,
+				Query: map[string][]string{
+					"digest": {d5sha512.String()},
+					"chunk":  {"1"},
+				},
+				Headers: http.Header{
+					"Content-Length": {"0"},
+					"Content-Type":   {"application/octet-stream"},
+				},
+			},
+			RespEntry: reqresp.RespEntry{
+				Status: http.StatusCreated,
+				Headers: http.Header{
+					"Content-Length":        {"0"},
+					"Location":              {"/v2" + blobRepo5 + "/blobs/" + d5.String()},
+					"Docker-Content-Digest": {d5sha512.String()},
+				},
+			},
+		},
+		// upload patch d5
+		{
+			ReqEntry: reqresp.ReqEntry{
+				DelOnUse: false,
+				Name:     "PATCH for d5 sha512",
+				Method:   "PATCH",
+				Path:     "/v2" + blobRepo5sha512 + "/blobs/uploads/" + uuid5,
+				Headers: http.Header{
+					"Content-Length": {fmt.Sprintf("%d", blobLen5)},
+					"Content-Range":  {fmt.Sprintf("%d-%d", 0, blobLen5-1)},
+					"Content-Type":   {"application/octet-stream"},
+				},
+				Body: blob5,
+			},
+			RespEntry: reqresp.RespEntry{
+				Status: http.StatusAccepted,
+				Headers: http.Header{
+					"Content-Length": {fmt.Sprintf("%d", 0)},
+					"Range":          {fmt.Sprintf("bytes=0-%d", blobLen5-1)},
+					"Location":       {uuid5 + "?chunk=1"},
+				},
+			},
+		}, // get upload6 location
 		{
 			ReqEntry: reqresp.ReqEntry{
 				Name:   "POST for d6",
@@ -1371,6 +1522,29 @@ func TestBlobPut(t *testing.T) {
 		}
 		if dp.Digest.String() != d5.String() {
 			t.Errorf("Digest mismatch, expected %s, received %s", d5.String(), dp.Digest.String())
+		}
+		if dp.Size != int64(len(blob5)) {
+			t.Errorf("Content length mismatch, expected %d, received %d", len(blob5), dp.Size)
+		}
+	})
+	// test put without a descriptor
+	t.Run("Digest-algorithm-sha512", func(t *testing.T) {
+		r, err := ref.New(tsURL.Host + blobRepo5sha512)
+		if err != nil {
+			t.Fatalf("Failed creating ref: %v", err)
+		}
+		br := bytes.NewReader(blob5)
+		d := descriptor.Descriptor{}
+		err = d.DigestAlgoPrefer(digest.SHA512)
+		if err != nil {
+			t.Fatalf("failed to set preferred digest algorithm: %v", err)
+		}
+		dp, err := reg.BlobPut(ctx, r, d, br)
+		if err != nil {
+			t.Fatalf("Failed running BlobPut: %v", err)
+		}
+		if dp.Digest.String() != d5sha512.String() {
+			t.Errorf("Digest mismatch, expected %s, received %s", d5sha512.String(), dp.Digest.String())
 		}
 		if dp.Size != int64(len(blob5)) {
 			t.Errorf("Content length mismatch, expected %d, received %d", len(blob5), dp.Size)

--- a/scheme/reg/reg.go
+++ b/scheme/reg/reg.go
@@ -30,9 +30,12 @@ const (
 	defaultManifestMaxPull = 1024 * 1024 * 8
 	// defaultManifestMaxPush limits the largest manifest that will be pushed
 	defaultManifestMaxPush = 1024 * 1024 * 4
-	// paramDigestAlgo specifies the query parameter to request a specific digest algorithm.
+	// paramBlobDigestAlgo specifies the query parameter to request a specific digest algorithm.
 	// TODO(bmitch): EXPERIMENTAL field, registry support and OCI spec update needed
-	paramDigestAlgo = "digest-algorithm"
+	paramBlobDigestAlgo = "digest-algorithm"
+	// paramManifestDigest specifies the query parameter to specify the digest of a manifest pushed by tag.
+	// TODO(bmitch): EXPERIMENTAL field, registry support and OCI spec update needed
+	paramManifestDigest = "digest"
 )
 
 // Reg is used for interacting with remote registry servers


### PR DESCRIPTION

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

When pushing a tagged manifest, an extra parameter is needed to change the digest algorithm from the registry default. This is needed if the manifest digest needs to be fixed to a non-canonical value to avoid breaking referrers, signatures, and pinned references.

These parameters are currently experimental and not standardized by OCI yet. This change will be part of a proposal to OCI, and changing the digest algorithm of images should not be done in a production environment at this time.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Push content with a different digest to the latest development release of olareg.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Feature: Experimental support for pushing tagged manifests with different digest algorithms
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
