### PR TITLE
Tar paths should use forward slashes

### DIFF
--- a/mod/layer.go
+++ b/mod/layer.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
@@ -426,7 +427,7 @@ func WithLayerRmIndex(index int) Opts {
 
 // WithLayerStripFile removes a file from within the layer tar.
 func WithLayerStripFile(file string) Opts {
-	file = strings.Trim(file, "/")
+	file = strings.Trim(filepath.ToSlash(file), "/")
 	fileRE := regexp.MustCompile("^/?" + regexp.QuoteMeta(file) + "(/.*)?$")
 	return func(dc *dagConfig, dm *dagManifest) error {
 		dc.stepsLayerFile = append(dc.stepsLayerFile, func(c context.Context, rc *regclient.RegClient, rSrc, rTgt ref.Ref, dl *dagLayer, th *tar.Header, tr io.Reader) (*tar.Header, io.Reader, changes, error) {

--- a/mod/mod_test.go
+++ b/mod/mod_test.go
@@ -597,6 +597,13 @@ func TestMod(t *testing.T) {
 			ref: tTgtHost + "/testrepo:v3",
 		},
 		{
+			name: "Layer Trim File With Local Separator",
+			opts: []Opts{
+				WithLayerStripFile(string(filepath.Separator) + "layer2"),
+			},
+			ref: tTgtHost + "/testrepo:v3",
+		},
+		{
 			name: "Layer Timestamp Set Missing",
 			opts: []Opts{
 				WithLayerTimestamp(OptTime{}),


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Fixes #786.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

The correct path separator inside of a tar file is `/`. On Windows, the `filepath.Clean` is converting these to backslashes. This either removes the `filepath.Clean` where it's not needed, or adds a `filepath.ToSlash` to ensure the tar filename separator is always assumed to be a `/`.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Export an image on Windows.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Fix: Tar path separator should always be a `/`.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

Tests for this are difficult since they depend on Go's behavior on a Windows system.
<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
