### PR TITLE
Refactor networking layer

### DIFF
--- a/config/host.go
+++ b/config/host.go
@@ -481,7 +481,7 @@ func (host *Host) Throttle() *pqueue.Queue[reqmeta.Data] {
 	mu.Lock()
 	defer mu.Unlock()
 	if host.throttle == nil {
-		host.throttle = pqueue.New(pqueue.Opts[reqmeta.Data]{Max: int(host.ReqConcurrent)})
+		host.throttle = pqueue.New(pqueue.Opts[reqmeta.Data]{Max: int(host.ReqConcurrent), Next: reqmeta.DataNext})
 	}
 	return host.throttle
 }

--- a/config/host.go
+++ b/config/host.go
@@ -44,7 +44,7 @@ const (
 	// defaultConcurrent is the default number of concurrent registry connections.
 	defaultConcurrent = 3
 	// defaultReqPerSec is the default maximum frequency to send requests to a registry.
-	defaultReqPerSec = 10
+	defaultReqPerSec = 0
 	// tokenUser is the username returned by credential helpers that indicates the password is an identity token.
 	tokenUser = "<token>"
 )
@@ -126,7 +126,7 @@ type Host struct {
 	APIOpts       map[string]string           `json:"apiOpts,omitempty" yaml:"apiOpts"`             // options for APIs
 	BlobChunk     int64                       `json:"blobChunk,omitempty" yaml:"blobChunk"`         // size of each blob chunk
 	BlobMax       int64                       `json:"blobMax,omitempty" yaml:"blobMax"`             // threshold to switch to chunked upload, -1 to disable, 0 for regclient.blobMaxPut
-	ReqPerSec     float64                     `json:"reqPerSec,omitempty" yaml:"reqPerSec"`         // requests per second, default is defaultReqPerSec(10)
+	ReqPerSec     float64                     `json:"reqPerSec,omitempty" yaml:"reqPerSec"`         // requests per second
 	ReqConcurrent int64                       `json:"reqConcurrent,omitempty" yaml:"reqConcurrent"` // concurrent requests, default is defaultConcurrent(3)
 	Scheme        string                      `json:"scheme,omitempty" yaml:"scheme"`               // Deprecated: use TLS instead
 	credRefresh   time.Time                   `json:"-" yaml:"-"`                                   // internal use, when to refresh credentials
@@ -441,7 +441,7 @@ func (host *Host) Merge(newHost Host, log *logrus.Logger) error {
 		host.BlobMax = newHost.BlobMax
 	}
 
-	if newHost.ReqPerSec > 0 {
+	if newHost.ReqPerSec != 0 {
 		if host.ReqPerSec != 0 && host.ReqPerSec != newHost.ReqPerSec {
 			log.WithFields(logrus.Fields{
 				"orig": host.ReqPerSec,

--- a/config/host.go
+++ b/config/host.go
@@ -122,7 +122,7 @@ type Host struct {
 	Mirrors       []string                    `json:"mirrors,omitempty" yaml:"mirrors"`             // list of other Host Names to use as mirrors
 	Priority      uint                        `json:"priority,omitempty" yaml:"priority"`           // priority when sorting mirrors, higher priority attempted first
 	RepoAuth      bool                        `json:"repoAuth,omitempty" yaml:"repoAuth"`           // tracks a separate auth per repo
-	API           string                      `json:"api,omitempty" yaml:"api"`                     // experimental: registry API to use
+	API           string                      `json:"api,omitempty" yaml:"api"`                     // Deprecated: registry API to use
 	APIOpts       map[string]string           `json:"apiOpts,omitempty" yaml:"apiOpts"`             // options for APIs
 	BlobChunk     int64                       `json:"blobChunk,omitempty" yaml:"blobChunk"`         // size of each blob chunk
 	BlobMax       int64                       `json:"blobMax,omitempty" yaml:"blobMax"`             // threshold to switch to chunked upload, -1 to disable, 0 for regclient.blobMaxPut
@@ -391,15 +391,12 @@ func (host *Host) Merge(newHost Host, log *logrus.Logger) error {
 		host.RepoAuth = newHost.RepoAuth
 	}
 
+	// TODO: eventually delete
 	if newHost.API != "" {
-		if host.API != "" && host.API != newHost.API {
-			log.WithFields(logrus.Fields{
-				"orig": host.API,
-				"new":  newHost.API,
-				"host": name,
-			}).Warn("Changing API settings for registry")
-		}
-		host.API = newHost.API
+		log.WithFields(logrus.Fields{
+			"api":  newHost.API,
+			"host": name,
+		}).Warn("API field has been deprecated")
 	}
 
 	if len(newHost.APIOpts) > 0 {

--- a/internal/pqueue/pqueue.go
+++ b/internal/pqueue/pqueue.go
@@ -1,0 +1,276 @@
+// Package pqueue implements a priority queue.
+package pqueue
+
+import (
+	"context"
+	"fmt"
+	"sync"
+)
+
+type Queue[T any] struct {
+	mu     sync.Mutex
+	max    int
+	next   func(queued, active []*T) int
+	active []*T
+	queued []*T
+	wait   []*chan struct{}
+}
+
+// Opts is used to configure a new priority queue.
+type Opts[T any] struct {
+	Max  int                           // maximum concurrent entries, defaults to 1.
+	Next func(queued, active []*T) int // function to lookup index of next queued entry to release, defaults to oldest entry.
+}
+
+// New creates a new priority queue.
+func New[T any](opts Opts[T]) *Queue[T] {
+	if opts.Max <= 0 {
+		opts.Max = 1
+	}
+	return &Queue[T]{
+		max:  opts.Max,
+		next: opts.Next,
+	}
+}
+
+// Acquire adds a new entry to the queue and returns once it is ready.
+// The returned function must be called when the queued job completes to release the next entry.
+// If there is any error, the returned function will be nil.
+func (q *Queue[T]) Acquire(ctx context.Context, e T) (func(), error) {
+	if q == nil {
+		return func() {}, nil
+	}
+	found, err := q.checkContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if found {
+		return func() {}, nil
+	}
+	q.mu.Lock()
+	if len(q.active)+len(q.queued) < q.max {
+		q.active = append(q.active, &e)
+		q.mu.Unlock()
+		return q.releaseFn(&e), nil
+	}
+	// limit reached, add to queue and wait
+	w := make(chan struct{}, 1)
+	q.queued = append(q.queued, &e)
+	q.wait = append(q.wait, &w)
+	q.mu.Unlock()
+	// wait on both context and queue
+	select {
+	case <-ctx.Done():
+		// context abort, remove queued entry
+		q.mu.Lock()
+		for i := range q.queued {
+			if q.queued[i] == &e {
+				if len(q.queued) >= i+1 {
+					q.queued = q.queued[:i]
+					q.wait = q.wait[:i]
+				} else {
+					q.queued = append(q.queued[:i], q.queued[i+1:]...)
+					q.wait = append(q.wait[:i], q.wait[i+1:]...)
+				}
+				q.mu.Unlock()
+				return nil, ctx.Err()
+			}
+		}
+		q.mu.Unlock()
+		// queued entry found, assume race condition with context and entry being released, release next entry
+		q.release(&e)
+		return nil, ctx.Err()
+	case <-w:
+		return q.releaseFn(&e), nil
+	}
+}
+
+// TryAcquire attempts to add an entry on to the list of active entries.
+// If the returned function is nil, the queue was not available.
+// If the returned function is not nil, it must be called when the job is complete to release the next entry.
+func (q *Queue[T]) TryAcquire(ctx context.Context, e T) (func(), error) {
+	if q == nil {
+		return func() {}, nil
+	}
+	found, err := q.checkContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if found {
+		return func() {}, nil
+	}
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if len(q.active)+len(q.queued) < q.max {
+		q.active = append(q.active, &e)
+		return q.releaseFn(&e), nil
+	}
+	return nil, nil
+}
+
+// release next entry or noop.
+func (q *Queue[T]) release(prev *T) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	// remove prev entry from active list
+	for i := range q.active {
+		if q.active[i] == prev {
+			if i == len(q.active)+1 {
+				q.active = q.active[:i]
+			} else {
+				q.active = append(q.active[:i], q.active[i+1:]...)
+			}
+			break
+		}
+	}
+	// skip checks when at limit or nothing queued
+	if len(q.active) >= q.max || len(q.queued) == 0 {
+		return
+	}
+	i := 0
+	if q.next != nil && len(q.queued) > 1 {
+		i = q.next(q.queued, q.active)
+		// validate response
+		if i < 0 {
+			i = 0
+		}
+		if i >= len(q.queued) {
+			i = len(q.queued) - 1
+		}
+	}
+	// release queued entry, move to active list, and remove from queued/wait lists
+	close(*q.wait[i])
+	q.active = append(q.active, q.queued[i])
+	if i == len(q.queued)-1 {
+		q.queued = q.queued[:i]
+		q.wait = q.wait[:i]
+	} else {
+		q.queued = append(q.queued[:i], q.queued[i+1:]...)
+		q.wait = append(q.wait[:i], q.wait[i+1:]...)
+	}
+}
+
+// releaseFn is a convenience wrapper around [release].
+func (q *Queue[T]) releaseFn(prev *T) func() {
+	return func() {
+		q.release(prev)
+	}
+}
+
+// TODO: is there a way to make a different context key for each generic type?
+type ctxType int
+
+var ctxKey ctxType
+
+type valMulti[T any] struct {
+	qList []*Queue[T]
+}
+
+// AcquireMulti is used to simultaneously lock multiple queues without the risk of deadlock.
+// The returned context needs to be used on calls to [Acquire] or [TryAcquire] which will immediately succeed since the resource is already acquired.
+// Attempting to acquire other resources with [Acquire], [TryAcquire], or [AcquireMulti] using the returned context and will fail for being outside of the transaction.
+// The returned function must be called to release the resources.
+// The returned function is not thread safe, ensure no other simultaneous calls to [Acquire] or [TryAcquire] using the returned context have finished before it is called.
+func AcquireMulti[T any](ctx context.Context, e T, qList ...*Queue[T]) (context.Context, func(), error) {
+	// verify context not already holding locks
+	qCtx := ctx.Value(ctxKey)
+	if qCtx != nil {
+		if qCtxVal, ok := qCtx.(*valMulti[T]); !ok || qCtxVal.qList != nil {
+			return ctx, nil, fmt.Errorf("context already used by another AcquireMulti request")
+		}
+	}
+	// delete nil entries
+	for i := len(qList) - 1; i >= 0; i-- {
+		if qList[i] == nil {
+			if i == len(qList)-1 {
+				qList = qList[:i]
+			} else {
+				qList = append(qList[:i], qList[i+1:]...)
+			}
+		}
+	}
+	// empty/nil list is a noop
+	if len(qList) == 0 {
+		return ctx, func() {}, nil
+	}
+	// dedup entries from the list
+	for i := len(qList) - 2; i >= 0; i-- {
+		for j := len(qList) - 1; j > i; j-- {
+			if qList[i] == qList[j] {
+				qList[j] = qList[len(qList)-1]
+				qList = qList[:len(qList)-1]
+			}
+		}
+	}
+	// Loop through queues to acquire, waiting on the first, and attempting the remaining.
+	// If any of the remaining entries cannot be immediately acquired, reset and make it the new queue to wait on.
+	lockI := 0
+	doneList := make([]func(), len(qList))
+	for {
+		acquired := true
+		i := 0
+		done, err := qList[lockI].Acquire(ctx, e)
+		if err != nil {
+			return ctx, nil, err
+		}
+		doneList[lockI] = done
+		for i < len(qList) {
+			if i != lockI {
+				doneList[i], err = qList[i].TryAcquire(ctx, e)
+				if doneList[i] == nil || err != nil {
+					acquired = false
+					break
+				}
+			}
+			i++
+		}
+		if err == nil && acquired {
+			break
+		}
+		// cleanup on failed attempt
+		if lockI > i {
+			doneList[lockI]()
+		}
+		// track blocking index for a retry
+		lockI = i
+		for i > 0 {
+			i--
+			doneList[i]()
+		}
+		// abort on errors
+		if err != nil {
+			return ctx, nil, err
+		}
+	}
+	// success, update context
+	ctxVal := valMulti[T]{qList: qList}
+	newCtx := context.WithValue(ctx, ctxKey, &ctxVal)
+	cleanup := func() {
+		ctxVal.qList = nil
+		for _, doneFn := range doneList {
+			doneFn()
+		}
+	}
+	return newCtx, cleanup, nil
+}
+
+func (q *Queue[T]) checkContext(ctx context.Context) (bool, error) {
+	qCtx := ctx.Value(ctxKey)
+	if qCtx == nil {
+		return false, nil
+	}
+	qCtxVal, ok := qCtx.(*valMulti[T])
+	if !ok {
+		return false, nil // another type is using the context, treat it as unset
+	}
+	if qCtxVal.qList == nil {
+		return false, nil
+	}
+	for _, cur := range qCtxVal.qList {
+		if cur == q {
+			// instance already locked
+			return true, nil
+		}
+	}
+	return true, fmt.Errorf("cannot acquire new locks during a transaction")
+}

--- a/internal/pqueue/pqueue.go
+++ b/internal/pqueue/pqueue.go
@@ -247,8 +247,9 @@ func AcquireMulti[T any](ctx context.Context, e T, qList ...*Queue[T]) (context.
 	newCtx := context.WithValue(ctx, ctxKey, &ctxVal)
 	cleanup := func() {
 		ctxVal.qList = nil
-		for _, doneFn := range doneList {
-			doneFn()
+		// dequeue in reverse order to minimize chance of another AcquireMulti being freed and immediately blocking on the next queue
+		for i := len(doneList) - 1; i >= 0; i-- {
+			doneList[i]()
 		}
 	}
 	return newCtx, cleanup, nil

--- a/internal/pqueue/pqueue.go
+++ b/internal/pqueue/pqueue.go
@@ -124,7 +124,16 @@ func (q *Queue[T]) release(prev *T) {
 		}
 	}
 	// skip checks when at limit or nothing queued
-	if len(q.active) >= q.max || len(q.queued) == 0 {
+	if len(q.queued) == 0 {
+		if len(q.active) == 0 {
+			// free up slices if this was the last active entry
+			q.active = nil
+			q.queued = nil
+			q.wait = nil
+		}
+		return
+	}
+	if len(q.active) >= q.max {
 		return
 	}
 	i := 0

--- a/internal/pqueue/pqueue_test.go
+++ b/internal/pqueue/pqueue_test.go
@@ -1,0 +1,369 @@
+package pqueue
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// create example data type
+type testData struct {
+	pref int
+}
+
+func TestNil(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	var qNil *Queue[testData]
+	e := testData{pref: 1}
+	done, err := qNil.Acquire(ctx, e)
+	if err != nil {
+		t.Errorf("failed to Acquire a nil queue: %v", err)
+	}
+	done()
+	done, err = qNil.TryAcquire(ctx, e)
+	if err != nil {
+		t.Errorf("failed to TryAcquire a nil queue: %v", err)
+	}
+	if done == nil {
+		t.Errorf("TryAcquire returned a nil done function")
+	} else {
+		done()
+	}
+}
+
+func TestQueue(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	q := New(Opts[testData]{
+		Max: 2,
+		Next: func(queued, active []*testData) int {
+			i := 0
+			for j := 1; j < len(queued); j++ {
+				if queued[i].pref < queued[j].pref {
+					i = j
+				}
+			}
+			return i
+		},
+	})
+	eList := make([]testData, 7)
+	for i := range eList {
+		eList[i] = testData{pref: i}
+	}
+	finished := make(chan int)
+	// first acquire two
+	done0, err := q.Acquire(ctx, eList[0])
+	if err != nil {
+		t.Fatalf("failed to acquire queue 2: %v", err)
+	}
+	done1, err := q.Acquire(ctx, eList[1])
+	if err != nil {
+		t.Fatalf("failed to acquire queue 3: %v", err)
+	}
+	// background acquire two more, which should block
+	for _, i := range []int{2, 3} {
+		go func(i int) {
+			done, err := q.Acquire(ctx, eList[i])
+			if err != nil {
+				t.Errorf("failed to acquire queue %d: %v", i, err)
+			}
+			finished <- i
+			done()
+		}(i)
+	}
+	// verify background jobs blocked
+	sleepMS(2)
+	select {
+	case i := <-finished:
+		t.Fatalf("acquired from a full queue entry %d", i)
+	default:
+	}
+	// release one, verify both background jobs acquire and release in correct priority order
+	done0()
+	i := <-finished
+	if i != 3 {
+		t.Errorf("released the wrong queue entry: expected 3, received %d", i)
+	}
+	i = <-finished
+	if i != 2 {
+		t.Errorf("released the wrong queue entry: expected 2, received %d", i)
+	}
+	// acquire another to fill the queue
+	done4, err := q.Acquire(ctx, eList[4])
+	if err != nil {
+		t.Fatalf("failed to acquire queue 4: %v", err)
+	}
+	// test context cancel with another background acquire
+	go func() {
+		done, err := q.Acquire(ctx, eList[5])
+		if err == nil {
+			t.Errorf("did not fail acquiring queue entry when context canceled")
+		}
+		if done != nil {
+			t.Errorf("done should be nil on failed acquire")
+			done()
+		}
+		finished <- 5
+	}()
+	sleepMS(2)
+	select {
+	case i := <-finished:
+		t.Fatalf("acquired from a full queue entry %d", i)
+	default:
+		// successfully blocked
+	}
+	cancel()
+	i = <-finished
+	if i != 5 {
+		t.Errorf("unexpected finished entry, expected 5, received %d", i)
+	}
+	// make a new context, and test TryAcquire with a full queue
+	ctx = context.Background()
+	done6, err := q.TryAcquire(ctx, eList[6])
+	if err != nil {
+		t.Fatalf("failed TryAcquire on 6: %v", err)
+	}
+	if done6 != nil {
+		t.Errorf("TryAcquire did not return a nil done")
+		done6()
+	}
+	// test TryAcquire with an available space
+	done1()
+	done6, err = q.TryAcquire(ctx, eList[6])
+	if err != nil {
+		t.Fatalf("failed TryAcquire on 6: %v", err)
+	}
+	if done6 == nil {
+		t.Errorf("TryAcquire returned a nil done")
+	} else {
+		done6()
+	}
+	done4()
+}
+
+func TestMulti(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	e := testData{pref: 1}
+	qList := make([]*Queue[testData], 4)
+	for i := range qList {
+		qList[i] = New(Opts[testData]{})
+	}
+	// test acquiring nil multiple times
+	_, done, err := AcquireMulti(ctx, e, nil, nil)
+	if err != nil {
+		t.Errorf("failed to acquire same queue multiple times: %v", err)
+	}
+	if done != nil {
+		done()
+	}
+	// test acquiring same queue multiple times
+	_, done, err = AcquireMulti(ctx, e, qList[0], qList[0])
+	if err != nil {
+		t.Errorf("failed to acquire same queue multiple times: %v", err)
+	}
+	if done != nil {
+		done()
+	}
+	ctxMulti, doneAll, err := AcquireMulti(ctx, e, qList[0], qList[1], nil, qList[0], qList[1], nil, qList[0])
+	if err != nil {
+		t.Errorf("failed to acquire a couple queues multiple times: %v", err)
+	}
+	// verify requests to Acquire inside of the context work, but only for the included queues
+	done, err = qList[0].TryAcquire(ctxMulti, e)
+	if err != nil {
+		t.Errorf("failed to acquire queue from AcquireMulti list: %v", err)
+	}
+	if done == nil {
+		t.Errorf("TryAcquire did not return a done func")
+	} else {
+		done()
+	}
+	done, err = qList[1].TryAcquire(ctxMulti, e)
+	if err != nil {
+		t.Errorf("failed to acquire queue from AcquireMulti list: %v", err)
+	}
+	if done == nil {
+		t.Errorf("TryAcquire did not return a done func")
+	} else {
+		done()
+	}
+	done, err = qList[2].TryAcquire(ctxMulti, e)
+	if err == nil {
+		t.Errorf("did not fail acquiring a queue missing from the AcquireMulti list")
+	}
+	if done != nil {
+		t.Errorf("TryAcquire returned a done function on a queue not in the context")
+		done()
+	}
+	done, err = qList[0].Acquire(ctxMulti, e)
+	if err != nil {
+		t.Errorf("failed to acquire queue from AcquireMulti list: %v", err)
+	}
+	if done == nil {
+		t.Errorf("Acquire did not return a done func")
+	} else {
+		done()
+	}
+	done, err = qList[1].Acquire(ctxMulti, e)
+	if err != nil {
+		t.Errorf("failed to acquire queue from AcquireMulti list: %v", err)
+	}
+	if done == nil {
+		t.Errorf("Acquire did not return a done func")
+	} else {
+		done()
+	}
+	done, err = qList[2].Acquire(ctxMulti, e)
+	if err == nil {
+		t.Errorf("did not fail acquiring a queue missing from the AcquireMulti list")
+	}
+	if done != nil {
+		t.Errorf("Acquire returned a done function on a queue not in the context")
+		done()
+	}
+	// try acquiring from outside of the context to verify request is blocked by the running MultiAcquire
+	done, err = qList[0].TryAcquire(ctx, e)
+	if err != nil {
+		t.Errorf("TryAcquire returned an error: %v", err)
+	}
+	if done != nil {
+		t.Errorf("TryAcquire succeeded before MultiAcquire released resource")
+		done()
+	}
+	done, err = qList[1].TryAcquire(ctx, e)
+	if err != nil {
+		t.Errorf("TryAcquire returned an error: %v", err)
+	}
+	if done != nil {
+		t.Errorf("TryAcquire succeeded before MultiAcquire released resource")
+		done()
+	}
+	// release the MultiAcquire
+	if doneAll != nil {
+		doneAll()
+	}
+	// try acquiring from outside of the context to verify request is no longer blocked
+	done, err = qList[0].TryAcquire(ctx, e)
+	if err != nil {
+		t.Errorf("TryAcquire returned an error: %v", err)
+	}
+	if done == nil {
+		t.Errorf("TryAcquire failed after MultiAcquire released resource")
+	} else {
+		done()
+	}
+	done, err = qList[1].TryAcquire(ctx, e)
+	if err != nil {
+		t.Errorf("TryAcquire returned an error: %v", err)
+	}
+	if done == nil {
+		t.Errorf("TryAcquire failed after MultiAcquire released resource")
+	} else {
+		done()
+	}
+	// try acquiring with the old context to verify it no longer blocks any request
+	for _, i := range []int{0, 1, 2} {
+		done, err = qList[i].TryAcquire(ctxMulti, e)
+		if err != nil {
+			t.Errorf("TryAcquire returned an error for %d: %v", i, err)
+		}
+		if done == nil {
+			t.Errorf("TryAcquire failed after MultiAcquire released resource for %d", i)
+		} else {
+			done()
+		}
+	}
+	// setup blocking requests to MultiAcquire, with tests for first, last, and middle entry in the queue list blocking
+	doneList := make([]func(), 3)
+	for _, i := range []int{0, 1, 2} {
+		doneList[i], err = qList[i].TryAcquire(ctx, e)
+		if err != nil {
+			t.Errorf("failed acquiring %d: %v", i, err)
+		}
+		if doneList[i] == nil {
+			t.Errorf("acquiring %d returned a nil", i)
+		}
+	}
+	finished := make(chan int)
+	for i, list := range [][]*Queue[testData]{
+		{qList[0], qList[3]},                          // first entry blocking
+		{qList[3], qList[1]},                          // last entry blocking
+		{qList[0], qList[2], nil, qList[1], qList[3]}, // middle entry blocking (0 and 1 will be released first)
+	} {
+		go func(i int, list []*Queue[testData]) {
+			_, done, err := AcquireMulti(ctx, e, list...)
+			if err != nil {
+				t.Errorf("failed to AcquireMulti for group %d: %v", i, err)
+			}
+			finished <- i
+			if done != nil {
+				done()
+			}
+		}(i, list)
+	}
+	sleepMS(5)
+	select {
+	case i := <-finished:
+		t.Errorf("unexpected early release of AcquireMulti group %d", i)
+	default:
+		// expected, all entries blocked
+	}
+	// release 0, verify AcquireMulti group 0 runs
+	doneList[0]()
+	i := <-finished
+	if i != 0 {
+		t.Errorf("unexpected group released %d", i)
+	}
+	// release 1, verify group 1 runs
+	doneList[1]()
+	i = <-finished
+	if i != 1 {
+		t.Errorf("unexpected group released %d", i)
+	}
+	// release 2, verify group 2 runs
+	doneList[2]()
+	i = <-finished
+	if i != 2 {
+		t.Errorf("unexpected group released %d", i)
+	}
+	// cancel context while MultiAcquire is blocked, verify return, release blocked queue, and verify nothing is blocked
+	cancelCtx, cancelFn := context.WithCancel(ctx)
+	done, err = qList[0].TryAcquire(cancelCtx, e)
+	if err != nil {
+		t.Errorf("failed acquiring %d: %v", i, err)
+	}
+	if done == nil {
+		t.Errorf("acquiring %d returned a nil", i)
+	}
+	go func() {
+		sleepMS(5)
+		cancelFn()
+	}()
+	_, doneAll, err = AcquireMulti(cancelCtx, e, qList[0], qList[1])
+	if err == nil {
+		t.Errorf("AcquireMulti did not error when context canceled")
+	}
+	if doneAll != nil {
+		t.Errorf("AcquireMulti on a canceled context did not return a nil done function")
+		doneAll()
+	}
+	done()
+	for i := range qList {
+		done, err = qList[i].TryAcquire(ctxMulti, e)
+		if err != nil {
+			t.Errorf("TryAcquire returned an error for %d: %v", i, err)
+		}
+		if done == nil {
+			t.Errorf("TryAcquire blocked for queue %d", i)
+		} else {
+			done()
+		}
+	}
+}
+
+func sleepMS(ms int64) {
+	time.Sleep(time.Millisecond * time.Duration(ms))
+}

--- a/internal/reghttp/http_test.go
+++ b/internal/reghttp/http_test.go
@@ -754,18 +754,13 @@ func TestRegHttp(t *testing.T) {
 	// test getting http response
 	// test read/closer
 	t.Run("Get", func(t *testing.T) {
-		apiGet := map[string]ReqAPI{
-			"": {
-				Method:     "GET",
-				Repository: "project",
-				Path:       "manifests/tag-get",
-				Headers:    headers,
-				Digest:     getDigest,
-			},
-		}
 		getReq := &Req{
-			Host: tsHost,
-			APIs: apiGet,
+			Host:       tsHost,
+			Method:     "GET",
+			Repository: "project",
+			Path:       "manifests/tag-get",
+			Headers:    headers,
+			Digest:     getDigest,
 		}
 		resp, err := hc.Do(ctx, getReq)
 		if err != nil {
@@ -786,18 +781,13 @@ func TestRegHttp(t *testing.T) {
 		}
 	})
 	t.Run("Seek", func(t *testing.T) {
-		apiGet := map[string]ReqAPI{
-			"": {
-				Method:     "GET",
-				Repository: "project",
-				Path:       "manifests/tag-get",
-				Headers:    headers,
-				Digest:     getDigest,
-			},
-		}
 		getReq := &Req{
-			Host: tsHost,
-			APIs: apiGet,
+			Host:       tsHost,
+			Method:     "GET",
+			Repository: "project",
+			Path:       "manifests/tag-get",
+			Headers:    headers,
+			Digest:     getDigest,
 		}
 		resp, err := hc.Do(ctx, getReq)
 		if err != nil {
@@ -838,17 +828,12 @@ func TestRegHttp(t *testing.T) {
 	t.Run("Direct", func(t *testing.T) {
 		u, _ := url.Parse(ts.URL)
 		u.Path = "/v2/project/manifests/tag-get"
-		apiGet := map[string]ReqAPI{
-			"": {
-				Method:    "GET",
-				DirectURL: u,
-				Headers:   headers,
-				Digest:    getDigest,
-			},
-		}
 		getReq := &Req{
-			Host: tsHost,
-			APIs: apiGet,
+			Host:      tsHost,
+			Method:    "GET",
+			DirectURL: u,
+			Headers:   headers,
+			Digest:    getDigest,
 		}
 		resp, err := hc.Do(ctx, getReq)
 		if err != nil {
@@ -870,18 +855,13 @@ func TestRegHttp(t *testing.T) {
 	})
 	// test digest validation
 	t.Run("Bad Digest", func(t *testing.T) {
-		apiBadDigest := map[string]ReqAPI{
-			"": {
-				Method:     "GET",
-				Repository: "project",
-				Path:       "manifests/tag-get",
-				Headers:    headers,
-				Digest:     digest.FromString("bad digest"),
-			},
-		}
 		badDigestReq := &Req{
-			Host: tsHost,
-			APIs: apiBadDigest,
+			Host:       tsHost,
+			Method:     "GET",
+			Repository: "project",
+			Path:       "manifests/tag-get",
+			Headers:    headers,
+			Digest:     digest.FromString("bad digest"),
 		}
 		resp, err := hc.Do(ctx, badDigestReq)
 		if err != nil {
@@ -904,17 +884,12 @@ func TestRegHttp(t *testing.T) {
 	t.Run("Direct Digest", func(t *testing.T) {
 		u, _ := url.Parse(ts.URL)
 		u.Path = "/v2/project/manifests/tag-get"
-		apiGet := map[string]ReqAPI{
-			"": {
-				Method:    "GET",
-				DirectURL: u,
-				Headers:   headers,
-				Digest:    digest.FromString("bad digest"),
-			},
-		}
 		getReq := &Req{
-			Host: tsHost,
-			APIs: apiGet,
+			Host:      tsHost,
+			Method:    "GET",
+			DirectURL: u,
+			Headers:   headers,
+			Digest:    digest.FromString("bad digest"),
 		}
 		resp, err := hc.Do(ctx, getReq)
 		if err != nil {
@@ -940,18 +915,13 @@ func TestRegHttp(t *testing.T) {
 		expCtx, cancelFunc := context.WithDeadline(ctx, deadline)
 		defer cancelFunc()
 
-		apiGet := map[string]ReqAPI{
-			"": {
-				Method:     "GET",
-				Repository: "project",
-				Path:       "manifests/tag-get",
-				Headers:    headers,
-				Digest:     getDigest,
-			},
-		}
 		getReq := &Req{
-			Host: tsHost,
-			APIs: apiGet,
+			Host:       tsHost,
+			Method:     "GET",
+			Repository: "project",
+			Path:       "manifests/tag-get",
+			Headers:    headers,
+			Digest:     getDigest,
 		}
 		resp, err := hc.Do(expCtx, getReq)
 		if err == nil {
@@ -961,18 +931,13 @@ func TestRegHttp(t *testing.T) {
 	})
 	// test head requests
 	t.Run("Head", func(t *testing.T) {
-		apiHead := map[string]ReqAPI{
-			"": {
-				Method:     "HEAD",
-				Repository: "project",
-				Path:       "manifests/tag-get",
-				Headers:    headers,
-				Digest:     getDigest,
-			},
-		}
 		headReq := &Req{
-			Host: tsHost,
-			APIs: apiHead,
+			Host:       tsHost,
+			Method:     "HEAD",
+			Repository: "project",
+			Path:       "manifests/tag-get",
+			Headers:    headers,
+			Digest:     getDigest,
 		}
 		resp, err := hc.Do(ctx, headReq)
 		if err != nil {
@@ -994,18 +959,13 @@ func TestRegHttp(t *testing.T) {
 	})
 	// test disabled head request
 	t.Run("Disabled Head", func(t *testing.T) {
-		apiHead := map[string]ReqAPI{
-			"": {
-				Method:     "HEAD",
-				Repository: "project",
-				Path:       "manifests/tag-get",
-				Headers:    headers,
-				Digest:     getDigest,
-			},
-		}
 		headReq := &Req{
-			Host: "nohead." + tsHost,
-			APIs: apiHead,
+			Host:       "nohead." + tsHost,
+			Method:     "HEAD",
+			Repository: "project",
+			Path:       "manifests/tag-get",
+			Headers:    headers,
+			Digest:     getDigest,
 		}
 		resp, err := hc.Do(ctx, headReq)
 		if err == nil {
@@ -1015,18 +975,13 @@ func TestRegHttp(t *testing.T) {
 	})
 	// test auth
 	t.Run("Auth", func(t *testing.T) {
-		apiAuth := map[string]ReqAPI{
-			"": {
-				Method:     "GET",
-				Repository: "project",
-				Path:       "manifests/tag-auth",
-				Headers:    headers,
-				Digest:     getDigest,
-			},
-		}
 		authReq := &Req{
-			Host: "auth." + tsHost,
-			APIs: apiAuth,
+			Host:       "auth." + tsHost,
+			Method:     "GET",
+			Repository: "project",
+			Path:       "manifests/tag-auth",
+			Headers:    headers,
+			Digest:     getDigest,
 		}
 		resp, err := hc.Do(ctx, authReq)
 		if err != nil {
@@ -1047,18 +1002,13 @@ func TestRegHttp(t *testing.T) {
 		}
 	})
 	t.Run("Unauth", func(t *testing.T) {
-		apiAuth := map[string]ReqAPI{
-			"": {
-				Method:     "GET",
-				Repository: "project",
-				Path:       "manifests/tag-auth",
-				Headers:    headers,
-				Digest:     getDigest,
-			},
-		}
 		authReq := &Req{
-			Host: "unauth." + tsHost,
-			APIs: apiAuth,
+			Host:       "unauth." + tsHost,
+			Method:     "GET",
+			Repository: "project",
+			Path:       "manifests/tag-auth",
+			Headers:    headers,
+			Digest:     getDigest,
 		}
 		resp, err := hc.Do(ctx, authReq)
 		if err == nil {
@@ -1069,18 +1019,13 @@ func TestRegHttp(t *testing.T) {
 		}
 	})
 	t.Run("Bad auth", func(t *testing.T) {
-		apiAuth := map[string]ReqAPI{
-			"": {
-				Method:     "GET",
-				Repository: "project-bad-auth",
-				Path:       "manifests/tag-repoauth",
-				Headers:    headers,
-				Digest:     getDigest,
-			},
-		}
 		authReq := &Req{
-			Host: "repoauth." + tsHost,
-			APIs: apiAuth,
+			Host:       "repoauth." + tsHost,
+			Method:     "GET",
+			Repository: "project-bad-auth",
+			Path:       "manifests/tag-repoauth",
+			Headers:    headers,
+			Digest:     getDigest,
 		}
 		resp, err := hc.Do(ctx, authReq)
 		if err == nil {
@@ -1091,18 +1036,13 @@ func TestRegHttp(t *testing.T) {
 		}
 	})
 	t.Run("Missing auth", func(t *testing.T) {
-		apiAuth := map[string]ReqAPI{
-			"": {
-				Method:     "GET",
-				Repository: "project-missing-auth",
-				Path:       "manifests/tag-repoauth",
-				Headers:    headers,
-				Digest:     getDigest,
-			},
-		}
 		authReq := &Req{
-			Host: "repoauth." + tsHost,
-			APIs: apiAuth,
+			Host:       "repoauth." + tsHost,
+			Method:     "GET",
+			Repository: "project-missing-auth",
+			Path:       "manifests/tag-repoauth",
+			Headers:    headers,
+			Digest:     getDigest,
 		}
 		resp, err := hc.Do(ctx, authReq)
 		if err == nil {
@@ -1114,18 +1054,13 @@ func TestRegHttp(t *testing.T) {
 	})
 	// test repoauth
 	t.Run("RepoAuth", func(t *testing.T) {
-		apiAuth1G := map[string]ReqAPI{
-			"": {
-				Method:     "GET",
-				Repository: "project",
-				Path:       "manifests/tag-repoauth",
-				Headers:    headers,
-				Digest:     getDigest,
-			},
-		}
 		authReq1G := &Req{
-			Host: "repoauth." + tsHost,
-			APIs: apiAuth1G,
+			Host:       "repoauth." + tsHost,
+			Method:     "GET",
+			Repository: "project",
+			Path:       "manifests/tag-repoauth",
+			Headers:    headers,
+			Digest:     getDigest,
 		}
 		resp, err := hc.Do(ctx, authReq1G)
 		if err != nil {
@@ -1145,19 +1080,14 @@ func TestRegHttp(t *testing.T) {
 			t.Errorf("error closing request: %v", err)
 		}
 
-		apiAuth1P := map[string]ReqAPI{
-			"": {
-				Method:     "PUT",
-				Repository: "project",
-				Path:       "manifests/tag-repoauth",
-				Headers:    headers,
-				Digest:     getDigest,
-				BodyBytes:  putBody,
-			},
-		}
 		authReq1P := &Req{
-			Host: "repoauth." + tsHost,
-			APIs: apiAuth1P,
+			Host:       "repoauth." + tsHost,
+			Method:     "PUT",
+			Repository: "project",
+			Path:       "manifests/tag-repoauth",
+			Headers:    headers,
+			Digest:     getDigest,
+			BodyBytes:  putBody,
 		}
 		resp, err = hc.Do(ctx, authReq1P)
 		if err != nil {
@@ -1171,18 +1101,13 @@ func TestRegHttp(t *testing.T) {
 			t.Errorf("error closing request: %v", err)
 		}
 
-		apiAuth2G := map[string]ReqAPI{
-			"": {
-				Method:     "GET",
-				Repository: "project2",
-				Path:       "manifests/tag-repoauth",
-				Headers:    headers,
-				Digest:     getDigest,
-			},
-		}
 		authReq2G := &Req{
-			Host: "repoauth." + tsHost,
-			APIs: apiAuth2G,
+			Host:       "repoauth." + tsHost,
+			Method:     "GET",
+			Repository: "project2",
+			Path:       "manifests/tag-repoauth",
+			Headers:    headers,
+			Digest:     getDigest,
 		}
 		resp, err = hc.Do(ctx, authReq2G)
 		if err != nil {
@@ -1202,19 +1127,14 @@ func TestRegHttp(t *testing.T) {
 			t.Errorf("error closing request: %v", err)
 		}
 
-		apiAuth2P := map[string]ReqAPI{
-			"": {
-				Method:     "PUT",
-				Repository: "project2",
-				Path:       "manifests/tag-repoauth",
-				Headers:    headers,
-				Digest:     getDigest,
-				BodyBytes:  putBody,
-			},
-		}
 		authReq2P := &Req{
-			Host: "repoauth." + tsHost,
-			APIs: apiAuth2P,
+			Host:       "repoauth." + tsHost,
+			Method:     "PUT",
+			Repository: "project2",
+			Path:       "manifests/tag-repoauth",
+			Headers:    headers,
+			Digest:     getDigest,
+			BodyBytes:  putBody,
 		}
 		resp, err = hc.Do(ctx, authReq2P)
 		if err != nil {
@@ -1230,18 +1150,13 @@ func TestRegHttp(t *testing.T) {
 	})
 	// test body func and body string
 	t.Run("Post body string", func(t *testing.T) {
-		apiPost := map[string]ReqAPI{
-			"": {
-				Method:     "POST",
-				Repository: "project",
-				Path:       "manifests/tag-post",
-				BodyBytes:  postBody,
-				BodyLen:    int64(len(postBody)),
-			},
-		}
 		postReq := &Req{
-			Host: tsHost,
-			APIs: apiPost,
+			Host:       tsHost,
+			Method:     "POST",
+			Repository: "project",
+			Path:       "manifests/tag-post",
+			BodyBytes:  postBody,
+			BodyLen:    int64(len(postBody)),
 		}
 		resp, err := hc.Do(ctx, postReq)
 		if err != nil {
@@ -1262,17 +1177,12 @@ func TestRegHttp(t *testing.T) {
 		}
 	})
 	t.Run("Put body retry", func(t *testing.T) {
-		apiPut := map[string]ReqAPI{
-			"": {
-				Method:     "PUT",
-				Repository: "project",
-				Path:       "manifests/tag-put-fail",
-				BodyBytes:  putBody,
-			},
-		}
 		putReq := &Req{
-			Host: tsHost,
-			APIs: apiPut,
+			Host:       tsHost,
+			Method:     "PUT",
+			Repository: "project",
+			Path:       "manifests/tag-put-fail",
+			BodyBytes:  putBody,
 		}
 		resp, err := hc.Do(ctx, putReq)
 		if err != nil {
@@ -1293,18 +1203,13 @@ func TestRegHttp(t *testing.T) {
 		}
 	})
 	t.Run("Put body func", func(t *testing.T) {
-		apiPut := map[string]ReqAPI{
-			"": {
-				Method:     "PUT",
-				Repository: "project",
-				Path:       "manifests/tag-put",
-				BodyFunc:   func() (io.ReadCloser, error) { return io.NopCloser(bytes.NewReader(putBody)), nil },
-				BodyLen:    int64(len(putBody)),
-			},
-		}
 		putReq := &Req{
-			Host: tsHost,
-			APIs: apiPut,
+			Host:       tsHost,
+			Method:     "PUT",
+			Repository: "project",
+			Path:       "manifests/tag-put",
+			BodyFunc:   func() (io.ReadCloser, error) { return io.NopCloser(bytes.NewReader(putBody)), nil },
+			BodyLen:    int64(len(putBody)),
 		}
 		resp, err := hc.Do(ctx, putReq)
 		if err != nil {
@@ -1326,16 +1231,11 @@ func TestRegHttp(t *testing.T) {
 	})
 	// test delete
 	t.Run("Delete", func(t *testing.T) {
-		apiDelete := map[string]ReqAPI{
-			"": {
-				Method:     "DELETE",
-				Repository: "project",
-				Path:       "manifests/tag-delete",
-			},
-		}
 		deleteReq := &Req{
-			Host: tsHost,
-			APIs: apiDelete,
+			Host:       tsHost,
+			Method:     "DELETE",
+			Repository: "project",
+			Path:       "manifests/tag-delete",
 		}
 		resp, err := hc.Do(ctx, deleteReq)
 		if err != nil {
@@ -1357,19 +1257,13 @@ func TestRegHttp(t *testing.T) {
 	})
 	// test a list of bad mirrors to ensure fall back
 	t.Run("Mirrors", func(t *testing.T) {
-		apiGet := map[string]ReqAPI{
-			"": {
-				Method:     "GET",
-				Repository: "project",
-				Path:       "manifests/tag-get",
-				Headers:    headers,
-				Digest:     getDigest,
-				// IgnoreErr:  true,
-			},
-		}
 		getReq := &Req{
-			Host: "mirrors." + tsHost,
-			APIs: apiGet,
+			Host:       "mirrors." + tsHost,
+			Method:     "GET",
+			Repository: "project",
+			Path:       "manifests/tag-get",
+			Headers:    headers,
+			Digest:     getDigest,
 		}
 		resp, err := hc.Do(ctx, getReq)
 		if err != nil {
@@ -1391,18 +1285,13 @@ func TestRegHttp(t *testing.T) {
 	})
 	// test error statuses (404, rate limit, timeout, server error)
 	t.Run("Missing", func(t *testing.T) {
-		apiGet := map[string]ReqAPI{
-			"": {
-				Method:     "GET",
-				Repository: "project",
-				Path:       "manifests/tag-get",
-				Headers:    headers,
-				Digest:     getDigest,
-			},
-		}
 		getReq := &Req{
-			Host: "missing." + tsHost,
-			APIs: apiGet,
+			Host:       "missing." + tsHost,
+			Method:     "GET",
+			Repository: "project",
+			Path:       "manifests/tag-get",
+			Headers:    headers,
+			Digest:     getDigest,
 		}
 		resp, err := hc.Do(ctx, getReq)
 		if err == nil {
@@ -1413,18 +1302,13 @@ func TestRegHttp(t *testing.T) {
 		}
 	})
 	t.Run("Forbidden", func(t *testing.T) {
-		apiGet := map[string]ReqAPI{
-			"": {
-				Method:     "GET",
-				Repository: "project",
-				Path:       "manifests/tag-get",
-				Headers:    headers,
-				Digest:     getDigest,
-			},
-		}
 		getReq := &Req{
-			Host: "forbidden." + tsHost,
-			APIs: apiGet,
+			Host:       "forbidden." + tsHost,
+			Method:     "GET",
+			Repository: "project",
+			Path:       "manifests/tag-get",
+			Headers:    headers,
+			Digest:     getDigest,
 		}
 		resp, err := hc.Do(ctx, getReq)
 		if err == nil {
@@ -1435,18 +1319,13 @@ func TestRegHttp(t *testing.T) {
 		}
 	})
 	t.Run("Bad GW", func(t *testing.T) {
-		apiGet := map[string]ReqAPI{
-			"": {
-				Method:     "GET",
-				Repository: "project",
-				Path:       "manifests/tag-get",
-				Headers:    headers,
-				Digest:     getDigest,
-			},
-		}
 		getReq := &Req{
-			Host: "bad-gw." + tsHost,
-			APIs: apiGet,
+			Host:       "bad-gw." + tsHost,
+			Method:     "GET",
+			Repository: "project",
+			Path:       "manifests/tag-get",
+			Headers:    headers,
+			Digest:     getDigest,
 		}
 		resp, err := hc.Do(ctx, getReq)
 		if err == nil {
@@ -1457,18 +1336,13 @@ func TestRegHttp(t *testing.T) {
 		}
 	})
 	t.Run("GW Timeout", func(t *testing.T) {
-		apiGet := map[string]ReqAPI{
-			"": {
-				Method:     "GET",
-				Repository: "project",
-				Path:       "manifests/tag-get",
-				Headers:    headers,
-				Digest:     getDigest,
-			},
-		}
 		getReq := &Req{
-			Host: "gw-timeout." + tsHost,
-			APIs: apiGet,
+			Host:       "gw-timeout." + tsHost,
+			Method:     "GET",
+			Repository: "project",
+			Path:       "manifests/tag-get",
+			Headers:    headers,
+			Digest:     getDigest,
 		}
 		resp, err := hc.Do(ctx, getReq)
 		if err == nil {
@@ -1479,18 +1353,13 @@ func TestRegHttp(t *testing.T) {
 		}
 	})
 	t.Run("Server error", func(t *testing.T) {
-		apiGet := map[string]ReqAPI{
-			"": {
-				Method:     "GET",
-				Repository: "project",
-				Path:       "manifests/tag-get",
-				Headers:    headers,
-				Digest:     getDigest,
-			},
-		}
 		getReq := &Req{
-			Host: "server-error." + tsHost,
-			APIs: apiGet,
+			Host:       "server-error." + tsHost,
+			Method:     "GET",
+			Repository: "project",
+			Path:       "manifests/tag-get",
+			Headers:    headers,
+			Digest:     getDigest,
 		}
 		resp, err := hc.Do(ctx, getReq)
 		if err == nil {
@@ -1504,18 +1373,13 @@ func TestRegHttp(t *testing.T) {
 	t.Run("Rate limit and timeout", func(t *testing.T) {
 		ctxTimeout, cancel := context.WithTimeout(ctx, delayInit*2)
 		defer cancel()
-		apiGet := map[string]ReqAPI{
-			"": {
-				Method:     "GET",
-				Repository: "project",
-				Path:       "manifests/tag-get",
-				Headers:    headers,
-				Digest:     getDigest,
-			},
-		}
 		getReq := &Req{
-			Host: "rate-limit." + tsHost,
-			APIs: apiGet,
+			Host:       "rate-limit." + tsHost,
+			Method:     "GET",
+			Repository: "project",
+			Path:       "manifests/tag-get",
+			Headers:    headers,
+			Digest:     getDigest,
 		}
 		resp, err := hc.Do(ctxTimeout, getReq)
 		if err == nil {
@@ -1527,17 +1391,12 @@ func TestRegHttp(t *testing.T) {
 	})
 	// test connection dropping during read and retry
 	t.Run("Short", func(t *testing.T) {
-		apiShort := map[string]ReqAPI{
-			"": {
-				Method:     "GET",
-				Repository: "project",
-				Path:       "manifests/tag-short",
-				Headers:    headers,
-			},
-		}
 		shortReq := &Req{
-			Host: tsHost,
-			APIs: apiShort,
+			Host:       tsHost,
+			Method:     "GET",
+			Repository: "project",
+			Path:       "manifests/tag-short",
+			Headers:    headers,
 		}
 		resp, err := hc.Do(ctx, shortReq)
 		if err != nil {
@@ -1558,18 +1417,13 @@ func TestRegHttp(t *testing.T) {
 		}
 	})
 	t.Run("Retry", func(t *testing.T) {
-		apiRetry := map[string]ReqAPI{
-			"": {
-				Method:     "GET",
-				Repository: "project",
-				Path:       "manifests/tag-retry",
-				Headers:    headers,
-				Digest:     retryDigest,
-			},
-		}
 		retryReq := &Req{
-			Host: "retry." + tsHost,
-			APIs: apiRetry,
+			Host:       "retry." + tsHost,
+			Method:     "GET",
+			Repository: "project",
+			Path:       "manifests/tag-retry",
+			Headers:    headers,
+			Digest:     retryDigest,
 		}
 		resp, err := hc.Do(ctx, retryReq)
 		if err != nil {
@@ -1590,18 +1444,13 @@ func TestRegHttp(t *testing.T) {
 		}
 	})
 	t.Run("Warning", func(t *testing.T) {
-		apiGet := map[string]ReqAPI{
-			"": {
-				Method:     "GET",
-				Repository: "project",
-				Path:       "manifests/warning",
-				Headers:    headers,
-				Digest:     getDigest,
-			},
-		}
 		getReq := &Req{
-			Host: tsHost,
-			APIs: apiGet,
+			Host:       tsHost,
+			Method:     "GET",
+			Repository: "project",
+			Path:       "manifests/warning",
+			Headers:    headers,
+			Digest:     getDigest,
 		}
 		w := &warning.Warning{}
 		wCtx := warning.NewContext(ctx, w)
@@ -1625,18 +1474,13 @@ func TestRegHttp(t *testing.T) {
 		}
 	})
 	t.Run("Host Normalized", func(t *testing.T) {
-		apiGet := map[string]ReqAPI{
-			"": {
-				Method:     "GET",
-				Repository: "project",
-				Path:       "manifests/tag-get",
-				Headers:    headers,
-				Digest:     getDigest,
-			},
-		}
 		getReq := &Req{
-			Host: tsHost + "/path",
-			APIs: apiGet,
+			Host:       tsHost + "/path",
+			Method:     "GET",
+			Repository: "project",
+			Path:       "manifests/tag-get",
+			Headers:    headers,
+			Digest:     getDigest,
 		}
 		resp, err := hc.Do(ctx, getReq)
 		if err != nil {
@@ -1660,18 +1504,13 @@ func TestRegHttp(t *testing.T) {
 		count := 3
 		ctxTimeout, cancel := context.WithTimeout(ctx, delayInit*4)
 		defer cancel()
-		apiGet := map[string]ReqAPI{
-			"": {
-				Method:     "GET",
-				Repository: "project",
-				Path:       "manifests/tag-get",
-				Headers:    headers,
-				Digest:     getDigest,
-			},
-		}
 		getReq := &Req{
-			Host: "rate-limit." + tsHost,
-			APIs: apiGet,
+			Host:       "rate-limit." + tsHost,
+			Method:     "GET",
+			Repository: "project",
+			Path:       "manifests/tag-get",
+			Headers:    headers,
+			Digest:     getDigest,
 		}
 		chResults := make(chan error)
 		for i := 0; i < count; i++ {

--- a/internal/reghttp/http_test.go
+++ b/internal/reghttp/http_test.go
@@ -760,7 +760,6 @@ func TestRegHttp(t *testing.T) {
 			Repository: "project",
 			Path:       "manifests/tag-get",
 			Headers:    headers,
-			Digest:     getDigest,
 		}
 		resp, err := hc.Do(ctx, getReq)
 		if err != nil {
@@ -787,7 +786,6 @@ func TestRegHttp(t *testing.T) {
 			Repository: "project",
 			Path:       "manifests/tag-get",
 			Headers:    headers,
-			Digest:     getDigest,
 		}
 		resp, err := hc.Do(ctx, getReq)
 		if err != nil {
@@ -833,7 +831,6 @@ func TestRegHttp(t *testing.T) {
 			Method:    "GET",
 			DirectURL: u,
 			Headers:   headers,
-			Digest:    getDigest,
 		}
 		resp, err := hc.Do(ctx, getReq)
 		if err != nil {
@@ -853,62 +850,6 @@ func TestRegHttp(t *testing.T) {
 			t.Errorf("error closing request: %v", err)
 		}
 	})
-	// test digest validation
-	t.Run("Bad Digest", func(t *testing.T) {
-		badDigestReq := &Req{
-			Host:       tsHost,
-			Method:     "GET",
-			Repository: "project",
-			Path:       "manifests/tag-get",
-			Headers:    headers,
-			Digest:     digest.FromString("bad digest"),
-		}
-		resp, err := hc.Do(ctx, badDigestReq)
-		if err != nil {
-			t.Fatalf("failed to run get: %v", err)
-		}
-		if resp.HTTPResponse().StatusCode != 200 {
-			t.Errorf("invalid status code, expected 200, received %d", resp.HTTPResponse().StatusCode)
-		}
-		body, err := io.ReadAll(resp)
-		if err == nil {
-			t.Errorf("body read unexpectedly succeeded: %s", body)
-		} else if !errors.Is(err, errs.ErrDigestMismatch) {
-			t.Errorf("unexpected error from digest mismatch: %v", err)
-		}
-		err = resp.Close()
-		if err != nil {
-			t.Errorf("error closing request: %v", err)
-		}
-	})
-	t.Run("Direct Digest", func(t *testing.T) {
-		u, _ := url.Parse(ts.URL)
-		u.Path = "/v2/project/manifests/tag-get"
-		getReq := &Req{
-			Host:      tsHost,
-			Method:    "GET",
-			DirectURL: u,
-			Headers:   headers,
-			Digest:    digest.FromString("bad digest"),
-		}
-		resp, err := hc.Do(ctx, getReq)
-		if err != nil {
-			t.Fatalf("failed to run get: %v", err)
-		}
-		if resp.HTTPResponse().StatusCode != 200 {
-			t.Errorf("invalid status code, expected 200, received %d", resp.HTTPResponse().StatusCode)
-		}
-		body, err := io.ReadAll(resp)
-		if err == nil {
-			t.Errorf("body read unexpectedly succeeded: %s", body)
-		} else if !errors.Is(err, errs.ErrDigestMismatch) {
-			t.Errorf("unexpected error from digest mismatch: %v", err)
-		}
-		err = resp.Close()
-		if err != nil {
-			t.Errorf("error closing request: %v", err)
-		}
-	})
 	// test context already expired
 	t.Run("Expired Context", func(t *testing.T) {
 		deadline := time.Now().Add(-1 * time.Second)
@@ -921,7 +862,6 @@ func TestRegHttp(t *testing.T) {
 			Repository: "project",
 			Path:       "manifests/tag-get",
 			Headers:    headers,
-			Digest:     getDigest,
 		}
 		resp, err := hc.Do(expCtx, getReq)
 		if err == nil {
@@ -937,7 +877,6 @@ func TestRegHttp(t *testing.T) {
 			Repository: "project",
 			Path:       "manifests/tag-get",
 			Headers:    headers,
-			Digest:     getDigest,
 		}
 		resp, err := hc.Do(ctx, headReq)
 		if err != nil {
@@ -965,7 +904,6 @@ func TestRegHttp(t *testing.T) {
 			Repository: "project",
 			Path:       "manifests/tag-get",
 			Headers:    headers,
-			Digest:     getDigest,
 		}
 		resp, err := hc.Do(ctx, headReq)
 		if err == nil {
@@ -981,7 +919,6 @@ func TestRegHttp(t *testing.T) {
 			Repository: "project",
 			Path:       "manifests/tag-auth",
 			Headers:    headers,
-			Digest:     getDigest,
 		}
 		resp, err := hc.Do(ctx, authReq)
 		if err != nil {
@@ -1008,7 +945,6 @@ func TestRegHttp(t *testing.T) {
 			Repository: "project",
 			Path:       "manifests/tag-auth",
 			Headers:    headers,
-			Digest:     getDigest,
 		}
 		resp, err := hc.Do(ctx, authReq)
 		if err == nil {
@@ -1025,7 +961,6 @@ func TestRegHttp(t *testing.T) {
 			Repository: "project-bad-auth",
 			Path:       "manifests/tag-repoauth",
 			Headers:    headers,
-			Digest:     getDigest,
 		}
 		resp, err := hc.Do(ctx, authReq)
 		if err == nil {
@@ -1042,7 +977,6 @@ func TestRegHttp(t *testing.T) {
 			Repository: "project-missing-auth",
 			Path:       "manifests/tag-repoauth",
 			Headers:    headers,
-			Digest:     getDigest,
 		}
 		resp, err := hc.Do(ctx, authReq)
 		if err == nil {
@@ -1060,7 +994,6 @@ func TestRegHttp(t *testing.T) {
 			Repository: "project",
 			Path:       "manifests/tag-repoauth",
 			Headers:    headers,
-			Digest:     getDigest,
 		}
 		resp, err := hc.Do(ctx, authReq1G)
 		if err != nil {
@@ -1086,7 +1019,6 @@ func TestRegHttp(t *testing.T) {
 			Repository: "project",
 			Path:       "manifests/tag-repoauth",
 			Headers:    headers,
-			Digest:     getDigest,
 			BodyBytes:  putBody,
 		}
 		resp, err = hc.Do(ctx, authReq1P)
@@ -1107,7 +1039,6 @@ func TestRegHttp(t *testing.T) {
 			Repository: "project2",
 			Path:       "manifests/tag-repoauth",
 			Headers:    headers,
-			Digest:     getDigest,
 		}
 		resp, err = hc.Do(ctx, authReq2G)
 		if err != nil {
@@ -1133,7 +1064,6 @@ func TestRegHttp(t *testing.T) {
 			Repository: "project2",
 			Path:       "manifests/tag-repoauth",
 			Headers:    headers,
-			Digest:     getDigest,
 			BodyBytes:  putBody,
 		}
 		resp, err = hc.Do(ctx, authReq2P)
@@ -1263,7 +1193,6 @@ func TestRegHttp(t *testing.T) {
 			Repository: "project",
 			Path:       "manifests/tag-get",
 			Headers:    headers,
-			Digest:     getDigest,
 		}
 		resp, err := hc.Do(ctx, getReq)
 		if err != nil {
@@ -1291,7 +1220,6 @@ func TestRegHttp(t *testing.T) {
 			Repository: "project",
 			Path:       "manifests/tag-get",
 			Headers:    headers,
-			Digest:     getDigest,
 		}
 		resp, err := hc.Do(ctx, getReq)
 		if err == nil {
@@ -1308,7 +1236,6 @@ func TestRegHttp(t *testing.T) {
 			Repository: "project",
 			Path:       "manifests/tag-get",
 			Headers:    headers,
-			Digest:     getDigest,
 		}
 		resp, err := hc.Do(ctx, getReq)
 		if err == nil {
@@ -1325,7 +1252,6 @@ func TestRegHttp(t *testing.T) {
 			Repository: "project",
 			Path:       "manifests/tag-get",
 			Headers:    headers,
-			Digest:     getDigest,
 		}
 		resp, err := hc.Do(ctx, getReq)
 		if err == nil {
@@ -1342,7 +1268,6 @@ func TestRegHttp(t *testing.T) {
 			Repository: "project",
 			Path:       "manifests/tag-get",
 			Headers:    headers,
-			Digest:     getDigest,
 		}
 		resp, err := hc.Do(ctx, getReq)
 		if err == nil {
@@ -1359,7 +1284,6 @@ func TestRegHttp(t *testing.T) {
 			Repository: "project",
 			Path:       "manifests/tag-get",
 			Headers:    headers,
-			Digest:     getDigest,
 		}
 		resp, err := hc.Do(ctx, getReq)
 		if err == nil {
@@ -1379,7 +1303,6 @@ func TestRegHttp(t *testing.T) {
 			Repository: "project",
 			Path:       "manifests/tag-get",
 			Headers:    headers,
-			Digest:     getDigest,
 		}
 		resp, err := hc.Do(ctxTimeout, getReq)
 		if err == nil {
@@ -1423,7 +1346,6 @@ func TestRegHttp(t *testing.T) {
 			Repository: "project",
 			Path:       "manifests/tag-retry",
 			Headers:    headers,
-			Digest:     retryDigest,
 		}
 		resp, err := hc.Do(ctx, retryReq)
 		if err != nil {
@@ -1450,7 +1372,6 @@ func TestRegHttp(t *testing.T) {
 			Repository: "project",
 			Path:       "manifests/warning",
 			Headers:    headers,
-			Digest:     getDigest,
 		}
 		w := &warning.Warning{}
 		wCtx := warning.NewContext(ctx, w)
@@ -1480,7 +1401,6 @@ func TestRegHttp(t *testing.T) {
 			Repository: "project",
 			Path:       "manifests/tag-get",
 			Headers:    headers,
-			Digest:     getDigest,
 		}
 		resp, err := hc.Do(ctx, getReq)
 		if err != nil {
@@ -1510,7 +1430,6 @@ func TestRegHttp(t *testing.T) {
 			Repository: "project",
 			Path:       "manifests/tag-get",
 			Headers:    headers,
-			Digest:     getDigest,
 		}
 		chResults := make(chan error)
 		for i := 0; i < count; i++ {

--- a/internal/reqmeta/data.go
+++ b/internal/reqmeta/data.go
@@ -10,7 +10,79 @@ type Kind int
 
 const (
 	Unknown Kind = iota
+	Head
 	Manifest
-	Blob
 	Query
+	Blob
 )
+
+const (
+	smallLimit = 4194304 // 4MiB
+	largePct   = 0.9     // anything above 90% of largest queued entry size is large
+)
+
+func DataNext(queued, active []*Data) int {
+	if len(queued) == 0 {
+		return -1
+	}
+	// After removing one small entry, split remaining requests 50/50 between large and old (truncated int division always rounds down).
+	// If len active = 2, this function returns the 3rd entry (+1), minus 1 for the small, divide by 2 to split with old = goal of 1.
+	largeGoal := len(active) / 2
+	largeI := 0
+	var largeSize int64
+	if largeGoal > 0 {
+		//  find the largest queued blob requests
+		for i, cur := range queued {
+			if cur.Kind == Blob && cur.Size > largeSize {
+				largeI = i
+				largeSize = cur.Size
+			}
+		}
+	}
+	largeCutoff := int64(float64(largeSize) * 0.9)
+	// count active requests by type
+	small := 0
+	large := 0
+	old := 0
+	for _, cur := range active {
+		if cur.Kind != Blob && cur.Size <= smallLimit {
+			small++
+		} else if cur.Kind == Blob && largeSize > 0 && cur.Size >= largeCutoff {
+			large++
+		} else {
+			old++
+		}
+	}
+	// if there is at least one active, and none are small, return the best small entry if available.
+	if len(active) > 0 && small == 0 {
+		var sizeI int64
+		bestI := -1
+		kindI := Unknown
+		for i, cur := range queued {
+			// the small search skips blobs and large requests
+			if cur.Kind == Blob || cur.Size > smallLimit {
+				continue
+			}
+			// the best small entry is the:
+			//  - first one found if no other matches
+			//  - one with a better Kind (Head > Manifest > Query)
+			//  - one with the same kind but smaller request
+			if bestI < 0 ||
+				(cur.Kind != Unknown && (kindI == Unknown || cur.Kind < kindI)) ||
+				(cur.Kind == kindI && cur.Size > 0 && (cur.Size < sizeI || sizeI <= 0)) {
+				bestI = i
+				kindI = cur.Kind
+				sizeI = cur.Size
+			}
+		}
+		if bestI >= 0 {
+			return bestI
+		}
+	}
+	// Prefer the biggest of these blobs to minimize the size of the last running blob.
+	if largeGoal > 0 && large < largeGoal && largeSize > 0 {
+		return largeI
+	}
+	// enough small and large, or none available, so return the oldest queued entry to avoid starvation.
+	return 0
+}

--- a/internal/reqmeta/data.go
+++ b/internal/reqmeta/data.go
@@ -1,0 +1,16 @@
+// Package reqmeta provides metadata on requests for prioritizing with a pqueue.
+package reqmeta
+
+type Data struct {
+	Kind Kind
+	Size int64
+}
+
+type Kind int
+
+const (
+	Unknown Kind = iota
+	Manifest
+	Blob
+	Query
+)

--- a/internal/reqmeta/data_test.go
+++ b/internal/reqmeta/data_test.go
@@ -1,0 +1,180 @@
+package reqmeta
+
+import "testing"
+
+func TestDataNext(t *testing.T) {
+	t.Parallel()
+	tt := []struct {
+		name           string
+		queued, active []*Data
+		expect         int
+	}{
+		{
+			name: "empty queued",
+			active: []*Data{
+				{Kind: Blob, Size: 1000},
+			},
+			expect: -1,
+		},
+		{
+			name: "no active",
+			queued: []*Data{
+				{Kind: Blob, Size: 1000},
+				{Kind: Blob, Size: 1000},
+			},
+			expect: 0,
+		},
+		{
+			name: "one active need small",
+			active: []*Data{
+				{Kind: Blob, Size: 10000},
+			},
+			queued: []*Data{
+				{Kind: Blob, Size: 1000},
+				{Kind: Manifest, Size: 1000},
+				{Kind: Blob, Size: 1000000},
+			},
+			expect: 1,
+		},
+		{
+			name: "one active find first head",
+			active: []*Data{
+				{Kind: Blob, Size: 10000},
+			},
+			queued: []*Data{
+				{Kind: Blob, Size: 1000},
+				{Kind: Query, Size: 0},
+				{Kind: Manifest, Size: 1000},
+				{Kind: Unknown, Size: 0},
+				{Kind: Head, Size: 0},
+				{Kind: Head, Size: 0},
+				{Kind: Blob, Size: 1000000},
+			},
+			expect: 4,
+		},
+		{
+			name: "one active find smallest manifest",
+			active: []*Data{
+				{Kind: Blob, Size: 10000},
+			},
+			queued: []*Data{
+				{Kind: Blob, Size: 1000},
+				{Kind: Query, Size: 0},
+				{Kind: Manifest, Size: 2000},
+				{Kind: Manifest, Size: 1000},
+				{Kind: Unknown, Size: 0},
+				{Kind: Blob, Size: 1000000},
+			},
+			expect: 3,
+		},
+		{
+			name: "one active ignore unknown size",
+			active: []*Data{
+				{Kind: Blob, Size: 10000},
+			},
+			queued: []*Data{
+				{Kind: Blob, Size: 1000},
+				{Kind: Query, Size: 0},
+				{Kind: Manifest, Size: 2000},
+				{Kind: Manifest, Size: 1000},
+				{Kind: Manifest, Size: 0},
+				{Kind: Unknown, Size: 0},
+				{Kind: Blob, Size: 1000000},
+			},
+			expect: 3,
+		},
+		{
+			name: "one active need old",
+			active: []*Data{
+				{Kind: Manifest, Size: 1000},
+			},
+			queued: []*Data{
+				{Kind: Blob, Size: 1000},
+				{Kind: Manifest, Size: 1000},
+				{Kind: Blob, Size: 1000000},
+			},
+			expect: 0,
+		},
+		{
+			name: "two active need large",
+			active: []*Data{
+				{Kind: Manifest, Size: 1000},
+				{Kind: Blob, Size: 100000},
+			},
+			queued: []*Data{
+				{Kind: Blob, Size: 1000},
+				{Kind: Manifest, Size: 1000},
+				{Kind: Blob, Size: 1000000},
+			},
+			expect: 2,
+		},
+		{
+			name: "three active pick large blob",
+			active: []*Data{
+				{Kind: Blob, Size: 1000000},
+				{Kind: Blob, Size: 10000},
+				{Kind: Manifest, Size: 10000},
+			},
+			queued: []*Data{
+				{Kind: Blob, Size: 1000},
+				{Kind: Manifest, Size: 1000},
+				{Kind: Blob, Size: 200000000},
+			},
+			expect: 2,
+		},
+		{
+			name: "three active need small",
+			active: []*Data{
+				{Kind: Blob, Size: 1000000},
+				{Kind: Blob, Size: 10000},
+				{Kind: Blob, Size: 20000},
+			},
+			queued: []*Data{
+				{Kind: Blob, Size: 1000},
+				{Kind: Manifest, Size: 1000},
+				{Kind: Blob, Size: 200000000},
+			},
+			expect: 1,
+		},
+		{
+			name: "three active pick largest",
+			active: []*Data{
+				{Kind: Blob, Size: 20000},
+				{Kind: Blob, Size: 10000},
+				{Kind: Manifest, Size: 10000},
+			},
+			queued: []*Data{
+				{Kind: Blob, Size: 1000},
+				{Kind: Manifest, Size: 1000},
+				{Kind: Blob, Size: 1000000},
+				{Kind: Blob, Size: 2000000},
+				{Kind: Blob, Size: 1500000},
+			},
+			expect: 3,
+		},
+		{
+			name: "three active no large",
+			active: []*Data{
+				{Kind: Blob, Size: 100000},
+				{Kind: Blob, Size: 2000000},
+				{Kind: Manifest, Size: 10000},
+			},
+			queued: []*Data{
+				{Kind: Blob, Size: 1000},
+				{Kind: Manifest, Size: 1000},
+				{Kind: Blob, Size: 20000},
+				{Kind: Blob, Size: 30000},
+			},
+			expect: 0,
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			result := DataNext(tc.queued, tc.active)
+			if result != tc.expect {
+				t.Errorf("unexpected result, expected %d, received %d", tc.expect, result)
+			}
+		})
+	}
+
+}

--- a/regclient.go
+++ b/regclient.go
@@ -232,7 +232,6 @@ func (rc *RegClient) hostLoad(src string, hosts []config.Host) {
 			"tls":        string(tls),
 			"pathPrefix": configHost.PathPrefix,
 			"mirrors":    configHost.Mirrors,
-			"api":        configHost.API,
 			"blobMax":    configHost.BlobMax,
 			"blobChunk":  configHost.BlobChunk,
 		}).Debugf("Loading %s config", src)

--- a/scheme/ocidir/blob.go
+++ b/scheme/ocidir/blob.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"github.com/regclient/regclient/internal/reqmeta"
 	"github.com/regclient/regclient/types/blob"
 	"github.com/regclient/regclient/types/descriptor"
 	"github.com/regclient/regclient/types/errs"
@@ -96,11 +97,11 @@ func (o *OCIDir) BlobMount(ctx context.Context, refSrc ref.Ref, refTgt ref.Ref, 
 // BlobPut sends a blob to the repository, returns the digest and size when successful
 func (o *OCIDir) BlobPut(ctx context.Context, r ref.Ref, d descriptor.Descriptor, rdr io.Reader) (descriptor.Descriptor, error) {
 	t := o.throttleGet(r, false)
-	err := t.Acquire(ctx)
+	done, err := t.Acquire(ctx, reqmeta.Data{Kind: reqmeta.Blob, Size: d.Size})
 	if err != nil {
 		return d, err
 	}
-	defer t.Release(ctx)
+	defer done()
 
 	err = o.initIndex(r, false)
 	if err != nil {

--- a/scheme/reg/blob.go
+++ b/scheme/reg/blob.go
@@ -32,14 +32,10 @@ var (
 // BlobDelete removes a blob from the repository
 func (reg *Reg) BlobDelete(ctx context.Context, r ref.Ref, d descriptor.Descriptor) error {
 	req := &reghttp.Req{
-		Host: r.Registry,
-		APIs: map[string]reghttp.ReqAPI{
-			"": {
-				Method:     "DELETE",
-				Repository: r.Repository,
-				Path:       "blobs/" + d.Digest.String(),
-			},
-		},
+		Host:       r.Registry,
+		Method:     "DELETE",
+		Repository: r.Repository,
+		Path:       "blobs/" + d.Digest.String(),
 	}
 	resp, err := reg.reghttp.Do(ctx, req)
 	if err != nil {
@@ -55,14 +51,10 @@ func (reg *Reg) BlobDelete(ctx context.Context, r ref.Ref, d descriptor.Descript
 func (reg *Reg) BlobGet(ctx context.Context, r ref.Ref, d descriptor.Descriptor) (blob.Reader, error) {
 	// build/send request
 	req := &reghttp.Req{
-		Host: r.Registry,
-		APIs: map[string]reghttp.ReqAPI{
-			"": {
-				Method:     "GET",
-				Repository: r.Repository,
-				Path:       "blobs/" + d.Digest.String(),
-			},
-		},
+		Host:       r.Registry,
+		Method:     "GET",
+		Repository: r.Repository,
+		Path:       "blobs/" + d.Digest.String(),
 	}
 	resp, err := reg.reghttp.Do(ctx, req)
 	if err != nil && len(d.URLs) > 0 {
@@ -74,15 +66,11 @@ func (reg *Reg) BlobGet(ctx context.Context, r ref.Ref, d descriptor.Descriptor)
 				return nil, fmt.Errorf("failed to parse external url \"%s\": %w", curURL, err)
 			}
 			req = &reghttp.Req{
-				Host: r.Registry,
-				APIs: map[string]reghttp.ReqAPI{
-					"": {
-						Method:     "GET",
-						Repository: r.Repository,
-						DirectURL:  u,
-					},
-				},
-				NoMirrors: true,
+				Host:       r.Registry,
+				Method:     "GET",
+				Repository: r.Repository,
+				DirectURL:  u,
+				NoMirrors:  true,
 			}
 			resp, err = reg.reghttp.Do(ctx, req)
 			if err == nil {
@@ -110,14 +98,10 @@ func (reg *Reg) BlobGet(ctx context.Context, r ref.Ref, d descriptor.Descriptor)
 func (reg *Reg) BlobHead(ctx context.Context, r ref.Ref, d descriptor.Descriptor) (blob.Reader, error) {
 	// build/send request
 	req := &reghttp.Req{
-		Host: r.Registry,
-		APIs: map[string]reghttp.ReqAPI{
-			"": {
-				Method:     "HEAD",
-				Repository: r.Repository,
-				Path:       "blobs/" + d.Digest.String(),
-			},
-		},
+		Host:       r.Registry,
+		Method:     "HEAD",
+		Repository: r.Repository,
+		Path:       "blobs/" + d.Digest.String(),
 	}
 	resp, err := reg.reghttp.Do(ctx, req)
 	if err != nil && len(d.URLs) > 0 {
@@ -129,15 +113,11 @@ func (reg *Reg) BlobHead(ctx context.Context, r ref.Ref, d descriptor.Descriptor
 				return nil, fmt.Errorf("failed to parse external url \"%s\": %w", curURL, err)
 			}
 			req = &reghttp.Req{
-				Host: r.Registry,
-				APIs: map[string]reghttp.ReqAPI{
-					"": {
-						Method:     "HEAD",
-						Repository: r.Repository,
-						DirectURL:  u,
-					},
-				},
-				NoMirrors: true,
+				Host:       r.Registry,
+				Method:     "HEAD",
+				Repository: r.Repository,
+				DirectURL:  u,
+				NoMirrors:  true,
 			}
 			resp, err = reg.reghttp.Do(ctx, req)
 			if err == nil {
@@ -245,16 +225,12 @@ func (reg *Reg) blobGetUploadURL(ctx context.Context, r ref.Ref, d descriptor.De
 	}
 	// request an upload location
 	req := &reghttp.Req{
-		Host:      r.Registry,
-		NoMirrors: true,
-		APIs: map[string]reghttp.ReqAPI{
-			"": {
-				Method:     "POST",
-				Repository: r.Repository,
-				Path:       "blobs/uploads/",
-				Query:      q,
-			},
-		},
+		Host:       r.Registry,
+		NoMirrors:  true,
+		Method:     "POST",
+		Repository: r.Repository,
+		Path:       "blobs/uploads/",
+		Query:      q,
 	}
 	resp, err := reg.reghttp.Do(ctx, req)
 	if err != nil {
@@ -321,17 +297,13 @@ func (reg *Reg) blobMount(ctx context.Context, rTgt ref.Ref, d descriptor.Descri
 	}
 
 	req := &reghttp.Req{
-		Host:      rTgt.Registry,
-		NoMirrors: true,
-		APIs: map[string]reghttp.ReqAPI{
-			"": {
-				Method:     "POST",
-				Repository: rTgt.Repository,
-				Path:       "blobs/uploads/",
-				Query:      query,
-				IgnoreErr:  ignoreErr,
-			},
-		},
+		Host:       rTgt.Registry,
+		NoMirrors:  true,
+		Method:     "POST",
+		Repository: rTgt.Repository,
+		Path:       "blobs/uploads/",
+		Query:      query,
+		IgnoreErr:  ignoreErr,
 	}
 	resp, err := reg.reghttp.Do(ctx, req)
 	if err != nil {
@@ -424,18 +396,14 @@ func (reg *Reg) blobPutUploadFull(ctx context.Context, r ref.Ref, d descriptor.D
 		"Content-Type": {"application/octet-stream"},
 	}
 	req := &reghttp.Req{
-		Host: r.Registry,
-		APIs: map[string]reghttp.ReqAPI{
-			"": {
-				Method:     "PUT",
-				Repository: r.Repository,
-				DirectURL:  putURL,
-				BodyFunc:   bodyFunc,
-				BodyLen:    d.Size,
-				Headers:    header,
-			},
-		},
-		NoMirrors: true,
+		Host:       r.Registry,
+		Method:     "PUT",
+		Repository: r.Repository,
+		DirectURL:  putURL,
+		BodyFunc:   bodyFunc,
+		BodyLen:    d.Size,
+		Headers:    header,
+		NoMirrors:  true,
 	}
 	resp, err := reg.reghttp.Do(ctx, req)
 	if err != nil {
@@ -524,18 +492,14 @@ func (reg *Reg) blobPutUploadChunked(ctx context.Context, r ref.Ref, d descripto
 				"Content-Range": {fmt.Sprintf("%d-%d", chunkStart, chunkStart+int64(chunkSize)-1)},
 			}
 			req := &reghttp.Req{
-				Host: r.Registry,
-				APIs: map[string]reghttp.ReqAPI{
-					"": {
-						Method:     "PATCH",
-						Repository: r.Repository,
-						DirectURL:  &chunkURL,
-						BodyFunc:   bodyFunc,
-						BodyLen:    int64(chunkSize),
-						Headers:    header,
-					},
-				},
-				NoMirrors: true,
+				Host:       r.Registry,
+				Method:     "PATCH",
+				Repository: r.Repository,
+				DirectURL:  &chunkURL,
+				BodyFunc:   bodyFunc,
+				BodyLen:    int64(chunkSize),
+				Headers:    header,
+				NoMirrors:  true,
 			}
 			resp, err := reg.reghttp.Do(ctx, req)
 			if err != nil && !errors.Is(err, errs.ErrHTTPStatus) && !errors.Is(err, errs.ErrNotFound) {
@@ -620,17 +584,13 @@ func (reg *Reg) blobPutUploadChunked(ctx context.Context, r ref.Ref, d descripto
 		"Content-Type": {"application/octet-stream"},
 	}
 	req := &reghttp.Req{
-		Host: r.Registry,
-		APIs: map[string]reghttp.ReqAPI{
-			"": {
-				Method:     "PUT",
-				Repository: r.Repository,
-				DirectURL:  &chunkURL,
-				BodyLen:    int64(0),
-				Headers:    header,
-			},
-		},
-		NoMirrors: true,
+		Host:       r.Registry,
+		Method:     "PUT",
+		Repository: r.Repository,
+		DirectURL:  &chunkURL,
+		BodyLen:    int64(0),
+		Headers:    header,
+		NoMirrors:  true,
 	}
 	resp, err := reg.reghttp.Do(ctx, req)
 	if err != nil {
@@ -651,15 +611,11 @@ func (reg *Reg) blobUploadCancel(ctx context.Context, r ref.Ref, putURL *url.URL
 		return fmt.Errorf("failed to cancel upload %s: url undefined", r.CommonName())
 	}
 	req := &reghttp.Req{
-		Host:      r.Registry,
-		NoMirrors: true,
-		APIs: map[string]reghttp.ReqAPI{
-			"": {
-				Method:     "DELETE",
-				Repository: r.Repository,
-				DirectURL:  putURL,
-			},
-		},
+		Host:       r.Registry,
+		NoMirrors:  true,
+		Method:     "DELETE",
+		Repository: r.Repository,
+		DirectURL:  putURL,
 	}
 	resp, err := reg.reghttp.Do(ctx, req)
 	if err != nil {
@@ -675,15 +631,11 @@ func (reg *Reg) blobUploadCancel(ctx context.Context, r ref.Ref, putURL *url.URL
 // blobUploadStatus provides a response with headers indicating the progress of an upload
 func (reg *Reg) blobUploadStatus(ctx context.Context, r ref.Ref, putURL *url.URL) (*http.Response, error) {
 	req := &reghttp.Req{
-		Host: r.Registry,
-		APIs: map[string]reghttp.ReqAPI{
-			"": {
-				Method:     "GET",
-				Repository: r.Repository,
-				DirectURL:  putURL,
-			},
-		},
-		NoMirrors: true,
+		Host:       r.Registry,
+		Method:     "GET",
+		Repository: r.Repository,
+		DirectURL:  putURL,
+		NoMirrors:  true,
 	}
 	resp, err := reg.reghttp.Do(ctx, req)
 	if err != nil {

--- a/scheme/reg/manifest.go
+++ b/scheme/reg/manifest.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/regclient/regclient/internal/limitread"
 	"github.com/regclient/regclient/internal/reghttp"
+	"github.com/regclient/regclient/internal/reqmeta"
 	"github.com/regclient/regclient/scheme"
 	"github.com/regclient/regclient/types/errs"
 	"github.com/regclient/regclient/types/manifest"
@@ -57,6 +58,7 @@ func (reg *Reg) ManifestDelete(ctx context.Context, r ref.Ref, opts ...scheme.Ma
 
 	// build/send request
 	req := &reghttp.Req{
+		MetaKind:   reqmeta.Query,
 		Host:       r.Registry,
 		NoMirrors:  true,
 		Method:     "DELETE",
@@ -103,6 +105,7 @@ func (reg *Reg) ManifestGet(ctx context.Context, r ref.Ref) (manifest.Manifest, 
 		},
 	}
 	req := &reghttp.Req{
+		MetaKind:   reqmeta.Manifest,
 		Host:       r.Registry,
 		Method:     "GET",
 		Repository: r.Repository,
@@ -176,6 +179,7 @@ func (reg *Reg) ManifestHead(ctx context.Context, r ref.Ref) (manifest.Manifest,
 		},
 	}
 	req := &reghttp.Req{
+		MetaKind:   reqmeta.Head,
 		Host:       r.Registry,
 		Method:     "HEAD",
 		Repository: r.Repository,
@@ -236,6 +240,7 @@ func (reg *Reg) ManifestPut(ctx context.Context, r ref.Ref, m manifest.Manifest,
 		q.Add(paramManifestDigest, m.GetDescriptor().Digest.String())
 	}
 	req := &reghttp.Req{
+		MetaKind:   reqmeta.Manifest,
 		Host:       r.Registry,
 		NoMirrors:  true,
 		Method:     "PUT",

--- a/scheme/reg/manifest.go
+++ b/scheme/reg/manifest.go
@@ -57,15 +57,11 @@ func (reg *Reg) ManifestDelete(ctx context.Context, r ref.Ref, opts ...scheme.Ma
 
 	// build/send request
 	req := &reghttp.Req{
-		Host:      r.Registry,
-		NoMirrors: true,
-		APIs: map[string]reghttp.ReqAPI{
-			"": {
-				Method:     "DELETE",
-				Repository: r.Repository,
-				Path:       "manifests/" + r.Digest,
-			},
-		},
+		Host:       r.Registry,
+		NoMirrors:  true,
+		Method:     "DELETE",
+		Repository: r.Repository,
+		Path:       "manifests/" + r.Digest,
 	}
 	resp, err := reg.reghttp.Do(ctx, req)
 	if err != nil {
@@ -107,15 +103,11 @@ func (reg *Reg) ManifestGet(ctx context.Context, r ref.Ref) (manifest.Manifest, 
 		},
 	}
 	req := &reghttp.Req{
-		Host: r.Registry,
-		APIs: map[string]reghttp.ReqAPI{
-			"": {
-				Method:     "GET",
-				Repository: r.Repository,
-				Path:       "manifests/" + tagOrDigest,
-				Headers:    headers,
-			},
-		},
+		Host:       r.Registry,
+		Method:     "GET",
+		Repository: r.Repository,
+		Path:       "manifests/" + tagOrDigest,
+		Headers:    headers,
 	}
 	resp, err := reg.reghttp.Do(ctx, req)
 	if err != nil {
@@ -184,15 +176,11 @@ func (reg *Reg) ManifestHead(ctx context.Context, r ref.Ref) (manifest.Manifest,
 		},
 	}
 	req := &reghttp.Req{
-		Host: r.Registry,
-		APIs: map[string]reghttp.ReqAPI{
-			"": {
-				Method:     "HEAD",
-				Repository: r.Repository,
-				Path:       "manifests/" + tagOrDigest,
-				Headers:    headers,
-			},
-		},
+		Host:       r.Registry,
+		Method:     "HEAD",
+		Repository: r.Repository,
+		Path:       "manifests/" + tagOrDigest,
+		Headers:    headers,
 	}
 	resp, err := reg.reghttp.Do(ctx, req)
 	if err != nil {
@@ -248,19 +236,15 @@ func (reg *Reg) ManifestPut(ctx context.Context, r ref.Ref, m manifest.Manifest,
 		q.Add(paramManifestDigest, m.GetDescriptor().Digest.String())
 	}
 	req := &reghttp.Req{
-		Host:      r.Registry,
-		NoMirrors: true,
-		APIs: map[string]reghttp.ReqAPI{
-			"": {
-				Method:     "PUT",
-				Repository: r.Repository,
-				Path:       "manifests/" + tagOrDigest,
-				Query:      q,
-				Headers:    headers,
-				BodyLen:    int64(len(mj)),
-				BodyBytes:  mj,
-			},
-		},
+		Host:       r.Registry,
+		NoMirrors:  true,
+		Method:     "PUT",
+		Repository: r.Repository,
+		Path:       "manifests/" + tagOrDigest,
+		Query:      q,
+		Headers:    headers,
+		BodyLen:    int64(len(mj)),
+		BodyBytes:  mj,
 	}
 	resp, err := reg.reghttp.Do(ctx, req)
 	if err != nil {

--- a/scheme/reg/ping.go
+++ b/scheme/reg/ping.go
@@ -15,12 +15,8 @@ func (reg *Reg) Ping(ctx context.Context, r ref.Ref) (ping.Result, error) {
 	req := &reghttp.Req{
 		Host:      r.Registry,
 		NoMirrors: true,
-		APIs: map[string]reghttp.ReqAPI{
-			"": {
-				Method: "GET",
-				Path:   "",
-			},
-		},
+		Method:    "GET",
+		Path:      "",
 	}
 
 	resp, err := reg.reghttp.Do(ctx, req)

--- a/scheme/reg/ping.go
+++ b/scheme/reg/ping.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/regclient/regclient/internal/reghttp"
+	"github.com/regclient/regclient/internal/reqmeta"
 	"github.com/regclient/regclient/types/ping"
 	"github.com/regclient/regclient/types/ref"
 )
@@ -13,6 +14,7 @@ import (
 func (reg *Reg) Ping(ctx context.Context, r ref.Ref) (ping.Result, error) {
 	ret := ping.Result{}
 	req := &reghttp.Req{
+		MetaKind:  reqmeta.Query,
 		Host:      r.Registry,
 		NoMirrors: true,
 		Method:    "GET",

--- a/scheme/reg/referrer.go
+++ b/scheme/reg/referrer.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/regclient/regclient/internal/httplink"
 	"github.com/regclient/regclient/internal/reghttp"
+	"github.com/regclient/regclient/internal/reqmeta"
 	"github.com/regclient/regclient/scheme"
 	"github.com/regclient/regclient/types/errs"
 	"github.com/regclient/regclient/types/manifest"
@@ -164,6 +165,7 @@ func (reg *Reg) referrerListByAPIPage(ctx context.Context, r ref.Ref, config sch
 		query.Set("artifactType", config.MatchOpt.ArtifactType)
 	}
 	req := &reghttp.Req{
+		MetaKind:   reqmeta.Query,
 		Host:       r.Registry,
 		Method:     "GET",
 		Repository: r.Repository,
@@ -377,6 +379,7 @@ func (reg *Reg) referrerPing(ctx context.Context, r ref.Ref) bool {
 		return referrerEnabled
 	}
 	req := &reghttp.Req{
+		MetaKind:   reqmeta.Query,
 		Host:       r.Registry,
 		Method:     "GET",
 		Repository: r.Repository,

--- a/scheme/reg/referrer.go
+++ b/scheme/reg/referrer.go
@@ -183,24 +183,17 @@ func (reg *Reg) referrerListByAPIPage(ctx context.Context, r ref.Ref, config sch
 		query.Set("artifactType", config.MatchOpt.ArtifactType)
 	}
 	req := &reghttp.Req{
-		Host: r.Registry,
-		APIs: map[string]reghttp.ReqAPI{
-			"": {
-				Method:     "GET",
-				Repository: r.Repository,
-				Path:       "referrers/" + r.Digest,
-				Query:      query,
-				IgnoreErr:  true,
-			},
-		},
+		Host:       r.Registry,
+		Method:     "GET",
+		Repository: r.Repository,
 	}
-	// replace the API if a link is provided
+	if link == nil {
+		req.Path = "referrers/" + r.Digest
+		req.Query = query
+		req.IgnoreErr = true
+	}
 	if link != nil {
-		req.APIs[""] = reghttp.ReqAPI{
-			Method:     "GET",
-			DirectURL:  link,
-			Repository: r.Repository,
-		}
+		req.DirectURL = link
 	}
 	resp, err := reg.reghttp.Do(ctx, req)
 	if err != nil {
@@ -382,14 +375,10 @@ func (reg *Reg) referrerPing(ctx context.Context, r ref.Ref) bool {
 		return referrerEnabled
 	}
 	req := &reghttp.Req{
-		Host: r.Registry,
-		APIs: map[string]reghttp.ReqAPI{
-			"": {
-				Method:     "GET",
-				Repository: r.Repository,
-				Path:       "referrers/" + r.Digest,
-			},
-		},
+		Host:       r.Registry,
+		Method:     "GET",
+		Repository: r.Repository,
+		Path:       "referrers/" + r.Digest,
 	}
 	resp, err := reg.reghttp.Do(ctx, req)
 	if err != nil {

--- a/scheme/reg/reg.go
+++ b/scheme/reg/reg.go
@@ -10,8 +10,9 @@ import (
 
 	"github.com/regclient/regclient/config"
 	"github.com/regclient/regclient/internal/cache"
+	"github.com/regclient/regclient/internal/pqueue"
 	"github.com/regclient/regclient/internal/reghttp"
-	"github.com/regclient/regclient/internal/throttle"
+	"github.com/regclient/regclient/internal/reqmeta"
 	"github.com/regclient/regclient/types/manifest"
 	"github.com/regclient/regclient/types/ref"
 	"github.com/regclient/regclient/types/referrer"
@@ -92,8 +93,8 @@ func New(opts ...Opts) *Reg {
 }
 
 // Throttle is used to limit concurrency
-func (reg *Reg) Throttle(r ref.Ref, put bool) []*throttle.Throttle {
-	tList := []*throttle.Throttle{}
+func (reg *Reg) Throttle(r ref.Ref, put bool) []*pqueue.Queue[reqmeta.Data] {
+	tList := []*pqueue.Queue[reqmeta.Data]{}
 	host := reg.hostGet(r.Registry)
 	t := host.Throttle()
 	if t != nil {

--- a/scheme/reg/repo.go
+++ b/scheme/reg/repo.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/regclient/regclient/internal/reghttp"
+	"github.com/regclient/regclient/internal/reqmeta"
 	"github.com/regclient/regclient/scheme"
 	"github.com/regclient/regclient/types/mediatype"
 	"github.com/regclient/regclient/types/repo"
@@ -36,6 +37,7 @@ func (reg *Reg) RepoList(ctx context.Context, hostname string, opts ...scheme.Re
 		"Accept": []string{"application/json"},
 	}
 	req := &reghttp.Req{
+		MetaKind:  reqmeta.Query,
 		Host:      hostname,
 		NoMirrors: true,
 		Method:    "GET",

--- a/scheme/reg/repo.go
+++ b/scheme/reg/repo.go
@@ -38,15 +38,11 @@ func (reg *Reg) RepoList(ctx context.Context, hostname string, opts ...scheme.Re
 	req := &reghttp.Req{
 		Host:      hostname,
 		NoMirrors: true,
-		APIs: map[string]reghttp.ReqAPI{
-			"": {
-				Method:   "GET",
-				Path:     "_catalog",
-				NoPrefix: true,
-				Query:    query,
-				Headers:  headers,
-			},
-		},
+		Method:    "GET",
+		Path:      "_catalog",
+		NoPrefix:  true,
+		Query:     query,
+		Headers:   headers,
 	}
 	resp, err := reg.reghttp.Do(ctx, req)
 	if err != nil {

--- a/scheme/reg/tag.go
+++ b/scheme/reg/tag.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/regclient/regclient/internal/httplink"
 	"github.com/regclient/regclient/internal/reghttp"
+	"github.com/regclient/regclient/internal/reqmeta"
 	"github.com/regclient/regclient/scheme"
 	"github.com/regclient/regclient/types/descriptor"
 	"github.com/regclient/regclient/types/docker/schema2"
@@ -44,6 +45,7 @@ func (reg *Reg) TagDelete(ctx context.Context, r ref.Ref) error {
 
 	// attempt to delete the tag directly, available in OCI distribution-spec, and Hub API
 	req := &reghttp.Req{
+		MetaKind:   reqmeta.Query,
 		Host:       r.Registry,
 		NoMirrors:  true,
 		Method:     "DELETE",
@@ -256,6 +258,7 @@ func (reg *Reg) tagListOCI(ctx context.Context, r ref.Ref, config scheme.TagConf
 		"Accept": []string{"application/json"},
 	}
 	req := &reghttp.Req{
+		MetaKind:   reqmeta.Query,
 		Host:       r.Registry,
 		Method:     "GET",
 		Repository: r.Repository,
@@ -301,6 +304,7 @@ func (reg *Reg) tagListLink(ctx context.Context, r ref.Ref, _ scheme.TagConfig, 
 		"Accept": []string{"application/json"},
 	}
 	req := &reghttp.Req{
+		MetaKind:   reqmeta.Query,
 		Host:       r.Registry,
 		Method:     "GET",
 		DirectURL:  link,

--- a/scheme/reg/tag.go
+++ b/scheme/reg/tag.go
@@ -44,27 +44,18 @@ func (reg *Reg) TagDelete(ctx context.Context, r ref.Ref) error {
 
 	// attempt to delete the tag directly, available in OCI distribution-spec, and Hub API
 	req := &reghttp.Req{
-		Host:      r.Registry,
-		NoMirrors: true,
-		APIs: map[string]reghttp.ReqAPI{
-			"": {
-				Method:     "DELETE",
-				Repository: r.Repository,
-				Path:       "manifests/" + r.Tag,
-				IgnoreErr:  true, // do not trigger backoffs if this fails
-			},
-			"hub": {
-				Method: "DELETE",
-				Path:   "repositories/" + r.Repository + "/tags/" + r.Tag + "/",
-			},
-		},
+		Host:       r.Registry,
+		NoMirrors:  true,
+		Method:     "DELETE",
+		Repository: r.Repository,
+		Path:       "manifests/" + r.Tag,
+		IgnoreErr:  true, // do not trigger backoffs if this fails
 	}
 
 	resp, err := reg.reghttp.Do(ctx, req)
 	if resp != nil {
 		defer resp.Close()
 	}
-	// TODO: Hub may return a different status
 	if err == nil && resp != nil && resp.HTTPResponse().StatusCode == 202 {
 		return nil
 	}
@@ -265,16 +256,12 @@ func (reg *Reg) tagListOCI(ctx context.Context, r ref.Ref, config scheme.TagConf
 		"Accept": []string{"application/json"},
 	}
 	req := &reghttp.Req{
-		Host: r.Registry,
-		APIs: map[string]reghttp.ReqAPI{
-			"": {
-				Method:     "GET",
-				Repository: r.Repository,
-				Path:       "tags/list",
-				Query:      query,
-				Headers:    headers,
-			},
-		},
+		Host:       r.Registry,
+		Method:     "GET",
+		Repository: r.Repository,
+		Path:       "tags/list",
+		Query:      query,
+		Headers:    headers,
 	}
 	resp, err := reg.reghttp.Do(ctx, req)
 	if err != nil {
@@ -314,15 +301,11 @@ func (reg *Reg) tagListLink(ctx context.Context, r ref.Ref, _ scheme.TagConfig, 
 		"Accept": []string{"application/json"},
 	}
 	req := &reghttp.Req{
-		Host: r.Registry,
-		APIs: map[string]reghttp.ReqAPI{
-			"": {
-				Method:     "GET",
-				DirectURL:  link,
-				Repository: r.Repository,
-				Headers:    headers,
-			},
-		},
+		Host:       r.Registry,
+		Method:     "GET",
+		DirectURL:  link,
+		Repository: r.Repository,
+		Headers:    headers,
 	}
 	resp, err := reg.reghttp.Do(ctx, req)
 	if err != nil {

--- a/scheme/scheme.go
+++ b/scheme/scheme.go
@@ -5,7 +5,8 @@ import (
 	"context"
 	"io"
 
-	"github.com/regclient/regclient/internal/throttle"
+	"github.com/regclient/regclient/internal/pqueue"
+	"github.com/regclient/regclient/internal/reqmeta"
 	"github.com/regclient/regclient/types/blob"
 	"github.com/regclient/regclient/types/descriptor"
 	"github.com/regclient/regclient/types/manifest"
@@ -65,7 +66,7 @@ type GCLocker interface {
 
 // Throttler is used to indicate the scheme implements Throttle.
 type Throttler interface {
-	Throttle(r ref.Ref, put bool) []*throttle.Throttle
+	Throttle(r ref.Ref, put bool) []*pqueue.Queue[reqmeta.Data]
 }
 
 // ManifestConfig is used by schemes to import [ManifestOpts].


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Copying images has a delayed start and regclient throttles itself even on a local network.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This is a significant refactor of the networking stack to remove the default rate limit and reorder the copy of layers to speed up the start of the copy and prioritize the copy of large layers to reduce the typical time to copy an image.

- Update scheme to use pqueue instead of throttle. This is a breaking change but library users are unlikely to encounter issues with the scheme change since both throttle and pqueue are internal packages, so it shouldn't be possible to call their methods directly or specify their types in variables.
- Remove multiple API support. This removes an undocumented API for deleting images from Hub. Users that depend on that functionality should consider a Docker Hub alternative like hub-tool.
- Remove digest calculation from `reghttp`. This is being done directly by blob and manifest types.
- Remove `reghttp.Resp` interface. Replace it with a pointer to a struct with private values.
- Remove `time.Ticker` for rate limiting. `time.Ticker` leaks goroutines. A simple time for the next request is good enough.
- Cleanup `reghttp.Resp` methods:
  - Do not export `next` method.
  - Document exported methods.
  - Arbitrary seek is allowed since digest is not calculated here.
- Configure priority queue algorithm and reorder image copy steps:
  - Priority queue algorithm prefers a small entry (non-blob API), and 50/50 split of largest and oldest queued entries.
  - Image reorder starts the blob copies sooner to avoid blocking on the tag listing for referrers or digest tags.
  - `pqueue.AcquireMulti` releases queues in reverse order to minimize risk of an acquire blocked by a soon to release queue.
  - Include type and size in the request for priority queue.
  - Use expected request size to validate response.
- Move logging into transport and rework backoff:
  - Logging in transport allows better debugging of each request, including redirects.
  - Backoff redesign better handles failed requests and slows down all requests.
- Remove default rate limit.

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

The copy command should start faster and copy large blobs earlier in the process to maximize concurrency:

```shell
regctl image copy $src $tgt
```

<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Feat: Significant refactor of http APIs to speed up image copies.
- Feat: Add a priority queue for network requests.
- Breaking: Update scheme to use pqueue instead of throttle.
- Breaking: Removes an undocumented API for deleting images from Hub.
- Refactor: Remove digest calculation from reghttp.
- Feat: Add priority queue algorithm and reorder image copy steps.
- Feat: Move logging into transport and rework backoff.
- Feat: Remove default rate limit.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
