### PR TITLE
Fix: Support auth on redirect

### DIFF
--- a/scheme/reg/reg.go
+++ b/scheme/reg/reg.go
@@ -84,7 +84,7 @@ func New(opts ...Opts) *Reg {
 		hosts:           map[string]*config.Host{},
 		features:        map[featureKey]*featureVal{},
 	}
-	r.reghttpOpts = append(r.reghttpOpts, reghttp.WithConfigHost(r.hostGet))
+	r.reghttpOpts = append(r.reghttpOpts, reghttp.WithConfigHostFn(r.hostGet))
 	for _, opt := range opts {
 		opt(&r)
 	}


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Unable to access registries that require a login or anonymous token from behind a redirect.

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

A registry server that is just a redirect to a real server that requires auth will now work. Previously, auth was only sent to the first server, now it is only sent to the server that performed the auth. The auth package itself was also refactored a bit, removing unneeded interfaces and reducing exported fields.

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
regctl tag ls nabo.codimd.dev/hackmdio/hackmd
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Fix: Support auth on redirect.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
