### PR TITLE
Fix: Lookup referrers when registry does not give digest with head

### DIFF
--- a/scheme/reg/referrer.go
+++ b/scheme/reg/referrer.go
@@ -74,6 +74,15 @@ func (reg *Reg) ReferrerList(ctx context.Context, r ref.Ref, opts ...scheme.Refe
 		if err != nil {
 			return rl, err
 		}
+		if m.GetDescriptor().Digest == "" {
+			m, err = reg.ManifestGet(ctx, r)
+			if err != nil {
+				return rl, err
+			}
+		}
+		if m.GetDescriptor().Digest == "" {
+			return rl, fmt.Errorf("unable to resolve digest for ref %s", r.CommonName())
+		}
 		r = r.SetDigest(m.GetDescriptor().Digest.String())
 	}
 	rl.Subject = r


### PR DESCRIPTION
Some registries do not include the docker digest headers. This should support referrers listing by tag on those registries.

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

If a registry does not return the docker digest header in the manifest HEAD request, this adds a fallback to use a manifest GET request to retrieve the digest needed to lookup referrers.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
make test
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Fix: Lookup referrers when registry does not give digest with head.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
