### PR TITLE
Chore: Update staticcheck and fix linter warnings for Go 1.23

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ ifneq "$(SYFT_CMD_VER)" "$(SYFT_VERSION)"
 		-u "$(shell id -u):$(shell id -g)" \
 		$(SYFT_CONTAINER)
 endif
-STATICCHECK_VER?=v0.4.7
+STATICCHECK_VER?=v0.5.0
 CI_DISTRIBUTION_VER?=2.8.3
 CI_ZOT_VER?=v2.1.0
 

--- a/cmd/regsync/root.go
+++ b/cmd/regsync/root.go
@@ -826,7 +826,7 @@ func (rootOpts *rootCmd) processRef(ctx context.Context, s ConfigSync, src, tgt 
 		opts = append(opts, regclient.ImageWithDigestTags())
 	}
 	if s.Referrers != nil && *s.Referrers {
-		if s.ReferrerFilters == nil || len(s.ReferrerFilters) == 0 {
+		if len(s.ReferrerFilters) == 0 {
 			opts = append(opts, regclient.ImageWithReferrers())
 		} else {
 			for _, filter := range s.ReferrerFilters {

--- a/mod/layer.go
+++ b/mod/layer.go
@@ -349,7 +349,7 @@ func WithLayerRmCreatedBy(re regexp.Regexp) Opts {
 			if dm.m.IsList() || dm.config.oc == nil {
 				return nil
 			}
-			if dm.layers == nil || len(dm.layers) == 0 {
+			if len(dm.layers) == 0 {
 				return fmt.Errorf("no layers found")
 			}
 			delLayers := []int{}
@@ -399,7 +399,7 @@ func WithLayerRmIndex(index int) Opts {
 			if !dm.top || dm.m.IsList() || dm.config.oc == nil {
 				return fmt.Errorf("remove layer by index requires v2 image manifest")
 			}
-			if dm.layers == nil || len(dm.layers) == 0 {
+			if len(dm.layers) == 0 {
 				return fmt.Errorf("no layers found")
 			}
 			curLayer := 0

--- a/types/descriptor/descriptor.go
+++ b/types/descriptor/descriptor.go
@@ -225,7 +225,7 @@ func (d Descriptor) Match(opt MatchOpt) bool {
 	if opt.ArtifactType != "" && d.ArtifactType != opt.ArtifactType {
 		return false
 	}
-	if opt.Annotations != nil && len(opt.Annotations) > 0 {
+	if len(opt.Annotations) > 0 {
 		if d.Annotations == nil {
 			return false
 		}

--- a/types/manifest/docker2.go
+++ b/types/manifest/docker2.go
@@ -165,7 +165,7 @@ func (m *docker2Manifest) MarshalPretty() ([]byte, error) {
 	}
 	fmt.Fprintf(tw, "MediaType:\t%s\n", m.desc.MediaType)
 	fmt.Fprintf(tw, "Digest:\t%s\n", m.desc.Digest.String())
-	if m.Annotations != nil && len(m.Annotations) > 0 {
+	if len(m.Annotations) > 0 {
 		fmt.Fprintf(tw, "Annotations:\t\n")
 		keys := make([]string, 0, len(m.Annotations))
 		for k := range m.Annotations {
@@ -211,7 +211,7 @@ func (m *docker2ManifestList) MarshalPretty() ([]byte, error) {
 	}
 	fmt.Fprintf(tw, "MediaType:\t%s\n", m.desc.MediaType)
 	fmt.Fprintf(tw, "Digest:\t%s\n", m.desc.Digest.String())
-	if m.Annotations != nil && len(m.Annotations) > 0 {
+	if len(m.Annotations) > 0 {
 		fmt.Fprintf(tw, "Annotations:\t\n")
 		keys := make([]string, 0, len(m.Annotations))
 		for k := range m.Annotations {

--- a/types/manifest/oci1.go
+++ b/types/manifest/oci1.go
@@ -226,7 +226,7 @@ func (m *oci1Manifest) MarshalPretty() ([]byte, error) {
 		fmt.Fprintf(tw, "ArtifactType:\t%s\n", m.ArtifactType)
 	}
 	fmt.Fprintf(tw, "Digest:\t%s\n", m.desc.Digest.String())
-	if m.Annotations != nil && len(m.Annotations) > 0 {
+	if len(m.Annotations) > 0 {
 		fmt.Fprintf(tw, "Annotations:\t\n")
 		keys := make([]string, 0, len(m.Annotations))
 		for k := range m.Annotations {
@@ -283,7 +283,7 @@ func (m *oci1Index) MarshalPretty() ([]byte, error) {
 		fmt.Fprintf(tw, "ArtifactType:\t%s\n", m.ArtifactType)
 	}
 	fmt.Fprintf(tw, "Digest:\t%s\n", m.desc.Digest.String())
-	if m.Annotations != nil && len(m.Annotations) > 0 {
+	if len(m.Annotations) > 0 {
 		fmt.Fprintf(tw, "Annotations:\t\n")
 		keys := make([]string, 0, len(m.Annotations))
 		for k := range m.Annotations {
@@ -332,7 +332,7 @@ func (m *oci1Artifact) MarshalPretty() ([]byte, error) {
 	fmt.Fprintf(tw, "MediaType:\t%s\n", m.desc.MediaType)
 	fmt.Fprintf(tw, "ArtifactType:\t%s\n", m.ArtifactType)
 	fmt.Fprintf(tw, "Digest:\t%s\n", m.desc.Digest.String())
-	if m.Annotations != nil && len(m.Annotations) > 0 {
+	if len(m.Annotations) > 0 {
 		fmt.Fprintf(tw, "Annotations:\t\n")
 		keys := make([]string, 0, len(m.Annotations))
 		for k := range m.Annotations {

--- a/types/referrer/referrer.go
+++ b/types/referrer/referrer.go
@@ -128,7 +128,7 @@ func (rl ReferrerList) MarshalPretty() ([]byte, error) {
 			return []byte{}, err
 		}
 	}
-	if rl.Annotations != nil && len(rl.Annotations) > 0 {
+	if len(rl.Annotations) > 0 {
 		fmt.Fprintf(tw, "Annotations:\t\n")
 		keys := make([]string, 0, len(rl.Annotations))
 		for k := range rl.Annotations {


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Upgrading to Go 1.23.0 in development causes the build to fail because of staticcheck failures. This upgrades staticcheck to support 1.23 and then cleans up the new linter warnings.

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Chore: Update staticcheck and fix linter warnings for Go 1.23.
- 
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
