### PR TITLE
Chore: Remove ReqPerSec in tests

### DIFF
--- a/blob_test.go
+++ b/blob_test.go
@@ -160,10 +160,9 @@ func TestBlobGet(t *testing.T) {
 	tsHost := tsURL.Host
 	rcHosts := []config.Host{
 		{
-			Name:      tsHost,
-			Hostname:  tsHost,
-			TLS:       config.TLSDisabled,
-			ReqPerSec: 100,
+			Name:     tsHost,
+			Hostname: tsHost,
+			TLS:      config.TLSDisabled,
 		},
 	}
 	log := &logrus.Logger{
@@ -649,7 +648,6 @@ func TestBlobPut(t *testing.T) {
 			TLS:       config.TLSDisabled,
 			BlobChunk: int64(blobChunk),
 			BlobMax:   int64(-1),
-			ReqPerSec: 100,
 		},
 	}
 	log := &logrus.Logger{
@@ -1135,7 +1133,6 @@ func TestBlobCopy(t *testing.T) {
 			TLS:       config.TLSDisabled,
 			BlobChunk: int64(blobChunk),
 			BlobMax:   int64(-1),
-			ReqPerSec: 100,
 		},
 	}
 	log := &logrus.Logger{

--- a/cmd/regbot/regbot_test.go
+++ b/cmd/regbot/regbot_test.go
@@ -41,16 +41,14 @@ func TestRegbot(t *testing.T) {
 	})
 	rcHosts := []config.Host{
 		{
-			Name:      tsHost,
-			Hostname:  tsHost,
-			TLS:       config.TLSDisabled,
-			ReqPerSec: 1000,
+			Name:     tsHost,
+			Hostname: tsHost,
+			TLS:      config.TLSDisabled,
 		},
 		{
-			Name:      "registry.example.org",
-			Hostname:  tsHost,
-			TLS:       config.TLSDisabled,
-			ReqPerSec: 1000,
+			Name:     "registry.example.org",
+			Hostname: tsHost,
+			TLS:      config.TLSDisabled,
 		},
 	}
 	delayInit, _ := time.ParseDuration("0.05s")

--- a/cmd/regsync/regsync_test.go
+++ b/cmd/regsync/regsync_test.go
@@ -52,16 +52,14 @@ func TestProcess(t *testing.T) {
 	})
 	rcHosts := []config.Host{
 		{
-			Name:      tsHost,
-			Hostname:  tsHost,
-			TLS:       config.TLSDisabled,
-			ReqPerSec: 1000,
+			Name:     tsHost,
+			Hostname: tsHost,
+			TLS:      config.TLSDisabled,
 		},
 		{
-			Name:      "registry.example.org",
-			Hostname:  tsHost,
-			TLS:       config.TLSDisabled,
-			ReqPerSec: 1000,
+			Name:     "registry.example.org",
+			Hostname: tsHost,
+			TLS:      config.TLSDisabled,
 		},
 	}
 	delayInit, _ := time.ParseDuration("0.05s")

