### PR TITLE
Fix: Detect integer overflows on type conversion

### DIFF
--- a/cmd/regctl/blob.go
+++ b/cmd/regctl/blob.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"math"
 	"os"
 	"strings"
 	"time"
@@ -585,8 +586,9 @@ func (blobOpts *blobCmd) blobReportLayer(tr *tar.Reader) ([]string, error) {
 			}
 			return report, err
 		}
-		// TODO: handle int overflows
-		//#nosec G115 tar header will hopefully not exceed fs.FileMode
+		if th.Mode < 0 || th.Mode > math.MaxUint32 {
+			return report, fmt.Errorf("integer conversion overflow/underflow (file mode = %d)", th.Mode)
+		}
 		line := fmt.Sprintf("%s %d/%d %8d", fs.FileMode(th.Mode).String(), th.Uid, th.Gid, th.Size)
 		if !blobOpts.diffIgnoreTime {
 			line += " " + th.ModTime.Format(time.RFC3339)

--- a/pkg/archive/tar.go
+++ b/pkg/archive/tar.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"math"
 	"os"
 	"path/filepath"
 	"time"
@@ -136,8 +137,9 @@ func Extract(ctx context.Context, path string, r io.Reader, opts ...TarOpts) err
 		fn := filepath.Join(path, filepath.Clean("/"+hdr.Name))
 		switch hdr.Typeflag {
 		case tar.TypeDir:
-			// TODO: handle int overflows
-			//#nosec G115 tar header will hopefully not exceed fs.FileMode
+			if hdr.Mode < 0 || hdr.Mode > math.MaxUint32 {
+				return fmt.Errorf("integer conversion overflow/underflow (file mode = %d)", hdr.Mode)
+			}
 			err = os.MkdirAll(fn, fs.FileMode(hdr.Mode))
 			if err != nil {
 				return err


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Detect integer overflows on type conversion. This removes a few gosec overrides.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
make lint-gosec
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Fix: Detect integer overflows on type conversion.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
