### PR TITLE
Feat: Add default host config

### DIFF
--- a/cmd/regctl/config_test.go
+++ b/cmd/regctl/config_test.go
@@ -15,8 +15,8 @@ func TestConfig(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed to run config get: %v", err)
 	}
-	if out != `{"hosts":{}}` {
-		t.Errorf("unexpected output from empty config, expected: %s, received: %s", `{"hosts":{}}`, out)
+	if out != `{}` {
+		t.Errorf("unexpected output from empty config, expected: %s, received: %s", `{}`, out)
 	}
 
 	// set options
@@ -52,10 +52,27 @@ func TestConfig(t *testing.T) {
 		t.Errorf("unexpected output for docker-cred, expected: false, received: %s", out)
 	}
 
-	// reset back to zero values
-	out, err = cobraTest(t, nil, "config", "set", "--blob-limit", "0", "--docker-cert", "--docker-cred")
+	// set a default credential helper
+	out, err = cobraTest(t, nil, "config", "set", "--default-cred-helper", "test-helper")
 	if err != nil {
-		t.Errorf("failed to set blob-limit: %v", err)
+		t.Errorf("failed to set credential helper: %v", err)
+	}
+	if out != "" {
+		t.Errorf("unexpected output from set: %s", out)
+	}
+
+	out, err = cobraTest(t, nil, "config", "get", "--format", "{{ .HostDefault.CredHelper }}")
+	if err != nil {
+		t.Errorf("failed to run config get on default cred helper: %v", err)
+	}
+	if out != "test-helper" {
+		t.Errorf("unexpected output for default cred helper, expected: test-helper, received: %s", out)
+	}
+
+	// reset back to zero values
+	out, err = cobraTest(t, nil, "config", "set", "--blob-limit", "0", "--docker-cert", "--docker-cred", "--default-cred-helper", "")
+	if err != nil {
+		t.Errorf("failed to set default values: %v", err)
 	}
 	if out != "" {
 		t.Errorf("unexpected output from set: %s", out)
@@ -66,8 +83,7 @@ func TestConfig(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed to run config get: %v", err)
 	}
-	if out != `{"hosts":{}}` {
-		t.Errorf("unexpected output from empty config, expected: %s, received: %s", `{"hosts":{}}`, out)
+	if out != `{}` {
+		t.Errorf("unexpected output from empty config, expected: %s, received: %s", `{}`, out)
 	}
-
 }

--- a/cmd/regctl/root.go
+++ b/cmd/regctl/root.go
@@ -172,6 +172,9 @@ func (rootOpts *rootCmd) newRegClient() *regclient.RegClient {
 	if conf.IncDockerCert == nil || *conf.IncDockerCert {
 		rcOpts = append(rcOpts, regclient.WithDockerCerts())
 	}
+	if conf.HostDefault != nil {
+		rcOpts = append(rcOpts, regclient.WithConfigHostDefault(*conf.HostDefault))
+	}
 
 	rcHosts := []config.Host{}
 	for name, host := range conf.Hosts {

--- a/config/testdata/docker-credential-test
+++ b/config/testdata/docker-credential-test
@@ -3,6 +3,7 @@
 list='{
   "https://index.docker.io/v1/": "hubuser",
   "http://http.example.com/": "hello",
+  "host.example.org": "hello",
   "testhost.example.com": "hello",
   "testtoken.example.com": "<token>"
 }'
@@ -17,6 +18,12 @@ registry_http='
 { "ServerURL": "http://http.example.com/",
   "Username": "hello",
   "Secret": "universe"
+}
+'
+registry_host_org='
+{ "ServerURL": "host.example.org",
+  "Username": "hello",
+  "Secret": "world"
 }
 '
 registry_testhost='
@@ -41,6 +48,10 @@ if [ "$1" = "get" ]; then
       ;;
     http://http.example.com/)
       echo "${registry_http}"
+      exit 0
+      ;;
+    host.example.org)
+      echo "${registry_host_org}"
       exit 0
       ;;
     testhost.example.com)

--- a/regclient.go
+++ b/regclient.go
@@ -31,12 +31,12 @@ const (
 
 // RegClient is used to access OCI distribution-spec registries.
 type RegClient struct {
-	hosts map[string]*config.Host
-	log   *logrus.Logger
-	// mu        sync.Mutex
-	regOpts   []reg.Opts
-	schemes   map[string]scheme.API
-	userAgent string
+	hosts       map[string]*config.Host
+	hostDefault *config.Host
+	log         *logrus.Logger
+	regOpts     []reg.Opts
+	schemes     map[string]scheme.API
+	userAgent   string
 }
 
 // Opt functions are used by [New] to create a [*RegClient].
@@ -47,10 +47,9 @@ func New(opts ...Opt) *RegClient {
 	var rc = RegClient{
 		hosts:     map[string]*config.Host{},
 		userAgent: DefaultUserAgent,
-		// logging is disabled by default
-		log:     &logrus.Logger{Out: io.Discard},
-		regOpts: []reg.Opts{},
-		schemes: map[string]scheme.API{},
+		log:       &logrus.Logger{Out: io.Discard},
+		regOpts:   []reg.Opts{},
+		schemes:   map[string]scheme.API{},
 	}
 
 	info := version.GetInfo()
@@ -74,6 +73,7 @@ func New(opts ...Opt) *RegClient {
 	}
 	rc.regOpts = append(rc.regOpts,
 		reg.WithConfigHosts(hostList),
+		reg.WithConfigHostDefault(rc.hostDefault),
 		reg.WithLog(rc.log),
 		reg.WithUserAgent(rc.userAgent),
 	)
@@ -123,6 +123,13 @@ func WithCertDir(path ...string) Opt {
 func WithConfigHost(configHost ...config.Host) Opt {
 	return func(rc *RegClient) {
 		rc.hostLoad("host", configHost)
+	}
+}
+
+// WithConfigHostDefault adds default settings for new hosts.
+func WithConfigHostDefault(configHost config.Host) Opt {
+	return func(rc *RegClient) {
+		rc.hostDefault = &configHost
 	}
 }
 
@@ -249,12 +256,9 @@ func (rc *RegClient) hostLoad(src string, hosts []config.Host) {
 func (rc *RegClient) hostSet(newHost config.Host) error {
 	name := newHost.Name
 	var err error
-	// hostSet should only run on New, which single threaded
-	// rc.mu.Lock()
-	// defer rc.mu.Unlock()
 	if _, ok := rc.hosts[name]; !ok {
 		// merge newHost with default host settings
-		rc.hosts[name] = config.HostNewName(name)
+		rc.hosts[name] = config.HostNewDefName(rc.hostDefault, name)
 		err = rc.hosts[name].Merge(newHost, nil)
 	} else {
 		// merge newHost with existing settings

--- a/regclient_test.go
+++ b/regclient_test.go
@@ -68,6 +68,7 @@ func TestNew(t *testing.T) {
 			},
 		},
 	}
+	defaultRegOptCount := 4
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			result := New(tc.opts...)
@@ -90,8 +91,8 @@ func TestNew(t *testing.T) {
 				}
 			}
 			if len(tc.expect.regOpts) > 0 {
-				if len(tc.expect.regOpts)+3 != len(result.regOpts) {
-					t.Errorf("regOpts length mismatch, expected %d, received %d", len(tc.expect.regOpts), len(result.regOpts))
+				if len(tc.expect.regOpts)+defaultRegOptCount != len(result.regOpts) {
+					t.Errorf("regOpts length mismatch, expected %d, received %d", len(tc.expect.regOpts)+defaultRegOptCount, len(result.regOpts))
 				}
 				// TODO: can content of each regOpt be compared?
 			}

--- a/scheme/reg/reg.go
+++ b/scheme/reg/reg.go
@@ -45,6 +45,7 @@ type Reg struct {
 	reghttpOpts     []reghttp.Opts
 	log             *logrus.Logger
 	hosts           map[string]*config.Host
+	hostDefault     *config.Host
 	features        map[featureKey]*featureVal
 	blobChunkSize   int64
 	blobChunkLimit  int64
@@ -115,7 +116,7 @@ func (reg *Reg) hostGet(hostname string) *config.Host {
 	reg.muHost.Lock()
 	defer reg.muHost.Unlock()
 	if _, ok := reg.hosts[hostname]; !ok {
-		newHost := config.HostNewName(hostname)
+		newHost := config.HostNewDefName(reg.hostDefault, hostname)
 		// check for normalized hostname
 		if newHost.Name != hostname {
 			hostname = newHost.Name
@@ -198,6 +199,13 @@ func WithCertDirs(dirs []string) Opts {
 func WithCertFiles(files []string) Opts {
 	return func(r *Reg) {
 		r.reghttpOpts = append(r.reghttpOpts, reghttp.WithCertFiles(files))
+	}
+}
+
+// WithConfigHostDefault provides default settings for hosts.
+func WithConfigHostDefault(ch *config.Host) Opts {
+	return func(r *Reg) {
+		r.hostDefault = ch
 	}
 }
 


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Fixes #802.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This adds support for a default host config in regclient. In `regctl`, this exposes a flag to set the default credential helper, however additional options can be directly edited in the config file.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
regctl config set --default-cred-helper "some-helper"
regctl tag ls $registry
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Feat: Add default host config.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