--- a/image_test.go
+++ b/image_test.go
@@ -41,16 +41,14 @@ func TestImageCheckBase(t *testing.T) {
 	})
 	rcHosts := []config.Host{
 		{
-			Name:      tsHost,
-			Hostname:  tsHost,
-			TLS:       config.TLSDisabled,
-			ReqPerSec: 1000,
+			Name:     tsHost,
+			Hostname: tsHost,
+			TLS:      config.TLSDisabled,
 		},
 		{
-			Name:      "registry.example.org",
-			Hostname:  tsHost,
-			TLS:       config.TLSDisabled,
-			ReqPerSec: 1000,
+			Name:     "registry.example.org",
+			Hostname: tsHost,
+			TLS:      config.TLSDisabled,
 		},
 	}
 	log := &logrus.Logger{
@@ -182,10 +180,9 @@ func TestImageConfig(t *testing.T) {
 	tsHost := tsURL.Host
 	rcHosts := []config.Host{
 		{
-			Name:      tsHost,
-			Hostname:  tsHost,
-			TLS:       config.TLSDisabled,
-			ReqPerSec: 1000,
+			Name:     tsHost,
+			Hostname: tsHost,
+			TLS:      config.TLSDisabled,
 		},
 	}
 	log := &logrus.Logger{
@@ -293,16 +290,14 @@ func TestCopy(t *testing.T) {
 	tsROHost := tsROURL.Host
 	rcHosts := []config.Host{
 		{
-			Name:      tsHost,
-			Hostname:  tsHost,
-			TLS:       config.TLSDisabled,
-			ReqPerSec: 1000,
+			Name:     tsHost,
+			Hostname: tsHost,
+			TLS:      config.TLSDisabled,
 		},
 		{
-			Name:      tsROHost,
-			Hostname:  tsROHost,
-			TLS:       config.TLSDisabled,
-			ReqPerSec: 1000,
+			Name:     tsROHost,
+			Hostname: tsROHost,
+			TLS:      config.TLSDisabled,
 		},
 	}
 	log := &logrus.Logger{

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -182,22 +182,19 @@ func TestManifest(t *testing.T) {
 	tsInternalHost := tsInternalURL.Host
 	rcHosts := []config.Host{
 		{
-			Name:      tsOlaregHost,
-			Hostname:  tsOlaregHost,
-			TLS:       config.TLSDisabled,
-			ReqPerSec: 100,
+			Name:     tsOlaregHost,
+			Hostname: tsOlaregHost,
+			TLS:      config.TLSDisabled,
 		},
 		{
-			Name:      "missing." + tsOlaregHost,
-			Hostname:  tsOlaregHost,
-			TLS:       config.TLSDisabled,
-			ReqPerSec: 100,
+			Name:     "missing." + tsOlaregHost,
+			Hostname: tsOlaregHost,
+			TLS:      config.TLSDisabled,
 		},
 		{
-			Name:      tsInternalHost,
-			Hostname:  tsInternalHost,
-			TLS:       config.TLSDisabled,
-			ReqPerSec: 100,
+			Name:     tsInternalHost,
+			Hostname: tsInternalHost,
+			TLS:      config.TLSDisabled,
 		},
 		{
 			Name:     "nohead." + tsInternalHost,
@@ -206,7 +203,6 @@ func TestManifest(t *testing.T) {
 			APIOpts: map[string]string{
 				"disableHead": "true",
 			},
-			ReqPerSec: 100,
 		},
 	}
 	log := &logrus.Logger{

--- a/mod/mod_test.go
+++ b/mod/mod_test.go
@@ -84,22 +84,19 @@ func TestMod(t *testing.T) {
 	// create regclient
 	rcHosts := []config.Host{
 		{
-			Name:      tSrcHost,
-			Hostname:  tSrcHost,
-			TLS:       config.TLSDisabled,
-			ReqPerSec: 1000,
+			Name:     tSrcHost,
+			Hostname: tSrcHost,
+			TLS:      config.TLSDisabled,
 		},
 		{
-			Name:      tTgtHost,
-			Hostname:  tTgtHost,
-			TLS:       config.TLSDisabled,
-			ReqPerSec: 1000,
+			Name:     tTgtHost,
+			Hostname: tTgtHost,
+			TLS:      config.TLSDisabled,
 		},
 		{
-			Name:      "registry.example.org",
-			Hostname:  tSrcHost,
-			TLS:       config.TLSDisabled,
-			ReqPerSec: 1000,
+			Name:     "registry.example.org",
+			Hostname: tSrcHost,
+			TLS:      config.TLSDisabled,
 		},
 	}
 	delayInit, _ := time.ParseDuration("0.05s")

--- a/tag_test.go
+++ b/tag_test.go
@@ -56,16 +56,14 @@ func TestTag(t *testing.T) {
 	})
 	rcHosts := []config.Host{
 		{
-			Name:      tsRWHost,
-			Hostname:  tsRWHost,
-			TLS:       config.TLSDisabled,
-			ReqPerSec: 1000,
+			Name:     tsRWHost,
+			Hostname: tsRWHost,
+			TLS:      config.TLSDisabled,
 		},
 		{
-			Name:      tsROHost,
-			Hostname:  tsROHost,
-			TLS:       config.TLSDisabled,
-			ReqPerSec: 1000,
+			Name:     tsROHost,
+			Hostname: tsROHost,
+			TLS:      config.TLSDisabled,
 		},
 	}
 	log := &logrus.Logger{


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

With the default requests per second setting removed, this override is no longer needed to speed up tests.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
make test
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text
- Chore: Remove `ReqPerSec` in tests.

<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
