### PR TITLE
Feat: Consolidate warnings

### DIFF
--- a/blob.go
+++ b/blob.go
@@ -18,6 +18,7 @@ import (
 	"github.com/regclient/regclient/types/descriptor"
 	"github.com/regclient/regclient/types/errs"
 	"github.com/regclient/regclient/types/ref"
+	"github.com/regclient/regclient/types/warning"
 )
 
 const blobCBFreq = time.Millisecond * 100
@@ -49,6 +50,10 @@ func (rc *RegClient) BlobCopy(ctx context.Context, refSrc ref.Ref, refTgt ref.Re
 	var opt blobOpt
 	for _, optFn := range opts {
 		optFn(&opt)
+	}
+	// dedup warnings
+	if w := warning.FromContext(ctx); w == nil {
+		ctx = warning.NewContext(ctx, &warning.Warning{Hook: warning.DefaultHook()})
 	}
 	tDesc := d
 	tDesc.URLs = []string{} // ignore URLs when pushing to target

--- a/cmd/regctl/artifact.go
+++ b/cmd/regctl/artifact.go
@@ -30,6 +30,7 @@ import (
 	"github.com/regclient/regclient/types/platform"
 	"github.com/regclient/regclient/types/ref"
 	"github.com/regclient/regclient/types/referrer"
+	"github.com/regclient/regclient/types/warning"
 )
 
 const (
@@ -268,6 +269,10 @@ func (artifactOpts *artifactCmd) runArtifactGet(cmd *cobra.Command, args []strin
 		if !fi.IsDir() {
 			return fmt.Errorf("output must be a directory: \"%s\"", artifactOpts.outputDir)
 		}
+	}
+	// dedup warnings
+	if w := warning.FromContext(ctx); w == nil {
+		ctx = warning.NewContext(ctx, &warning.Warning{Hook: warning.DefaultHook()})
 	}
 
 	r := ref.Ref{}
@@ -545,6 +550,10 @@ func (artifactOpts *artifactCmd) runArtifactList(cmd *cobra.Command, args []stri
 	if artifactOpts.latest && artifactOpts.sortAnnot != "" {
 		return fmt.Errorf("--latest cannot be used with --sort-annotation")
 	}
+	// dedup warnings
+	if w := warning.FromContext(ctx); w == nil {
+		ctx = warning.NewContext(ctx, &warning.Warning{Hook: warning.DefaultHook()})
+	}
 
 	rc := artifactOpts.rootOpts.newRegClient()
 	defer rc.Close(ctx, rSubject)
@@ -641,6 +650,11 @@ func (artifactOpts *artifactCmd) runArtifactPut(cmd *cobra.Command, args []strin
 		hasConfig = true
 	default:
 		return fmt.Errorf("unsupported manifest media type: %s%.0w", artifactOpts.artifactMT, errs.ErrUnsupportedMediaType)
+	}
+
+	// dedup warnings
+	if w := warning.FromContext(ctx); w == nil {
+		ctx = warning.NewContext(ctx, &warning.Warning{Hook: warning.DefaultHook()})
 	}
 
 	// validate inputs
@@ -1003,6 +1017,10 @@ func (artifactOpts *artifactCmd) runArtifactTree(cmd *cobra.Command, args []stri
 	rc := artifactOpts.rootOpts.newRegClient()
 	defer rc.Close(ctx, r)
 
+	// dedup warnings
+	if w := warning.FromContext(ctx); w == nil {
+		ctx = warning.NewContext(ctx, &warning.Warning{Hook: warning.DefaultHook()})
+	}
 	referrerOpts := []scheme.ReferrerOpts{}
 	if artifactOpts.filterAT != "" {
 		referrerOpts = append(referrerOpts, scheme.WithReferrerMatchOpt(descriptor.MatchOpt{ArtifactType: artifactOpts.filterAT}))

--- a/cmd/regctl/blob.go
+++ b/cmd/regctl/blob.go
@@ -22,6 +22,7 @@ import (
 	"github.com/regclient/regclient/pkg/template"
 	"github.com/regclient/regclient/types/descriptor"
 	"github.com/regclient/regclient/types/ref"
+	"github.com/regclient/regclient/types/warning"
 )
 
 type blobCmd struct {
@@ -236,6 +237,10 @@ func (blobOpts *blobCmd) runBlobDiffConfig(cmd *cobra.Command, args []string) er
 		diffOpts = append(diffOpts, diff.WithFullContext())
 	}
 	ctx := cmd.Context()
+	// dedup warnings
+	if w := warning.FromContext(ctx); w == nil {
+		ctx = warning.NewContext(ctx, &warning.Warning{Hook: warning.DefaultHook()})
+	}
 	r1, err := ref.New(args[0])
 	if err != nil {
 		return err
@@ -290,6 +295,10 @@ func (blobOpts *blobCmd) runBlobDiffLayer(cmd *cobra.Command, args []string) err
 		diffOpts = append(diffOpts, diff.WithFullContext())
 	}
 	ctx := cmd.Context()
+	// dedup warnings
+	if w := warning.FromContext(ctx); w == nil {
+		ctx = warning.NewContext(ctx, &warning.Warning{Hook: warning.DefaultHook()})
+	}
 	r1, err := ref.New(args[0])
 	if err != nil {
 		return err

--- a/cmd/regctl/image.go
+++ b/cmd/regctl/image.go
@@ -37,6 +37,7 @@ import (
 	v1 "github.com/regclient/regclient/types/oci/v1"
 	"github.com/regclient/regclient/types/platform"
 	"github.com/regclient/regclient/types/ref"
+	"github.com/regclient/regclient/types/warning"
 )
 
 type imageCmd struct {
@@ -1385,6 +1386,10 @@ func (imageOpts *imageCmd) runImageCreate(cmd *cobra.Command, args []string) err
 
 func (imageOpts *imageCmd) runImageExport(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
+	// dedup warnings
+	if w := warning.FromContext(ctx); w == nil {
+		ctx = warning.NewContext(ctx, &warning.Warning{Hook: warning.DefaultHook()})
+	}
 	r, err := ref.New(args[0])
 	if err != nil {
 		return err
@@ -1430,6 +1435,10 @@ func (imageOpts *imageCmd) runImageExport(cmd *cobra.Command, args []string) err
 
 func (imageOpts *imageCmd) runImageGetFile(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
+	// dedup warnings
+	if w := warning.FromContext(ctx); w == nil {
+		ctx = warning.NewContext(ctx, &warning.Warning{Hook: warning.DefaultHook()})
+	}
 	r, err := ref.New(args[0])
 	if err != nil {
 		return err

--- a/cmd/regctl/index.go
+++ b/cmd/regctl/index.go
@@ -18,6 +18,7 @@ import (
 	v1 "github.com/regclient/regclient/types/oci/v1"
 	"github.com/regclient/regclient/types/platform"
 	"github.com/regclient/regclient/types/ref"
+	"github.com/regclient/regclient/types/warning"
 )
 
 var indexKnownTypes = []string{
@@ -143,6 +144,10 @@ regctl index delete registry.example.org/repo:v1 \
 
 func (indexOpts *indexCmd) runIndexAdd(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
+	// dedup warnings
+	if w := warning.FromContext(ctx); w == nil {
+		ctx = warning.NewContext(ctx, &warning.Warning{Hook: warning.DefaultHook()})
+	}
 
 	// parse ref
 	r, err := ref.New(args[0])
@@ -205,6 +210,10 @@ func (indexOpts *indexCmd) runIndexAdd(cmd *cobra.Command, args []string) error 
 
 func (indexOpts *indexCmd) runIndexCreate(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
+	// dedup warnings
+	if w := warning.FromContext(ctx); w == nil {
+		ctx = warning.NewContext(ctx, &warning.Warning{Hook: warning.DefaultHook()})
+	}
 
 	// validate media type
 	if indexOpts.mediaType != mediatype.OCI1ManifestList && indexOpts.mediaType != mediatype.Docker2ManifestList {
@@ -311,6 +320,10 @@ func (indexOpts *indexCmd) runIndexCreate(cmd *cobra.Command, args []string) err
 
 func (indexOpts *indexCmd) runIndexDelete(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
+	// dedup warnings
+	if w := warning.FromContext(ctx); w == nil {
+		ctx = warning.NewContext(ctx, &warning.Warning{Hook: warning.DefaultHook()})
+	}
 
 	// parse ref
 	r, err := ref.New(args[0])

--- a/cmd/regctl/manifest.go
+++ b/cmd/regctl/manifest.go
@@ -16,6 +16,7 @@ import (
 	"github.com/regclient/regclient/types/manifest"
 	"github.com/regclient/regclient/types/platform"
 	"github.com/regclient/regclient/types/ref"
+	"github.com/regclient/regclient/types/warning"
 )
 
 type manifestCmd struct {
@@ -177,6 +178,10 @@ regctl manifest put \
 
 func (manifestOpts *manifestCmd) runManifestDelete(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
+	// dedup warnings
+	if w := warning.FromContext(ctx); w == nil {
+		ctx = warning.NewContext(ctx, &warning.Warning{Hook: warning.DefaultHook()})
+	}
 	r, err := ref.New(args[0])
 	if err != nil {
 		return err
@@ -222,6 +227,10 @@ func (manifestOpts *manifestCmd) runManifestDiff(cmd *cobra.Command, args []stri
 		diffOpts = append(diffOpts, diff.WithFullContext())
 	}
 	ctx := cmd.Context()
+	// dedup warnings
+	if w := warning.FromContext(ctx); w == nil {
+		ctx = warning.NewContext(ctx, &warning.Warning{Hook: warning.DefaultHook()})
+	}
 	r1, err := ref.New(args[0])
 	if err != nil {
 		return err

--- a/image.go
+++ b/image.go
@@ -235,6 +235,10 @@ func (rc *RegClient) ImageCheckBase(ctx context.Context, r ref.Ref, opts ...Imag
 	var m manifest.Manifest
 	var err error
 
+	// dedup warnings
+	if w := warning.FromContext(ctx); w == nil {
+		ctx = warning.NewContext(ctx, &warning.Warning{Hook: warning.DefaultHook()})
+	}
 	// if the base name is not provided, check image for base annotations
 	if opt.checkBaseRef == "" {
 		m, err = rc.ManifestGet(ctx, r)
@@ -445,6 +449,10 @@ func (rc *RegClient) ImageConfig(ctx context.Context, r ref.Ref, opts ...ImageOp
 	}
 	for _, optFn := range opts {
 		optFn(&opt)
+	}
+	// dedup warnings
+	if w := warning.FromContext(ctx); w == nil {
+		ctx = warning.NewContext(ctx, &warning.Warning{Hook: warning.DefaultHook()})
 	}
 	p, err := platform.Parse(opt.platform)
 	if err != nil {
@@ -1037,6 +1045,10 @@ func (rc *RegClient) ImageExport(ctx context.Context, r ref.Ref, outStream io.Wr
 		opt.exportRef = r
 	}
 
+	// dedup warnings
+	if w := warning.FromContext(ctx); w == nil {
+		ctx = warning.NewContext(ctx, &warning.Warning{Hook: warning.DefaultHook()})
+	}
 	// create tar writer object
 	out := outStream
 	if opt.exportCompress {
@@ -1270,6 +1282,10 @@ func (rc *RegClient) ImageImport(ctx context.Context, r ref.Ref, rs io.ReadSeeke
 		optFn(&opt)
 	}
 
+	// dedup warnings
+	if w := warning.FromContext(ctx); w == nil {
+		ctx = warning.NewContext(ctx, &warning.Warning{Hook: warning.DefaultHook()})
+	}
 	trd := &tarReadData{
 		name:      opt.importName,
 		handlers:  map[string]tarFileHandler{},

--- a/manifest.go
+++ b/manifest.go
@@ -10,6 +10,7 @@ import (
 	"github.com/regclient/regclient/types/manifest"
 	"github.com/regclient/regclient/types/platform"
 	"github.com/regclient/regclient/types/ref"
+	"github.com/regclient/regclient/types/warning"
 )
 
 type manifestOpt struct {
@@ -107,6 +108,10 @@ func (rc *RegClient) ManifestGet(ctx context.Context, r ref.Ref, opts ...Manifes
 			)
 		}
 	}
+	// dedup warnings
+	if w := warning.FromContext(ctx); w == nil {
+		ctx = warning.NewContext(ctx, &warning.Warning{Hook: warning.DefaultHook()})
+	}
 	schemeAPI, err := rc.schemeGet(r.Scheme)
 	if err != nil {
 		return nil, err
@@ -141,6 +146,10 @@ func (rc *RegClient) ManifestHead(ctx context.Context, r ref.Ref, opts ...Manife
 	opt := manifestOpt{schemeOpts: []scheme.ManifestOpts{}}
 	for _, fn := range opts {
 		fn(&opt)
+	}
+	// dedup warnings
+	if w := warning.FromContext(ctx); w == nil {
+		ctx = warning.NewContext(ctx, &warning.Warning{Hook: warning.DefaultHook()})
 	}
 	schemeAPI, err := rc.schemeGet(r.Scheme)
 	if err != nil {

--- a/scheme/reg/blob.go
+++ b/scheme/reg/blob.go
@@ -24,6 +24,7 @@ import (
 	"github.com/regclient/regclient/types/descriptor"
 	"github.com/regclient/regclient/types/errs"
 	"github.com/regclient/regclient/types/ref"
+	"github.com/regclient/regclient/types/warning"
 )
 
 var (
@@ -170,6 +171,10 @@ func (reg *Reg) BlobPut(ctx context.Context, r ref.Ref, d descriptor.Descriptor,
 	var putURL *url.URL
 	var err error
 	validDesc := (d.Size > 0 && d.Digest.Validate() == nil) || (d.Size == 0 && d.Digest == zeroDig)
+	// dedup warnings
+	if w := warning.FromContext(ctx); w == nil {
+		ctx = warning.NewContext(ctx, &warning.Warning{Hook: warning.DefaultHook()})
+	}
 
 	// attempt an anonymous blob mount
 	if validDesc {

--- a/scheme/reg/referrer.go
+++ b/scheme/reg/referrer.go
@@ -18,6 +18,7 @@ import (
 	"github.com/regclient/regclient/types/platform"
 	"github.com/regclient/regclient/types/ref"
 	"github.com/regclient/regclient/types/referrer"
+	"github.com/regclient/regclient/types/warning"
 )
 
 const OCISubjectHeader = "OCI-Subject"
@@ -30,6 +31,10 @@ func (reg *Reg) ReferrerList(ctx context.Context, r ref.Ref, opts ...scheme.Refe
 	}
 	rl := referrer.ReferrerList{
 		Tags: []string{},
+	}
+	// dedup warnings
+	if w := warning.FromContext(ctx); w == nil {
+		ctx = warning.NewContext(ctx, &warning.Warning{Hook: warning.DefaultHook()})
 	}
 	// select a platform from a manifest list
 	if config.Platform != "" {
@@ -271,6 +276,10 @@ func (reg *Reg) referrerListByTag(ctx context.Context, r ref.Ref) (referrer.Refe
 
 // referrerDelete deletes a referrer associated with a manifest
 func (reg *Reg) referrerDelete(ctx context.Context, r ref.Ref, m manifest.Manifest) error {
+	// dedup warnings
+	if w := warning.FromContext(ctx); w == nil {
+		ctx = warning.NewContext(ctx, &warning.Warning{Hook: warning.DefaultHook()})
+	}
 	// get subject field
 	mSubject, ok := m.(manifest.Subjecter)
 	if !ok {
@@ -320,6 +329,10 @@ func (reg *Reg) referrerDelete(ctx context.Context, r ref.Ref, m manifest.Manife
 
 // referrerPut pushes a new referrer associated with a manifest
 func (reg *Reg) referrerPut(ctx context.Context, r ref.Ref, m manifest.Manifest) error {
+	// dedup warnings
+	if w := warning.FromContext(ctx); w == nil {
+		ctx = warning.NewContext(ctx, &warning.Warning{Hook: warning.DefaultHook()})
+	}
 	// get subject field
 	mSubject, ok := m.(manifest.Subjecter)
 	if !ok {

--- a/scheme/reg/tag.go
+++ b/scheme/reg/tag.go
@@ -32,6 +32,7 @@ import (
 	"github.com/regclient/regclient/types/platform"
 	"github.com/regclient/regclient/types/ref"
 	"github.com/regclient/regclient/types/tag"
+	"github.com/regclient/regclient/types/warning"
 )
 
 // TagDelete removes a tag from a repository.
@@ -41,6 +42,10 @@ func (reg *Reg) TagDelete(ctx context.Context, r ref.Ref) error {
 	var tempManifest manifest.Manifest
 	if r.Tag == "" {
 		return errs.ErrMissingTag
+	}
+	// dedup warnings
+	if w := warning.FromContext(ctx); w == nil {
+		ctx = warning.NewContext(ctx, &warning.Warning{Hook: warning.DefaultHook()})
 	}
 
 	// attempt to delete the tag directly, available in OCI distribution-spec, and Hub API


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Various requests return multiple warning messages if a registry outputs a warning header on every request.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

When a registry returns a warning header on every request, clients should try to consolidate these.

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Test with olareg:

```shell
olareg serve --store-type mem --warning "Ephemeral registry, content may be deleted"
```

Requests with `regctl` to that registry should return one warning per command.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Feat: Consolidate warnings.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

Testing this would need something monitoring stderr for every test, and enabling a registry with warnings on every test. For now, this is just a best effort.
<!-- Mark the following with an [X] to verify they are included -->

- [ ] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
