### PR TITLE
Chore: Move throttle from config to reghttp

### DIFF
--- a/config/host.go
+++ b/config/host.go
@@ -6,13 +6,10 @@ import (
 	"fmt"
 	"io"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/regclient/regclient/internal/pqueue"
-	"github.com/regclient/regclient/internal/reqmeta"
 	"github.com/regclient/regclient/internal/timejson"
 )
 
@@ -47,10 +44,6 @@ const (
 	defaultReqPerSec = 0
 	// tokenUser is the username returned by credential helpers that indicates the password is an identity token.
 	tokenUser = "<token>"
-)
-
-var (
-	mu = sync.Mutex{}
 )
 
 // MarshalJSON converts TLSConf to a json string using MarshalText.
@@ -106,31 +99,30 @@ func (t *TLSConf) UnmarshalText(b []byte) error {
 
 // Host defines settings for connecting to a registry.
 type Host struct {
-	Name          string                      `json:"-" yaml:"registry,omitempty"`                  // Name of the registry (required) (yaml configs pass this as a field, json provides this from the object key)
-	TLS           TLSConf                     `json:"tls,omitempty" yaml:"tls"`                     // TLS setting: enabled (default), disabled, insecure
-	RegCert       string                      `json:"regcert,omitempty" yaml:"regcert"`             // public pem cert of registry
-	ClientCert    string                      `json:"clientCert,omitempty" yaml:"clientCert"`       // public pem cert for client (mTLS)
-	ClientKey     string                      `json:"clientKey,omitempty" yaml:"clientKey"`         // private pem cert for client (mTLS)
-	Hostname      string                      `json:"hostname,omitempty" yaml:"hostname"`           // hostname of registry, default is the registry name
-	User          string                      `json:"user,omitempty" yaml:"user"`                   // username, not used with credHelper
-	Pass          string                      `json:"pass,omitempty" yaml:"pass"`                   // password, not used with credHelper
-	Token         string                      `json:"token,omitempty" yaml:"token"`                 // token, experimental for specific APIs
-	CredHelper    string                      `json:"credHelper,omitempty" yaml:"credHelper"`       // credential helper command for requesting logins
-	CredExpire    timejson.Duration           `json:"credExpire,omitempty" yaml:"credExpire"`       // time until credential expires
-	CredHost      string                      `json:"credHost" yaml:"credHost"`                     // used when a helper hostname doesn't match Hostname
-	PathPrefix    string                      `json:"pathPrefix,omitempty" yaml:"pathPrefix"`       // used for mirrors defined within a repository namespace
-	Mirrors       []string                    `json:"mirrors,omitempty" yaml:"mirrors"`             // list of other Host Names to use as mirrors
-	Priority      uint                        `json:"priority,omitempty" yaml:"priority"`           // priority when sorting mirrors, higher priority attempted first
-	RepoAuth      bool                        `json:"repoAuth,omitempty" yaml:"repoAuth"`           // tracks a separate auth per repo
-	API           string                      `json:"api,omitempty" yaml:"api"`                     // Deprecated: registry API to use
-	APIOpts       map[string]string           `json:"apiOpts,omitempty" yaml:"apiOpts"`             // options for APIs
-	BlobChunk     int64                       `json:"blobChunk,omitempty" yaml:"blobChunk"`         // size of each blob chunk
-	BlobMax       int64                       `json:"blobMax,omitempty" yaml:"blobMax"`             // threshold to switch to chunked upload, -1 to disable, 0 for regclient.blobMaxPut
-	ReqPerSec     float64                     `json:"reqPerSec,omitempty" yaml:"reqPerSec"`         // requests per second
-	ReqConcurrent int64                       `json:"reqConcurrent,omitempty" yaml:"reqConcurrent"` // concurrent requests, default is defaultConcurrent(3)
-	Scheme        string                      `json:"scheme,omitempty" yaml:"scheme"`               // Deprecated: use TLS instead
-	credRefresh   time.Time                   `json:"-" yaml:"-"`                                   // internal use, when to refresh credentials
-	throttle      *pqueue.Queue[reqmeta.Data] `json:"-" yaml:"-"`                                   // internal use, limit for concurrent requests
+	Name          string            `json:"-" yaml:"registry,omitempty"`                  // Name of the registry (required) (yaml configs pass this as a field, json provides this from the object key)
+	TLS           TLSConf           `json:"tls,omitempty" yaml:"tls"`                     // TLS setting: enabled (default), disabled, insecure
+	RegCert       string            `json:"regcert,omitempty" yaml:"regcert"`             // public pem cert of registry
+	ClientCert    string            `json:"clientCert,omitempty" yaml:"clientCert"`       // public pem cert for client (mTLS)
+	ClientKey     string            `json:"clientKey,omitempty" yaml:"clientKey"`         // private pem cert for client (mTLS)
+	Hostname      string            `json:"hostname,omitempty" yaml:"hostname"`           // hostname of registry, default is the registry name
+	User          string            `json:"user,omitempty" yaml:"user"`                   // username, not used with credHelper
+	Pass          string            `json:"pass,omitempty" yaml:"pass"`                   // password, not used with credHelper
+	Token         string            `json:"token,omitempty" yaml:"token"`                 // token, experimental for specific APIs
+	CredHelper    string            `json:"credHelper,omitempty" yaml:"credHelper"`       // credential helper command for requesting logins
+	CredExpire    timejson.Duration `json:"credExpire,omitempty" yaml:"credExpire"`       // time until credential expires
+	CredHost      string            `json:"credHost" yaml:"credHost"`                     // used when a helper hostname doesn't match Hostname
+	PathPrefix    string            `json:"pathPrefix,omitempty" yaml:"pathPrefix"`       // used for mirrors defined within a repository namespace
+	Mirrors       []string          `json:"mirrors,omitempty" yaml:"mirrors"`             // list of other Host Names to use as mirrors
+	Priority      uint              `json:"priority,omitempty" yaml:"priority"`           // priority when sorting mirrors, higher priority attempted first
+	RepoAuth      bool              `json:"repoAuth,omitempty" yaml:"repoAuth"`           // tracks a separate auth per repo
+	API           string            `json:"api,omitempty" yaml:"api"`                     // Deprecated: registry API to use
+	APIOpts       map[string]string `json:"apiOpts,omitempty" yaml:"apiOpts"`             // options for APIs
+	BlobChunk     int64             `json:"blobChunk,omitempty" yaml:"blobChunk"`         // size of each blob chunk
+	BlobMax       int64             `json:"blobMax,omitempty" yaml:"blobMax"`             // threshold to switch to chunked upload, -1 to disable, 0 for regclient.blobMaxPut
+	ReqPerSec     float64           `json:"reqPerSec,omitempty" yaml:"reqPerSec"`         // requests per second
+	ReqConcurrent int64             `json:"reqConcurrent,omitempty" yaml:"reqConcurrent"` // concurrent requests, default is defaultConcurrent(3)
+	Scheme        string            `json:"scheme,omitempty" yaml:"scheme"`               // Deprecated: use TLS instead
+	credRefresh   time.Time         `json:"-" yaml:"-"`                                   // internal use, when to refresh credentials
 }
 
 // Cred defines a user credential for accessing a registry.
@@ -454,14 +446,6 @@ func (host *Host) Merge(newHost Host, log *logrus.Logger) error {
 
 	if newHost.ReqConcurrent > 0 {
 		if host.ReqConcurrent != 0 && host.ReqConcurrent != newHost.ReqConcurrent {
-			if host.throttle != nil {
-				log.WithFields(logrus.Fields{
-					"orig": host.ReqConcurrent,
-					"new":  newHost.ReqConcurrent,
-					"host": name,
-				}).Warn("Unable to change ReqConcurrent after throttle is created")
-				return fmt.Errorf("unable to change ReqConcurrent after throttle is created")
-			}
 			log.WithFields(logrus.Fields{
 				"orig": host.ReqConcurrent,
 				"new":  newHost.ReqConcurrent,
@@ -472,18 +456,6 @@ func (host *Host) Merge(newHost Host, log *logrus.Logger) error {
 	}
 
 	return nil
-}
-
-func (host *Host) Throttle() *pqueue.Queue[reqmeta.Data] {
-	if host.ReqConcurrent <= 0 {
-		return nil
-	}
-	mu.Lock()
-	defer mu.Unlock()
-	if host.throttle == nil {
-		host.throttle = pqueue.New(pqueue.Opts[reqmeta.Data]{Max: int(host.ReqConcurrent), Next: reqmeta.DataNext})
-	}
-	return host.throttle
 }
 
 func copyMapString(src map[string]string) map[string]string {

--- a/scheme/reg/reg.go
+++ b/scheme/reg/reg.go
@@ -96,13 +96,13 @@ func New(opts ...Opts) *Reg {
 func (reg *Reg) Throttle(r ref.Ref, put bool) []*pqueue.Queue[reqmeta.Data] {
 	tList := []*pqueue.Queue[reqmeta.Data]{}
 	host := reg.hostGet(r.Registry)
-	t := host.Throttle()
+	t := reg.reghttp.GetThrottle(r.Registry)
 	if t != nil {
 		tList = append(tList, t)
 	}
 	if !put {
 		for _, mirror := range host.Mirrors {
-			t := reg.hostGet(mirror).Throttle()
+			t := reg.reghttp.GetThrottle(mirror)
 			if t != nil {
 				tList = append(tList, t)
 			}


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This removes the throttle from the `config`, putting it in `reghttp` where it is used. Ideally the config should only have static config values, but some methods for credential helpers are likely to remain.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

This is transparent to anyone unless they accessed the `config` method directly.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Chore: Move throttle from `config` to `reghttp`.
- Breaking: `config.Host.Throttle()` has been removed. Use `scheme.Throttler` instead.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
