### PR TITLE
Fix: Update GHA output generating steps

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -120,9 +120,9 @@ jobs:
         RELEASE_NOTES="${RELEASE_NOTES//'%'/'%25'}"
         RELEASE_NOTES="${RELEASE_NOTES//$'\n'/'%0A'}"
         RELEASE_NOTES="${RELEASE_NOTES//$'\r'/'%0D'}"
-        echo ::set-output name=version::${VERSION}
-        echo ::set-output name=valid::${VALID_RELEASE}
-        echo ::set-output name=release_notes::${RELEASE_NOTES}
+        echo "valid=${VALID_RELEASE}" >>$GITHUB_OUTPUT
+        echo "version=${VERSION}" >>$GITHUB_OUTPUT
+        echo "release_notes=${RELEASE_NOTES}" >>$GITHUB_OUTPUT
 
     - name: Create release
       if: steps.release_details.outputs.valid == 'true' && matrix.gover == env.RELEASE_GO_VER


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Warning are output from GHA when performing a release.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Update GHA output generating steps. The old "echo ::set-output..." method was deprecated for writing to a file.

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

The next release should not output warnings for the "set-output" lines.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Fix: Update GHA output generating steps.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
