### PR TITLE
Fix: Validate the digest of the ref when provided

### DIFF
--- a/scheme/reg/referrer.go
+++ b/scheme/reg/referrer.go
@@ -209,7 +209,7 @@ func (reg *Reg) referrerListByAPIPage(ctx context.Context, r ref.Ref, config sch
 	}
 
 	m, err := manifest.New(
-		manifest.WithRef(r),
+		manifest.WithRef(r.SetDigest("")),
 		manifest.WithHeader(resp.HTTPResponse().Header),
 		manifest.WithRaw(rawBody),
 	)

--- a/types/manifest/manifest_test.go
+++ b/types/manifest/manifest_test.go
@@ -828,7 +828,15 @@ func TestNew(t *testing.T) {
 			wantE: fmt.Errorf("manifest contains an unexpected media type: expected %s, received %s", mediatype.OCI1Manifest, mediatype.OCI1ManifestList),
 		},
 		{
-			name: "Invalid digest",
+			name: "Invalid ref digest",
+			opts: []Opts{
+				WithRef(r.SetDigest(digestInvalid.String())),
+				WithRaw(rawDockerSchema2),
+			},
+			wantE: errs.ErrDigestMismatch,
+		},
+		{
+			name: "Invalid descriptor digest",
 			opts: []Opts{
 				WithRef(r),
 				WithRaw(rawDockerSchema2),
@@ -838,7 +846,7 @@ func TestNew(t *testing.T) {
 					Size:      int64(len(rawDockerSchema2)),
 				}),
 			},
-			wantE: fmt.Errorf("manifest digest mismatch, expected %s, computed %s", digestInvalid, digestDockerSchema2),
+			wantE: errs.ErrDigestMismatch,
 		},
 		{
 			name: "Invalid Media Type",


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

When pulling a pinned manifest, regclient should verify the provided pin and not the headers from the registry.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This prefers the user provided digest for the manifest over the registry header when it is available.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Fix: Validate the digest of the ref when provided
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
