### PR TITLE
Fix: Prevent data race when reading blob and seeking

### DIFF
--- a/blob_test.go
+++ b/blob_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/regclient/regclient/config"
 	"github.com/regclient/regclient/internal/reqresp"
+	"github.com/regclient/regclient/types"
 	"github.com/regclient/regclient/types/descriptor"
 	"github.com/regclient/regclient/types/errs"
 	"github.com/regclient/regclient/types/ref"
@@ -736,9 +737,11 @@ func TestBlobCopy(t *testing.T) {
 	d1, blob1 := reqresp.NewRandomBlob(blobLen, seed)
 	d2, blob2 := reqresp.NewRandomBlob(blobLen, seed+1)
 	d3, blob3 := reqresp.NewRandomBlob(blobLen, seed+2)
-	uuid1 := reqresp.NewRandomID(seed + 3)
-	uuid2 := reqresp.NewRandomID(seed + 4)
-	uuid3 := reqresp.NewRandomID(seed + 5)
+	d4, blob4 := reqresp.NewRandomBlob(blobLen, seed+3)
+	uuid1 := reqresp.NewRandomID(seed + 10)
+	uuid2 := reqresp.NewRandomID(seed + 11)
+	uuid3 := reqresp.NewRandomID(seed + 12)
+	uuid4 := reqresp.NewRandomID(seed + 13)
 
 	// define req/resp entries
 	rrs := []reqresp.ReqResp{
@@ -1081,8 +1084,9 @@ func TestBlobCopy(t *testing.T) {
 					"Content-Length": {fmt.Sprintf("%d", len(blob3))},
 					"Content-Type":   {"application/octet-stream"},
 				},
-				Body:    blob3,
-				IfState: []string{"d3fail"},
+				Body:     blob3,
+				IfState:  []string{"d3fail"},
+				SetState: "d3",
 			},
 			RespEntry: reqresp.RespEntry{
 				Status: http.StatusCreated,
@@ -1116,6 +1120,107 @@ func TestBlobCopy(t *testing.T) {
 					"Docker-Content-Digest": {d3.String()},
 				},
 				Fail: true,
+			},
+		},
+
+		// head
+		{
+			ReqEntry: reqresp.ReqEntry{
+				Name:   "HEAD for repo a - d4",
+				Method: "HEAD",
+				Path:   "/v2" + blobRepoA + "/blobs/" + d4.String(),
+			},
+			RespEntry: reqresp.RespEntry{
+				Status: http.StatusOK,
+				Headers: http.Header{
+					"Content-Length":        {fmt.Sprintf("%d", blobLen)},
+					"Content-Type":          {"application/octet-stream"},
+					"Docker-Content-Digest": {d4.String()},
+				},
+			},
+		},
+		// head
+		{
+			ReqEntry: reqresp.ReqEntry{
+				Name:    "HEAD for repo b - d4",
+				Method:  "HEAD",
+				Path:    "/v2" + blobRepoB + "/blobs/" + d4.String(),
+				IfState: []string{"", "d3"},
+			},
+			RespEntry: reqresp.RespEntry{
+				Status: http.StatusNotFound,
+			},
+		},
+		// get
+		{
+			ReqEntry: reqresp.ReqEntry{
+				Name:   "GET for repo a - d4",
+				Method: "GET",
+				Path:   "/v2" + blobRepoA + "/blobs/" + d4.String(),
+			},
+			RespEntry: reqresp.RespEntry{
+				Status: http.StatusOK,
+				Body:   blob4,
+				Headers: http.Header{
+					"Content-Length":        {fmt.Sprintf("%d", blobLen)},
+					"Content-Type":          {"application/octet-stream"},
+					"Docker-Content-Digest": {d4.String()},
+				},
+			},
+		},
+		// get upload location
+		{
+			ReqEntry: reqresp.ReqEntry{
+				Name:   "POST for repo b - d4",
+				Method: "POST",
+				Path:   "/v2" + blobRepoB + "/blobs/uploads/",
+				Query: map[string][]string{
+					"mount": {d4.String()},
+				},
+				IfState: []string{"", "d3"},
+			},
+			RespEntry: reqresp.RespEntry{
+				Status: http.StatusAccepted,
+				Headers: http.Header{
+					"Content-Length": {"0"},
+					"Location":       {uuid4},
+				},
+			},
+		},
+		// upload blob
+		{
+			ReqEntry: reqresp.ReqEntry{
+				Name:   "PUT for repo b - d4",
+				Method: "PUT",
+				Path:   "/v2" + blobRepoB + "/blobs/uploads/" + uuid4,
+				Query: map[string][]string{
+					"digest": {d4.String()},
+				},
+				Headers: http.Header{
+					"Content-Length": {fmt.Sprintf("%d", len(blob4))},
+					"Content-Type":   {"application/octet-stream"},
+				},
+				Body:     blob4,
+				IfState:  []string{"", "d3"},
+				SetState: "d4",
+			},
+			RespEntry: reqresp.RespEntry{
+				Status: http.StatusCreated,
+				Headers: http.Header{
+					"Content-Length":        {"0"},
+					"Location":              {"/v2" + blobRepoB + "/blobs/" + d4.String()},
+					"Docker-Content-Digest": {d4.String()},
+				},
+			},
+		},
+		{
+			ReqEntry: reqresp.ReqEntry{
+				Name:   "DELETE for repo b - d4",
+				Method: "DELETE",
+				Path:   "/v2" + blobRepoB + "/blobs/uploads/" + uuid4,
+			},
+			RespEntry: reqresp.RespEntry{
+				Status: http.StatusAccepted,
 			},
 		},
 	}
@@ -1199,4 +1304,34 @@ func TestBlobCopy(t *testing.T) {
 		}
 	})
 
+	// copy with callback
+	t.Run("callback", func(t *testing.T) {
+		err = rc.BlobCopy(ctx, refA, refB, descriptor.Descriptor{Digest: d4},
+			BlobWithCallback(func(kind types.CallbackKind, instance string, state types.CallbackState, cur, total int64) {
+				if kind != types.CallbackBlob {
+					t.Errorf("unexpected callback kind, expected %d, received %d", types.CallbackBlob, kind)
+				}
+				if instance != d4.String() {
+					t.Errorf("unexpected instance, expected %s, received %s", d4.String(), instance)
+				}
+				switch state {
+				case types.CallbackStarted:
+					if cur > 0 {
+						t.Errorf("cur > 0 on startup, %d", cur)
+					}
+				case types.CallbackActive:
+					if cur > int64(blobLen) {
+						t.Errorf("cur > length, %d > %d", cur, blobLen)
+					}
+				case types.CallbackFinished:
+				case types.CallbackSkipped:
+					t.Errorf("blob copy skipped")
+				default:
+					t.Errorf("unexpected state, expected %d, received %d", types.CallbackActive, state)
+				}
+			}))
+		if err != nil {
+			t.Fatalf("Failed to copy d4 from repo a to b: %v", err)
+		}
+	})
 }


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

It's possible for `regctl image copy` to panic from a data race.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Prevent data race when reading blob and seeking simultaneously. A seek to the current location is used to monitor the progress, making it possible for the callback to panic.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Testing with `-race` now has tests to detect this.

```shell
make test
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Fix: Prevent data race when reading blob and seeking.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
