### PR TITLE
Fix: Race condition in the pqueue tests

### DIFF
--- a/internal/pqueue/pqueue_test.go
+++ b/internal/pqueue/pqueue_test.go
@@ -298,10 +298,10 @@ func TestMulti(t *testing.T) {
 			if err != nil {
 				t.Errorf("failed to AcquireMulti for group %d: %v", i, err)
 			}
-			finished <- i
 			if done != nil {
 				done()
 			}
+			finished <- i
 		}(i, list)
 	}
 	sleepMS(5)
@@ -350,7 +350,9 @@ func TestMulti(t *testing.T) {
 		t.Errorf("AcquireMulti on a canceled context did not return a nil done function")
 		doneAll()
 	}
-	done()
+	if done != nil {
+		done()
+	}
 	for i := range qList {
 		done, err = qList[i].TryAcquire(ctxMulti, e)
 		if err != nil {


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Race condition discovered in pqueue_test.go in recent GHA run.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Fix ordering of channel to release next step of the test to run after queue is freed, and avoid nil pointer deref.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Fix: Race condition in the pqueue tests.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
