### PR TITLE
Add WithDockerCredsFile() RegClient Opt

### DIFF
--- a/config/docker.go
+++ b/config/docker.go
@@ -64,6 +64,12 @@ func DockerLoad() ([]Host, error) {
 	return dockerParse(cf)
 }
 
+// DockerLoadFile returns a slice of hosts from a named docker config file.
+func DockerLoadFile(fname string) ([]Host, error) {
+	cf := conffile.New(conffile.WithFullname(fname))
+	return dockerParse(cf)
+}
+
 // dockerParse parses a docker config into a slice of Hosts.
 func dockerParse(cf *conffile.File) ([]Host, error) {
 	rdr, err := cf.Open()

--- a/regclient.go
+++ b/regclient.go
@@ -153,6 +153,21 @@ func WithDockerCreds() Opt {
 	}
 }
 
+// WithDockerCredsFile adds configuration from a named docker config file with registry logins.
+// This changes the default value from the config file, and should be added after the config file is loaded.
+func WithDockerCredsFile(fname string) Opt {
+	return func(rc *RegClient) {
+		configHosts, err := config.DockerLoadFile(fname)
+		if err != nil {
+			rc.log.WithFields(logrus.Fields{
+				"err": err,
+			}).Warn("Failed to load docker creds")
+			return
+		}
+		rc.hostLoad("docker-file", configHosts)
+	}
+}
+
 // WithLog overrides default logrus Logger.
 func WithLog(log *logrus.Logger) Opt {
 	return func(rc *RegClient) {


### PR DESCRIPTION
Make it easier to pull creds from a docker config.json outside of the standard location, without needing environmental variables. For example, a mounted K8s Secret of type `kubernetes.io/dockerconfigjson`.

### Describe the change

`new feature`

This is a small nice-to-have, exposing existing functionality to `regclient` library users.

### How to verify it

Connect to a registry using creds in a non-standard config file.

### Changelog text

<!-- If the release changelog should have an entry for this, include it here -->

- Add a `WithDockerCredsFile() regclient.Opt`

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
 - N/A - regclient doesn't have much coverage for opts, config.Docker tests reads
- [X] Documentation has been added, updated, or not applicable
 - will be picked up in godoc
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
