### PR TITLE
Feat: Refactor logging to use log/slog

### DIFF
--- a/blob_test.go
+++ b/blob_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -14,7 +15,6 @@ import (
 	"time"
 
 	"github.com/opencontainers/go-digest"
-	"github.com/sirupsen/logrus"
 
 	"github.com/regclient/regclient/config"
 	"github.com/regclient/regclient/internal/reqresp"
@@ -166,17 +166,12 @@ func TestBlobGet(t *testing.T) {
 			TLS:      config.TLSDisabled,
 		},
 	}
-	log := &logrus.Logger{
-		Out:       os.Stderr,
-		Formatter: new(logrus.TextFormatter),
-		Hooks:     make(logrus.LevelHooks),
-		Level:     logrus.WarnLevel,
-	}
+	log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
 	delayInit, _ := time.ParseDuration("0.05s")
 	delayMax, _ := time.ParseDuration("0.10s")
 	rc := New(
 		WithConfigHost(rcHosts...),
-		WithLog(log),
+		WithSlog(log),
 		WithRetryDelay(delayInit, delayMax),
 	)
 	// Test successful blob
@@ -651,18 +646,13 @@ func TestBlobPut(t *testing.T) {
 			BlobMax:   int64(-1),
 		},
 	}
-	log := &logrus.Logger{
-		Out:       os.Stderr,
-		Formatter: new(logrus.TextFormatter),
-		Hooks:     make(logrus.LevelHooks),
-		Level:     logrus.WarnLevel,
-	}
+	log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
 	// use short delays for fast tests
 	delayInit, _ := time.ParseDuration("0.05s")
 	delayMax, _ := time.ParseDuration("0.10s")
 	rc := New(
 		WithConfigHost(rcHosts...),
-		WithLog(log),
+		WithSlog(log),
 		WithRetryDelay(delayInit, delayMax),
 	)
 
@@ -1240,18 +1230,13 @@ func TestBlobCopy(t *testing.T) {
 			BlobMax:   int64(-1),
 		},
 	}
-	log := &logrus.Logger{
-		Out:       os.Stderr,
-		Formatter: new(logrus.TextFormatter),
-		Hooks:     make(logrus.LevelHooks),
-		Level:     logrus.WarnLevel,
-	}
+	log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
 	// use short delays for fast tests
 	delayInit, _ := time.ParseDuration("0.05s")
 	delayMax, _ := time.ParseDuration("0.10s")
 	rc := New(
 		WithConfigHost(rcHosts...),
-		WithLog(log),
+		WithSlog(log),
 		WithRetryDelay(delayInit, delayMax),
 	)
 

--- a/config/host.go
+++ b/config/host.go
@@ -5,10 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"strings"
 	"time"
-
-	"github.com/sirupsen/logrus"
 
 	"github.com/regclient/regclient/internal/timejson"
 )
@@ -267,13 +266,13 @@ func (host Host) IsZero() bool {
 }
 
 // Merge adds fields from a new config host entry.
-func (host *Host) Merge(newHost Host, log *logrus.Logger) error {
+func (host *Host) Merge(newHost Host, log *slog.Logger) error {
 	name := newHost.Name
 	if name == "" {
 		name = host.Name
 	}
 	if log == nil {
-		log = &logrus.Logger{Out: io.Discard}
+		log = slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{}))
 	}
 
 	// merge the existing and new config host
@@ -296,62 +295,56 @@ func (host *Host) Merge(newHost Host, log *logrus.Logger) error {
 
 	if newHost.User != "" {
 		if host.User != "" && host.User != newHost.User {
-			log.WithFields(logrus.Fields{
-				"orig": host.User,
-				"new":  newHost.User,
-				"host": name,
-			}).Warn("Changing login user for registry")
+			log.Warn("Changing login user for registry",
+				slog.String("orig", host.User),
+				slog.String("new", newHost.User),
+				slog.String("host", name))
 		}
 		host.User = newHost.User
 	}
 
 	if newHost.Pass != "" {
 		if host.Pass != "" && host.Pass != newHost.Pass {
-			log.WithFields(logrus.Fields{
-				"host": name,
-			}).Warn("Changing login password for registry")
+			log.Warn("Changing login password for registry",
+				slog.String("host", name))
 		}
 		host.Pass = newHost.Pass
 	}
 
 	if newHost.Token != "" {
 		if host.Token != "" && host.Token != newHost.Token {
-			log.WithFields(logrus.Fields{
-				"host": name,
-			}).Warn("Changing login token for registry")
+			log.Warn("Changing login token for registry",
+				slog.String("host", name))
 		}
 		host.Token = newHost.Token
 	}
 
 	if newHost.CredHelper != "" {
 		if host.CredHelper != "" && host.CredHelper != newHost.CredHelper {
-			log.WithFields(logrus.Fields{
-				"host": name,
-				"orig": host.CredHelper,
-				"new":  newHost.CredHelper,
-			}).Warn("Changing credential helper for registry")
+			log.Warn("Changing credential helper for registry",
+				slog.String("host", name),
+				slog.String("orig", host.CredHelper),
+				slog.String("new", newHost.CredHelper))
 		}
 		host.CredHelper = newHost.CredHelper
 	}
 
 	if newHost.CredExpire != 0 {
 		if host.CredExpire != 0 && host.CredExpire != newHost.CredExpire {
-			log.WithFields(logrus.Fields{
-				"host": name,
-				"orig": host.CredExpire,
-				"new":  newHost.CredExpire,
-			}).Warn("Changing credential expire for registry")
+			log.Warn("Changing credential expire for registry",
+				slog.String("host", name),
+				slog.Any("orig", host.CredExpire),
+				slog.Any("new", newHost.CredExpire))
 		}
 		host.CredExpire = newHost.CredExpire
 	}
 
 	if newHost.CredHost != "" {
 		if host.CredHost != "" && host.CredHost != newHost.CredHost {
-			log.WithFields(logrus.Fields{
-				"host": name,
-				"orig": host.CredHost,
-				"new":  newHost.CredHost,
-			}).Warn("Changing credential host for registry")
+			log.Warn("Changing credential host for registry",
+				slog.String("host", name),
+				slog.String("orig", host.CredHost),
+				slog.String("new", newHost.CredHost))
 		}
 		host.CredHost = newHost.CredHost
 	}
@@ -360,53 +353,48 @@ func (host *Host) Merge(newHost Host, log *logrus.Logger) error {
 		if host.TLS != TLSUndefined && host.TLS != newHost.TLS {
 			tlsOrig, _ := host.TLS.MarshalText()
 			tlsNew, _ := newHost.TLS.MarshalText()
-			log.WithFields(logrus.Fields{
-				"orig": string(tlsOrig),
-				"new":  string(tlsNew),
-				"host": name,
-			}).Warn("Changing TLS settings for registry")
+			log.Warn("Changing TLS settings for registry",
+				slog.String("orig", string(tlsOrig)),
+				slog.String("new", string(tlsNew)),
+				slog.String("host", name))
 		}
 		host.TLS = newHost.TLS
 	}
 
 	if newHost.RegCert != "" {
 		if host.RegCert != "" && host.RegCert != newHost.RegCert {
-			log.WithFields(logrus.Fields{
-				"orig": host.RegCert,
-				"new":  newHost.RegCert,
-				"host": name,
-			}).Warn("Changing certificate settings for registry")
+			log.Warn("Changing certificate settings for registry",
+				slog.String("orig", host.RegCert),
+				slog.String("new", newHost.RegCert),
+				slog.String("host", name))
 		}
 		host.RegCert = newHost.RegCert
 	}
 
 	if newHost.ClientCert != "" {
 		if host.ClientCert != "" && host.ClientCert != newHost.ClientCert {
-			log.WithFields(logrus.Fields{
-				"orig": host.ClientCert,
-				"new":  newHost.ClientCert,
-				"host": name,
-			}).Warn("Changing client certificate settings for registry")
+			log.Warn("Changing client certificate settings for registry",
+				slog.String("orig", host.ClientCert),
+				slog.String("new", newHost.ClientCert),
+				slog.String("host", name))
 		}
 		host.ClientCert = newHost.ClientCert
 	}
 
 	if newHost.ClientKey != "" {
 		if host.ClientKey != "" && host.ClientKey != newHost.ClientKey {
-			log.WithFields(logrus.Fields{
-				"host": name,
-			}).Warn("Changing client certificate key settings for registry")
+			log.Warn("Changing client certificate key settings for registry",
+				slog.String("host", name))
 		}
 		host.ClientKey = newHost.ClientKey
 	}
 
 	if newHost.Hostname != "" {
 		if host.Hostname != "" && host.Hostname != newHost.Hostname {
-			log.WithFields(logrus.Fields{
-				"orig": host.Hostname,
-				"new":  newHost.Hostname,
-				"host": name,
-			}).Warn("Changing hostname settings for registry")
+			log.Warn("Changing hostname settings for registry",
+				slog.String("orig", host.Hostname),
+				slog.String("new", newHost.Hostname),
+				slog.String("host", name))
 		}
 		host.Hostname = newHost.Hostname
 	}
@@ -414,33 +402,30 @@ func (host *Host) Merge(newHost Host, log *logrus.Logger) error {
 	if newHost.PathPrefix != "" {
 		newHost.PathPrefix = strings.Trim(newHost.PathPrefix, "/") // leading and trailing / are not needed
 		if host.PathPrefix != "" && host.PathPrefix != newHost.PathPrefix {
-			log.WithFields(logrus.Fields{
-				"orig": host.PathPrefix,
-				"new":  newHost.PathPrefix,
-				"host": name,
-			}).Warn("Changing path prefix settings for registry")
+			log.Warn("Changing path prefix settings for registry",
+				slog.String("orig", host.PathPrefix),
+				slog.String("new", newHost.PathPrefix),
+				slog.String("host", name))
 		}
 		host.PathPrefix = newHost.PathPrefix
 	}
 
 	if len(newHost.Mirrors) > 0 {
 		if len(host.Mirrors) > 0 && !stringSliceEq(host.Mirrors, newHost.Mirrors) {
-			log.WithFields(logrus.Fields{
-				"orig": host.Mirrors,
-				"new":  newHost.Mirrors,
-				"host": name,
-			}).Warn("Changing mirror settings for registry")
+			log.Warn("Changing mirror settings for registry",
+				slog.Any("orig", host.Mirrors),
+				slog.Any("new", newHost.Mirrors),
+				slog.String("host", name))
 		}
 		host.Mirrors = newHost.Mirrors
 	}
 
 	if newHost.Priority != 0 {
 		if host.Priority != 0 && host.Priority != newHost.Priority {
-			log.WithFields(logrus.Fields{
-				"orig": host.Priority,
-				"new":  newHost.Priority,
-				"host": name,
-			}).Warn("Changing priority settings for registry")
+			log.Warn("Changing priority settings for registry",
+				slog.Uint64("orig", uint64(host.Priority)),
+				slog.Uint64("new", uint64(newHost.Priority)),
+				slog.String("host", name))
 		}
 		host.Priority = newHost.Priority
 	}
@@ -451,10 +436,9 @@ func (host *Host) Merge(newHost Host, log *logrus.Logger) error {
 
 	// TODO: eventually delete
 	if newHost.API != "" {
-		log.WithFields(logrus.Fields{
-			"api":  newHost.API,
-			"host": name,
-		}).Warn("API field has been deprecated")
+		log.Warn("API field has been deprecated",
+			slog.String("api", newHost.API),
+			slog.String("host", name))
 	}
 
 	if len(newHost.APIOpts) > 0 {
@@ -462,12 +446,11 @@ func (host *Host) Merge(newHost Host, log *logrus.Logger) error {
 			merged := copyMapString(host.APIOpts)
 			for k, v := range newHost.APIOpts {
 				if host.APIOpts[k] != "" && host.APIOpts[k] != v {
-					log.WithFields(logrus.Fields{
-						"orig": host.APIOpts[k],
-						"new":  newHost.APIOpts[k],
-						"opt":  k,
-						"host": name,
-					}).Warn("Changing APIOpts setting for registry")
+					log.Warn("Changing APIOpts setting for registry",
+						slog.String("orig", host.APIOpts[k]),
+						slog.String("new", newHost.APIOpts[k]),
+						slog.String("opt", k),
+						slog.String("host", name))
 				}
 				merged[k] = v
 			}
@@ -479,44 +462,40 @@ func (host *Host) Merge(newHost Host, log *logrus.Logger) error {
 
 	if newHost.BlobChunk > 0 {
 		if host.BlobChunk != 0 && host.BlobChunk != newHost.BlobChunk {
-			log.WithFields(logrus.Fields{
-				"orig": host.BlobChunk,
-				"new":  newHost.BlobChunk,
-				"host": name,
-			}).Warn("Changing blobChunk settings for registry")
+			log.Warn("Changing blobChunk settings for registry",
+				slog.Int64("orig", host.BlobChunk),
+				slog.Int64("new", newHost.BlobChunk),
+				slog.String("host", name))
 		}
 		host.BlobChunk = newHost.BlobChunk
 	}
 
 	if newHost.BlobMax != 0 {
 		if host.BlobMax != 0 && host.BlobMax != newHost.BlobMax {
-			log.WithFields(logrus.Fields{
-				"orig": host.BlobMax,
-				"new":  newHost.BlobMax,
-				"host": name,
-			}).Warn("Changing blobMax settings for registry")
+			log.Warn("Changing blobMax settings for registry",
+				slog.Int64("orig", host.BlobMax),
+				slog.Int64("new", newHost.BlobMax),
+				slog.String("host", name))
 		}
 		host.BlobMax = newHost.BlobMax
 	}
 
 	if newHost.ReqPerSec != 0 {
 		if host.ReqPerSec != 0 && host.ReqPerSec != newHost.ReqPerSec {
-			log.WithFields(logrus.Fields{
-				"orig": host.ReqPerSec,
-				"new":  newHost.ReqPerSec,
-				"host": name,
-			}).Warn("Changing reqPerSec settings for registry")
+			log.Warn("Changing reqPerSec settings for registry",
+				slog.Float64("orig", host.ReqPerSec),
+				slog.Float64("new", newHost.ReqPerSec),
+				slog.String("host", name))
 		}
 		host.ReqPerSec = newHost.ReqPerSec
 	}
 
 	if newHost.ReqConcurrent > 0 {
 		if host.ReqConcurrent != 0 && host.ReqConcurrent != newHost.ReqConcurrent {
-			log.WithFields(logrus.Fields{
-				"orig": host.ReqConcurrent,
-				"new":  newHost.ReqConcurrent,
-				"host": name,
-			}).Warn("Changing reqPerSec settings for registry")
+			log.Warn("Changing reqPerSec settings for registry",
+				slog.Int64("orig", host.ReqConcurrent),
+				slog.Int64("new", newHost.ReqConcurrent),
+				slog.String("host", name))
 		}
 		host.ReqConcurrent = newHost.ReqConcurrent
 	}

--- a/image_test.go
+++ b/image_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"log/slog"
 	"net/http/httptest"
 	"net/url"
 	"os"
@@ -14,7 +15,6 @@ import (
 
 	"github.com/olareg/olareg"
 	oConfig "github.com/olareg/olareg/config"
-	"github.com/sirupsen/logrus"
 
 	"github.com/regclient/regclient/config"
 	"github.com/regclient/regclient/internal/copyfs"
@@ -51,17 +51,12 @@ func TestImageCheckBase(t *testing.T) {
 			TLS:      config.TLSDisabled,
 		},
 	}
-	log := &logrus.Logger{
-		Out:       os.Stderr,
-		Formatter: new(logrus.TextFormatter),
-		Hooks:     make(logrus.LevelHooks),
-		Level:     logrus.WarnLevel,
-	}
+	log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
 	delayInit, _ := time.ParseDuration("0.05s")
 	delayMax, _ := time.ParseDuration("0.10s")
 	rc := New(
 		WithConfigHost(rcHosts...),
-		WithLog(log),
+		WithSlog(log),
 		WithRegOpts(reg.WithDelay(delayInit, delayMax)),
 	)
 	rb1, err := ref.New(tsHost + "/testrepo:b1")
@@ -185,17 +180,12 @@ func TestImageConfig(t *testing.T) {
 			TLS:      config.TLSDisabled,
 		},
 	}
-	log := &logrus.Logger{
-		Out:       os.Stderr,
-		Formatter: new(logrus.TextFormatter),
-		Hooks:     make(logrus.LevelHooks),
-		Level:     logrus.WarnLevel,
-	}
+	log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
 	delayInit, _ := time.ParseDuration("0.05s")
 	delayMax, _ := time.ParseDuration("0.10s")
 	rc := New(
 		WithConfigHost(rcHosts...),
-		WithLog(log),
+		WithSlog(log),
 		WithRetryDelay(delayInit, delayMax),
 	)
 	tt := []struct {
@@ -300,17 +290,12 @@ func TestCopy(t *testing.T) {
 			TLS:      config.TLSDisabled,
 		},
 	}
-	log := &logrus.Logger{
-		Out:       os.Stderr,
-		Formatter: new(logrus.TextFormatter),
-		Hooks:     make(logrus.LevelHooks),
-		Level:     logrus.WarnLevel,
-	}
+	log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
 	delayInit, _ := time.ParseDuration("0.05s")
 	delayMax, _ := time.ParseDuration("0.10s")
 	rc := New(
 		WithConfigHost(rcHosts...),
-		WithLog(log),
+		WithSlog(log),
 		WithRetryDelay(delayInit, delayMax),
 	)
 	tempDir := t.TempDir()

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -3,13 +3,13 @@ package auth
 import (
 	"encoding/json"
 	"errors"
+	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"testing"
 	"time"
-
-	"github.com/sirupsen/logrus"
 
 	"github.com/regclient/regclient/internal/reqresp"
 )
@@ -395,7 +395,7 @@ func TestBearer(t *testing.T) {
 	tsHost := tsURL.Host
 	bearer := NewBearerHandler(&http.Client{}, useragent, tsHost,
 		func(h string) Cred { return Cred{User: user, Password: pass} },
-		&logrus.Logger{},
+		slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{})),
 	).(*bearerHandler)
 
 	// handle token1, verify expired token gets current time and isn't expired

--- a/internal/reghttp/http.go
+++ b/internal/reghttp/http.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"os"
@@ -24,8 +25,6 @@ import (
 	// crypto libraries included for go-digest
 	_ "crypto/sha256"
 	_ "crypto/sha512"
-
-	"github.com/sirupsen/logrus"
 
 	"github.com/regclient/regclient/config"
 	"github.com/regclient/regclient/internal/auth"
@@ -55,7 +54,7 @@ type Client struct {
 	retryLimit    int                       // number of retries before failing a request, this applies to each host, and each request
 	delayInit     time.Duration             // how long to initially delay requests on a failure
 	delayMax      time.Duration             // maximum time to delay a request
-	log           *logrus.Logger            // logging for tracing and failures
+	slog          *slog.Logger              // logging for tracing and failures
 	userAgent     string                    // user agent to specify in http request headers
 	mu            sync.Mutex                // mutex to prevent data races
 }
@@ -64,7 +63,7 @@ type clientHost struct {
 	config       *config.Host                // config entry
 	httpClient   *http.Client                // modified http client for registry specific settings
 	userAgent    string                      // user agent to specify in http request headers
-	log          *logrus.Logger              // logging for tracing and failures
+	slog         *slog.Logger                // logging for tracing and failures
 	auth         map[string]*auth.Auth       // map of auth handlers by repository
 	backoffCur   int                         // current count of backoffs for this host
 	backoffLast  time.Time                   // time the last request was released, this may be in the future if there is a queue, or zero if no delay is needed
@@ -120,7 +119,7 @@ func NewClient(opts ...Opts) *Client {
 		retryLimit: DefaultRetryLimit,
 		delayInit:  defaultDelayInit,
 		delayMax:   defaultDelayMax,
-		log:        &logrus.Logger{Out: io.Discard},
+		slog:       slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{})),
 		rootCAPool: [][]byte{},
 		rootCADirs: []string{},
 	}
@@ -151,10 +150,9 @@ func WithCertFiles(files []string) Opts {
 			//#nosec G304 command is run by a user accessing their own files
 			cert, err := os.ReadFile(f)
 			if err != nil {
-				c.log.WithFields(logrus.Fields{
-					"err":  err,
-					"file": f,
-				}).Warn("Failed to read certificate")
+				c.slog.Warn("Failed to read certificate",
+					slog.String("err", err.Error()),
+					slog.String("file", f))
 			} else {
 				c.rootCAPool = append(c.rootCAPool, cert)
 			}
@@ -203,10 +201,10 @@ func WithRetryLimit(rl int) Opts {
 	}
 }
 
-// WithLog injects a logrus Logger configuration.
-func WithLog(log *logrus.Logger) Opts {
+// WithLog injects a slog Logger configuration.
+func WithLog(slog *slog.Logger) Opts {
 	return func(c *Client) {
-		c.log = log
+		c.slog = slog
 	}
 }
 
@@ -336,10 +334,9 @@ func (resp *Resp) next() error {
 			bu := resp.backoffGet()
 			if !bu.IsZero() && bu.After(time.Now()) {
 				sleepTime := time.Until(bu)
-				c.log.WithFields(logrus.Fields{
-					"Host":    h.config.Name,
-					"Seconds": sleepTime.Seconds(),
-				}).Debug("Sleeping for backoff")
+				c.slog.Debug("Sleeping for backoff",
+					slog.String("Host", h.config.Name),
+					slog.Duration("Duration", sleepTime))
 				select {
 				case <-resp.ctx.Done():
 					return errs.ErrCanceled
@@ -426,10 +423,9 @@ func (resp *Resp) next() error {
 			resp.resp, err = hc.Do(httpReq)
 
 			if err != nil {
-				c.log.WithFields(logrus.Fields{
-					"URL": u.String(),
-					"err": err,
-				}).Debug("Request failed")
+				c.slog.Debug("Request failed",
+					slog.String("URL", u.String()),
+					slog.String("err", err.Error()))
 				backoff = true
 				return err
 			}
@@ -446,15 +442,13 @@ func (resp *Resp) next() error {
 					}
 					if err != nil {
 						if errors.Is(err, errs.ErrEmptyChallenge) || errors.Is(err, errs.ErrNoNewChallenge) || errors.Is(err, errs.ErrHTTPUnauthorized) {
-							c.log.WithFields(logrus.Fields{
-								"URL": u.String(),
-								"Err": err,
-							}).Debug("Failed to handle auth request")
+							c.slog.Debug("Failed to handle auth request",
+								slog.String("URL", u.String()),
+								slog.String("Err", err.Error()))
 						} else {
-							c.log.WithFields(logrus.Fields{
-								"URL": u.String(),
-								"Err": err,
-							}).Warn("Failed to handle auth request")
+							c.slog.Warn("Failed to handle auth request",
+								slog.String("URL", u.String()),
+								slog.String("Err", err.Error()))
 						}
 						dropHost = true
 					} else {
@@ -489,10 +483,9 @@ func (resp *Resp) next() error {
 			if resp.readCur == 0 && clHeader != "" {
 				cl, parseErr := strconv.ParseInt(clHeader, 10, 64)
 				if parseErr != nil {
-					c.log.WithFields(logrus.Fields{
-						"err":    err,
-						"header": clHeader,
-					}).Debug("failed to parse content-length header")
+					c.slog.Debug("failed to parse content-length header",
+						slog.String("err", parseErr.Error()),
+						slog.String("header", clHeader))
 				} else if resp.readMax > 0 {
 					if resp.readMax != cl {
 						return fmt.Errorf("unexpected content-length, expected %d, received %d", resp.readMax, cl)
@@ -570,10 +563,9 @@ func (resp *Resp) Read(b []byte) (int, error) {
 			resp.done = true
 		} else {
 			// short read, retry?
-			resp.client.log.WithFields(logrus.Fields{
-				"curRead":    resp.readCur,
-				"contentLen": resp.readMax,
-			}).Debug("EOF before reading all content, retrying")
+			resp.client.slog.Debug("EOF before reading all content, retrying",
+				slog.Int64("curRead", resp.readCur),
+				slog.Int64("contentLen", resp.readMax))
 			// retry
 			respErr := resp.backoffSet()
 			if respErr == nil {
@@ -581,9 +573,8 @@ func (resp *Resp) Read(b []byte) (int, error) {
 			}
 			// unrecoverable EOF
 			if respErr != nil {
-				resp.client.log.WithFields(logrus.Fields{
-					"err": respErr,
-				}).Warn("Failed to recover from short read")
+				resp.client.slog.Warn("Failed to recover from short read",
+					slog.String("err", respErr.Error()))
 				resp.done = true
 				return i, err
 			}
@@ -740,7 +731,7 @@ func (c *Client) getHost(host string) *clientHost {
 	h := &clientHost{
 		config:    conf,
 		userAgent: c.userAgent,
-		log:       c.log,
+		slog:      c.slog,
 		auth:      map[string]*auth.Auth{},
 	}
 	if h.config.ReqPerSec > 0 {
@@ -771,9 +762,8 @@ func (c *Client) getHost(host string) *clientHost {
 			} else {
 				rootPool, err := makeRootPool(c.rootCAPool, c.rootCADirs, h.config.Hostname, h.config.RegCert)
 				if err != nil {
-					c.log.WithFields(logrus.Fields{
-						"err": err,
-					}).Warn("failed to setup CA pool")
+					c.slog.Warn("failed to setup CA pool",
+						slog.String("err", err.Error()))
 				} else {
 					tlsc.RootCAs = rootPool
 				}
@@ -781,9 +771,8 @@ func (c *Client) getHost(host string) *clientHost {
 			if h.config.ClientCert != "" && h.config.ClientKey != "" {
 				cert, err := tls.X509KeyPair([]byte(h.config.ClientCert), []byte(h.config.ClientKey))
 				if err != nil {
-					c.log.WithFields(logrus.Fields{
-						"err": err,
-					}).Warn("failed to configure client certs")
+					c.slog.Warn("failed to configure client certs",
+						slog.String("err", err.Error()))
 				} else {
 					tlsc.Certificates = []tls.Certificate{cert}
 				}
@@ -841,7 +830,7 @@ func (ch *clientHost) getAuth(repo string) *auth.Auth {
 	}
 	if _, ok := ch.auth[repo]; !ok {
 		ch.auth[repo] = auth.NewAuth(
-			auth.WithLog(ch.log),
+			auth.WithLog(ch.slog),
 			auth.WithHTTPClient(ch.httpClient),
 			auth.WithCreds(ch.AuthCreds()),
 			auth.WithClientID(ch.userAgent),
@@ -873,27 +862,25 @@ func (wt *wrapTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		reqHead.Set("Authorization", "[censored]")
 	}
 	if err != nil {
-		wt.c.log.WithFields(logrus.Fields{
-			"req-method":  req.Method,
-			"req-url":     req.URL.String(),
-			"req-headers": reqHead,
-			"err":         err,
-		}).Debug("reg http request")
+		wt.c.slog.Debug("reg http request",
+			slog.String("req-method", req.Method),
+			slog.String("req-url", req.URL.String()),
+			slog.Any("req-headers", reqHead),
+			slog.String("err", err.Error()))
 	} else {
 		// extract any warnings
 		for _, wh := range resp.Header.Values("Warning") {
 			if match := warnRegexp.FindStringSubmatch(wh); len(match) == 2 {
 				// TODO(bmitch): pass other fields (registry hostname) with structured logging
-				warning.Handle(req.Context(), wt.c.log, match[1])
+				warning.Handle(req.Context(), wt.c.slog, match[1])
 			}
 		}
-		wt.c.log.WithFields(logrus.Fields{
-			"req-method":   req.Method,
-			"req-url":      req.URL.String(),
-			"req-headers":  reqHead,
-			"resp-status":  resp.Status,
-			"resp-headers": resp.Header,
-		}).Trace("reg http request")
+		wt.c.slog.Log(req.Context(), slog.LevelDebug-4, "reg http request",
+			slog.String("req-method", req.Method),
+			slog.String("req-url", req.URL.String()),
+			slog.Any("req-headers", reqHead),
+			slog.String("resp-status", resp.Status),
+			slog.Any("resp-headers", resp.Header))
 	}
 	return resp, err
 }

--- a/internal/sloghandle/logrus.go
+++ b/internal/sloghandle/logrus.go
@@ -1,0 +1,121 @@
+// Package sloghandle provides a transition handler for migrating from logrus to slog.
+package sloghandle
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+func Logrus(logger *logrus.Logger) *logrusHandler {
+	return &logrusHandler{
+		logger: logger,
+	}
+}
+
+type logrusHandler struct {
+	logger *logrus.Logger
+	attrs  []slog.Attr
+	groups []string
+}
+
+func (h *logrusHandler) Enabled(_ context.Context, level slog.Level) bool {
+	ll := h.logger.GetLevel()
+	if curLevel, ok := logrusToSlog[ll]; ok {
+		return level >= curLevel
+	}
+	return true
+}
+
+func (h *logrusHandler) Handle(ctx context.Context, r slog.Record) error {
+	log := logrus.NewEntry(h.logger).WithContext(ctx)
+	if !r.Time.IsZero() {
+		log = log.WithTime(r.Time)
+	}
+	fields := logrus.Fields{}
+	for _, a := range h.attrs {
+		if a.Key != "" {
+			fields[a.Key] = a.Value
+		}
+	}
+	r.Attrs(func(a slog.Attr) bool {
+		if a.Key != "" {
+			fields[a.Key] = a.Value
+		}
+		return true
+	})
+	if len(fields) > 0 {
+		log = log.WithFields(fields)
+	}
+	log.Log(slogToLogrus(r.Level), r.Message)
+	return nil
+}
+
+func (h *logrusHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	ret := h.clone()
+	prefix := ""
+	if len(h.groups) > 0 {
+		prefix = strings.Join(h.groups, ":") + ":"
+	}
+	for _, a := range attrs {
+		if a.Key == "" {
+			continue
+		}
+		ret.attrs = append(ret.attrs, slog.Attr{
+			Key:   prefix + a.Key,
+			Value: a.Value,
+		})
+	}
+	return ret
+}
+
+func (h *logrusHandler) WithGroup(name string) slog.Handler {
+	if name == "" {
+		return h
+	}
+	ret := h.clone()
+	ret.groups = append(ret.groups, name)
+	return ret
+}
+
+func (h *logrusHandler) clone() *logrusHandler {
+	attrs := make([]slog.Attr, len(h.attrs))
+	copy(attrs, h.attrs)
+	groups := make([]string, len(h.groups))
+	copy(groups, h.groups)
+	return &logrusHandler{
+		logger: h.logger,
+		attrs:  attrs,
+		groups: groups,
+	}
+}
+
+var logrusToSlog = map[logrus.Level]slog.Level{
+	logrus.TraceLevel: slog.LevelDebug - 4,
+	logrus.DebugLevel: slog.LevelDebug,
+	logrus.InfoLevel:  slog.LevelInfo,
+	logrus.WarnLevel:  slog.LevelWarn,
+	logrus.ErrorLevel: slog.LevelError,
+	logrus.FatalLevel: slog.LevelError + 4,
+	logrus.PanicLevel: slog.LevelError + 8,
+}
+
+func slogToLogrus(level slog.Level) logrus.Level {
+	if level <= slog.LevelDebug-4 {
+		return logrus.TraceLevel
+	} else if level <= slog.LevelDebug {
+		return logrus.DebugLevel
+	} else if level <= slog.LevelInfo {
+		return logrus.InfoLevel
+	} else if level <= slog.LevelWarn {
+		return logrus.WarnLevel
+	} else if level <= slog.LevelError {
+		return logrus.ErrorLevel
+	} else if level <= slog.LevelError+4 {
+		return logrus.FatalLevel
+	} else {
+		return logrus.PanicLevel
+	}
+}

--- a/internal/sloghandle/logrus_test.go
+++ b/internal/sloghandle/logrus_test.go
@@ -1,0 +1,120 @@
+package sloghandle
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+func TestLogrus(t *testing.T) {
+	tt := []struct {
+		name         string
+		logrusLevel  logrus.Level
+		slogLevel    slog.Level
+		inexactLevel bool
+	}{
+		{
+			name:        "trace",
+			logrusLevel: logrus.TraceLevel,
+			slogLevel:   slog.LevelDebug - 4,
+		},
+		{
+			name:        "debug",
+			logrusLevel: logrus.DebugLevel,
+			slogLevel:   slog.LevelDebug,
+		},
+		{
+			name:        "info",
+			logrusLevel: logrus.InfoLevel,
+			slogLevel:   slog.LevelInfo,
+		},
+		{
+			name:        "warn",
+			logrusLevel: logrus.WarnLevel,
+			slogLevel:   slog.LevelWarn,
+		},
+		{
+			name:        "fatal",
+			logrusLevel: logrus.FatalLevel,
+			slogLevel:   slog.LevelError + 4,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			// compare level mapping
+			if slogToLogrus(tc.slogLevel) != tc.logrusLevel {
+				t.Errorf("convert to logrus level expected %v, received %v", tc.logrusLevel, slogToLogrus(tc.slogLevel))
+			}
+			if !tc.inexactLevel && logrusToSlog[tc.logrusLevel] != tc.slogLevel {
+				t.Errorf("convert to slog level expected %v, received %v", tc.slogLevel, logrusToSlog[tc.logrusLevel])
+			}
+			// create an slog handler with the default text logger
+			out := &bytes.Buffer{}
+			logrusLogger := logrus.New()
+			logrusLogger.Out = out
+			logrusLogger.Level = tc.logrusLevel
+			slogLogger := slog.New(Logrus(logrusLogger))
+			// generate some sample logs
+			slogLogger.Debug("test debug message", "attr1", "value1", "attr2", 2)
+			slogLogger.Warn("test warn message inline", "attr3", "value3", "attr4", 4)
+			// create a child logger
+			slogChild := slog.New(slogLogger.Handler().WithGroup("child").WithAttrs([]slog.Attr{slog.String("child", "value")}))
+			slogChild.Info("test info message", "attr5", "value5", "attr6", 6)
+			// add a few more tests
+			slogLogger.Warn("test warn with formatted attributes",
+				slog.Group("child2", slog.String("attr-c1", "c1"), slog.Int("attr-c2", 2)),
+				slog.String("attr7", "value7"), slog.Int("attr8", 8))
+			slogLogger.Log(ctx, slog.LevelDebug-4, "test trace message", "attr9", "value9")
+			// check output for logs and check if enabled based on logging level
+			logs := out.String()
+			t.Logf("all logs:\n%s", logs)
+			if strings.Contains(logs, "test trace message") {
+				if tc.slogLevel > slog.LevelDebug-4 {
+					t.Errorf("trace message seen")
+				}
+			} else if tc.slogLevel <= slog.LevelDebug-4 {
+				t.Errorf("trace message not seen")
+			}
+			if strings.Contains(logs, "test debug message") {
+				if tc.slogLevel > slog.LevelDebug {
+					t.Errorf("debug message seen")
+				}
+			} else if tc.slogLevel <= slog.LevelDebug {
+				t.Errorf("debug message not seen")
+			}
+			if strings.Contains(logs, "test info message") {
+				if !strings.Contains(logs, "child:child") {
+					t.Errorf("child:child not seen in info message")
+				}
+				if tc.slogLevel > slog.LevelInfo {
+					t.Errorf("info message seen")
+				}
+			} else if tc.slogLevel <= slog.LevelInfo {
+				t.Errorf("info message not seen")
+			}
+			if strings.Contains(logs, "test warn message inline") {
+				if tc.slogLevel > slog.LevelWarn {
+					t.Errorf("warn message (inline) seen")
+				}
+			} else if tc.slogLevel <= slog.LevelWarn {
+				t.Errorf("warn message (inline) not seen")
+			}
+			if strings.Contains(logs, "test warn with formatted attributes") {
+				if !strings.Contains(logs, "child2") {
+					t.Errorf("child2 not seen in warn message")
+				}
+				if tc.slogLevel > slog.LevelWarn {
+					t.Errorf("warn message (formatted attributes) seen")
+				}
+			} else if tc.slogLevel <= slog.LevelWarn {
+				t.Errorf("warn message (formatted attributes) not seen")
+			}
+		})
+	}
+}

--- a/manifest.go
+++ b/manifest.go
@@ -3,6 +3,7 @@ package regclient
 import (
 	"context"
 	"fmt"
+	"log/slog"
 
 	"github.com/regclient/regclient/scheme"
 	"github.com/regclient/regclient/types/descriptor"
@@ -121,7 +122,9 @@ func (rc *RegClient) ManifestGet(ctx context.Context, r ref.Ref, opts ...Manifes
 		return m, err
 	}
 	if opt.platform != nil && !m.IsList() {
-		rc.log.Debugf("ignoring platform option %s, %s is not an index", opt.platform.String(), r.CommonName())
+		rc.slog.Debug("ignoring platform option, image is not an index",
+			slog.String("platform", opt.platform.String()),
+			slog.String("ref", r.CommonName()))
 	}
 	// this will loop to handle a nested index
 	for opt.platform != nil && m.IsList() {
@@ -160,7 +163,9 @@ func (rc *RegClient) ManifestHead(ctx context.Context, r ref.Ref, opts ...Manife
 		return m, err
 	}
 	if opt.platform != nil && !m.IsList() {
-		rc.log.Debugf("ignoring platform option %s, %s is not an index", opt.platform.String(), r.CommonName())
+		rc.slog.Debug("ignoring platform option, image is not an index",
+			slog.String("platform", opt.platform.String()),
+			slog.String("ref", r.CommonName()))
 	}
 	// this will loop to handle a nested index
 	for opt.platform != nil && m.IsList() {

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -16,7 +17,6 @@ import (
 	"github.com/olareg/olareg"
 	oConfig "github.com/olareg/olareg/config"
 	"github.com/opencontainers/go-digest"
-	"github.com/sirupsen/logrus"
 
 	"github.com/regclient/regclient/config"
 	"github.com/regclient/regclient/internal/reqresp"
@@ -205,17 +205,12 @@ func TestManifest(t *testing.T) {
 			},
 		},
 	}
-	log := &logrus.Logger{
-		Out:       os.Stderr,
-		Formatter: new(logrus.TextFormatter),
-		Hooks:     make(logrus.LevelHooks),
-		Level:     logrus.WarnLevel,
-	}
+	log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
 	delayInit, _ := time.ParseDuration("0.05s")
 	delayMax, _ := time.ParseDuration("0.10s")
 	rc := New(
 		WithConfigHost(rcHosts...),
-		WithLog(log),
+		WithSlog(log),
 		WithRetryDelay(delayInit, delayMax),
 	)
 	t.Run("Get", func(t *testing.T) {

--- a/regclient.go
+++ b/regclient.go
@@ -3,6 +3,7 @@ package regclient
 
 import (
 	"io"
+	"log/slog"
 	"time"
 
 	"fmt"
@@ -10,6 +11,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/regclient/regclient/config"
+	"github.com/regclient/regclient/internal/sloghandle"
 	"github.com/regclient/regclient/internal/version"
 	"github.com/regclient/regclient/scheme"
 	"github.com/regclient/regclient/scheme/ocidir"
@@ -33,9 +35,9 @@ const (
 type RegClient struct {
 	hosts       map[string]*config.Host
 	hostDefault *config.Host
-	log         *logrus.Logger
 	regOpts     []reg.Opts
 	schemes     map[string]scheme.API
+	slog        *slog.Logger
 	userAgent   string
 }
 
@@ -47,9 +49,9 @@ func New(opts ...Opt) *RegClient {
 	var rc = RegClient{
 		hosts:     map[string]*config.Host{},
 		userAgent: DefaultUserAgent,
-		log:       &logrus.Logger{Out: io.Discard},
 		regOpts:   []reg.Opts{},
 		schemes:   map[string]scheme.API{},
+		slog:      slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{})),
 	}
 
 	info := version.GetInfo()
@@ -74,20 +76,19 @@ func New(opts ...Opt) *RegClient {
 	rc.regOpts = append(rc.regOpts,
 		reg.WithConfigHosts(hostList),
 		reg.WithConfigHostDefault(rc.hostDefault),
-		reg.WithLog(rc.log),
+		reg.WithSlog(rc.slog),
 		reg.WithUserAgent(rc.userAgent),
 	)
 
 	// setup scheme's
 	rc.schemes["reg"] = reg.New(rc.regOpts...)
 	rc.schemes["ocidir"] = ocidir.New(
-		ocidir.WithLog(rc.log),
+		ocidir.WithSlog(rc.slog),
 	)
 
-	rc.log.WithFields(logrus.Fields{
-		"VCSRef": info.VCSRef,
-		"VCSTag": info.VCSTag,
-	}).Debug("regclient initialized")
+	rc.slog.Debug("regclient initialized",
+		slog.String("VCSRef", info.VCSRef),
+		slog.String("VCSTag", info.VCSTag))
 
 	return &rc
 }
@@ -151,9 +152,8 @@ func WithDockerCreds() Opt {
 	return func(rc *RegClient) {
 		configHosts, err := config.DockerLoad()
 		if err != nil {
-			rc.log.WithFields(logrus.Fields{
-				"err": err,
-			}).Warn("Failed to load docker creds")
+			rc.slog.Warn("Failed to load docker creds",
+				slog.String("err", err.Error()))
 			return
 		}
 		rc.hostLoad("docker", configHosts)
@@ -166,19 +166,19 @@ func WithDockerCredsFile(fname string) Opt {
 	return func(rc *RegClient) {
 		configHosts, err := config.DockerLoadFile(fname)
 		if err != nil {
-			rc.log.WithFields(logrus.Fields{
-				"err": err,
-			}).Warn("Failed to load docker creds")
+			rc.slog.Warn("Failed to load docker creds",
+				slog.String("err", err.Error()))
 			return
 		}
 		rc.hostLoad("docker-file", configHosts)
 	}
 }
 
-// WithLog overrides default logrus Logger.
+// WithLog configuring logging with a logrus Logger.
+// Note that regclient has switched to log/slog for logging and my eventually deprecate logrus support.
 func WithLog(log *logrus.Logger) Opt {
 	return func(rc *RegClient) {
-		rc.log = log
+		rc.slog = slog.New(sloghandle.Logrus(log))
 	}
 }
 
@@ -210,6 +210,13 @@ func WithRetryLimit(retryLimit int) Opt {
 	}
 }
 
+// WithSlog configures the slog Logger.
+func WithSlog(slog *slog.Logger) Opt {
+	return func(rc *RegClient) {
+		rc.slog = slog
+	}
+}
+
 // WithUserAgent specifies the User-Agent http header.
 func WithUserAgent(ua string) Opt {
 	return func(rc *RegClient) {
@@ -220,7 +227,14 @@ func WithUserAgent(ua string) Opt {
 func (rc *RegClient) hostLoad(src string, hosts []config.Host) {
 	for _, configHost := range hosts {
 		if configHost.Name == "" {
-			// TODO: should this error, warn, or fall back to hostname?
+			if configHost.Pass != "" {
+				configHost.Pass = "***"
+			}
+			if configHost.Token != "" {
+				configHost.Token = "***"
+			}
+			rc.slog.Warn("Ignoring registry config without a name",
+				slog.Any("entry", configHost))
 			continue
 		}
 		if configHost.Name == DockerRegistry || configHost.Name == DockerRegistryDNS || configHost.Name == DockerRegistryAuth {
@@ -230,25 +244,24 @@ func (rc *RegClient) hostLoad(src string, hosts []config.Host) {
 			}
 		}
 		tls, _ := configHost.TLS.MarshalText()
-		rc.log.WithFields(logrus.Fields{
-			"name":       configHost.Name,
-			"user":       configHost.User,
-			"hostname":   configHost.Hostname,
-			"helper":     configHost.CredHelper,
-			"repoAuth":   configHost.RepoAuth,
-			"tls":        string(tls),
-			"pathPrefix": configHost.PathPrefix,
-			"mirrors":    configHost.Mirrors,
-			"blobMax":    configHost.BlobMax,
-			"blobChunk":  configHost.BlobChunk,
-		}).Debugf("Loading %s config", src)
+		rc.slog.Debug("Loading config",
+			slog.Int64("blobChunk", configHost.BlobChunk),
+			slog.Int64("blobMax", configHost.BlobMax),
+			slog.String("helper", configHost.CredHelper),
+			slog.String("hostname", configHost.Hostname),
+			slog.Any("mirrors", configHost.Mirrors),
+			slog.String("name", configHost.Name),
+			slog.String("pathPrefix", configHost.PathPrefix),
+			slog.Bool("repoAuth", configHost.RepoAuth),
+			slog.String("source", src),
+			slog.String("tls", string(tls)),
+			slog.String("user", configHost.User))
 		err := rc.hostSet(configHost)
 		if err != nil {
-			rc.log.WithFields(logrus.Fields{
-				"host":  configHost.Name,
-				"user":  configHost.User,
-				"error": err,
-			}).Warn("Failed to update host config")
+			rc.slog.Warn("Failed to update host config",
+				slog.String("host", configHost.Name),
+				slog.String("user", configHost.User),
+				slog.String("error", err.Error()))
 		}
 	}
 }
@@ -262,7 +275,7 @@ func (rc *RegClient) hostSet(newHost config.Host) error {
 		err = rc.hosts[name].Merge(newHost, nil)
 	} else {
 		// merge newHost with existing settings
-		err = rc.hosts[name].Merge(newHost, rc.log)
+		err = rc.hosts[name].Merge(newHost, rc.slog)
 	}
 	if err != nil {
 		return err

--- a/regclient_test.go
+++ b/regclient_test.go
@@ -1,16 +1,16 @@
 package regclient
 
 import (
+	"log/slog"
+	"os"
 	"testing"
-
-	"github.com/sirupsen/logrus"
 
 	"github.com/regclient/regclient/scheme/reg"
 )
 
 func TestNew(t *testing.T) {
 	t.Parallel()
-	logPtr := logrus.New()
+	logPtr := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
 	tt := []struct {
 		name   string
 		opts   []Opt
@@ -52,10 +52,10 @@ func TestNew(t *testing.T) {
 		{
 			name: "log",
 			opts: []Opt{
-				WithLog(logPtr),
+				WithSlog(logPtr),
 			},
 			expect: RegClient{
-				log: logPtr,
+				slog: logPtr,
 			},
 		},
 		{
@@ -83,11 +83,11 @@ func TestNew(t *testing.T) {
 					}
 				}
 			}
-			if tc.expect.log != nil {
-				if result.log == nil {
-					t.Errorf("log is nil")
-				} else if result.log != tc.expect.log {
-					t.Errorf("log pointer mismatch")
+			if tc.expect.slog != nil {
+				if result.slog == nil {
+					t.Errorf("slog is nil")
+				} else if result.slog != tc.expect.slog {
+					t.Errorf("slog pointer mismatch")
 				}
 			}
 			if len(tc.expect.regOpts) > 0 {

--- a/repo_test.go
+++ b/repo_test.go
@@ -3,27 +3,21 @@ package regclient
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"os"
 	"testing"
 	"time"
-
-	"github.com/sirupsen/logrus"
 
 	"github.com/regclient/regclient/types/errs"
 )
 
 func TestRepoList(t *testing.T) {
 	ctx := context.Background()
-	log := &logrus.Logger{
-		Out:       os.Stderr,
-		Formatter: new(logrus.TextFormatter),
-		Hooks:     make(logrus.LevelHooks),
-		Level:     logrus.WarnLevel,
-	}
+	log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
 	delayInit, _ := time.ParseDuration("0.05s")
 	delayMax, _ := time.ParseDuration("0.10s")
 	rc := New(
-		WithLog(log),
+		WithSlog(log),
 		WithRetryDelay(delayInit, delayMax),
 	)
 	_, err := rc.RepoList(ctx, "registry.example.com/path")

--- a/scheme/ocidir/blob.go
+++ b/scheme/ocidir/blob.go
@@ -6,10 +6,9 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"log/slog"
 	"os"
 	"path"
-
-	"github.com/sirupsen/logrus"
 
 	"github.com/regclient/regclient/internal/reqmeta"
 	"github.com/regclient/regclient/types/blob"
@@ -55,10 +54,9 @@ func (o *OCIDir) BlobGet(ctx context.Context, r ref.Ref, d descriptor.Descriptor
 		blob.WithReader(fd),
 		blob.WithDesc(d),
 	)
-	o.log.WithFields(logrus.Fields{
-		"ref":  r.CommonName(),
-		"file": file,
-	}).Debug("retrieved blob")
+	o.slog.Debug("retrieved blob",
+		slog.String("ref", r.CommonName()),
+		slog.String("file", file))
 	return br, nil
 }
 
@@ -150,10 +148,9 @@ func (o *OCIDir) BlobPut(ctx context.Context, r ref.Ref, d descriptor.Descriptor
 	if err != nil {
 		return d, fmt.Errorf("failed to write blob (rename tmp file %s to %s): %w", path.Join(dir, tmpName), file, err)
 	}
-	o.log.WithFields(logrus.Fields{
-		"ref":  r.CommonName(),
-		"file": file,
-	}).Debug("pushed blob")
+	o.slog.Debug("pushed blob",
+		slog.String("ref", r.CommonName()),
+		slog.String("file", file))
 
 	o.mu.Lock()
 	o.refMod(r)

--- a/scheme/ocidir/manifest.go
+++ b/scheme/ocidir/manifest.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"log/slog"
 	"os"
 	"path"
 
@@ -15,7 +16,6 @@ import (
 	_ "crypto/sha512"
 
 	"github.com/opencontainers/go-digest"
-	"github.com/sirupsen/logrus"
 
 	"github.com/regclient/regclient/scheme"
 	"github.com/regclient/regclient/types/errs"
@@ -134,10 +134,9 @@ func (o *OCIDir) manifestGet(_ context.Context, r ref.Ref) (manifest.Manifest, e
 	if desc.Size == 0 {
 		desc.Size = int64(len(mb))
 	}
-	o.log.WithFields(logrus.Fields{
-		"ref":  r.CommonName(),
-		"file": file,
-	}).Debug("retrieved manifest")
+	o.slog.Debug("retrieved manifest",
+		slog.String("ref", r.CommonName()),
+		slog.String("file", file))
 	return manifest.New(
 		manifest.WithRef(r),
 		manifest.WithDesc(desc),
@@ -279,10 +278,9 @@ func (o *OCIDir) manifestPut(ctx context.Context, r ref.Ref, m manifest.Manifest
 		return err
 	}
 	o.refMod(r)
-	o.log.WithFields(logrus.Fields{
-		"ref":  r.CommonName(),
-		"file": file,
-	}).Debug("pushed manifest")
+	o.slog.Debug("pushed manifest",
+		slog.String("ref", r.CommonName()),
+		slog.String("file", file))
 
 	// update referrers if defined on this manifest
 	if ms, ok := m.(manifest.Subjecter); ok {

--- a/scheme/ocidir/ocidir.go
+++ b/scheme/ocidir/ocidir.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"log/slog"
 	"os"
 	"path"
 	"strings"
@@ -16,6 +17,7 @@ import (
 
 	"github.com/regclient/regclient/internal/pqueue"
 	"github.com/regclient/regclient/internal/reqmeta"
+	"github.com/regclient/regclient/internal/sloghandle"
 	"github.com/regclient/regclient/types/descriptor"
 	"github.com/regclient/regclient/types/errs"
 	"github.com/regclient/regclient/types/mediatype"
@@ -32,7 +34,7 @@ const (
 
 // OCIDir is used for accessing OCI Image Layouts defined as a directory
 type OCIDir struct {
-	log         *logrus.Logger
+	slog        *slog.Logger
 	gc          bool
 	modRefs     map[string]*ociGC
 	throttle    map[string]*pqueue.Queue[reqmeta.Data]
@@ -47,7 +49,7 @@ type ociGC struct {
 
 type ociConf struct {
 	gc       bool
-	log      *logrus.Logger
+	slog     *slog.Logger
 	throttle int
 }
 
@@ -57,7 +59,7 @@ type Opts func(*ociConf)
 // New creates a new OCIDir with options
 func New(opts ...Opts) *OCIDir {
 	conf := ociConf{
-		log:      &logrus.Logger{Out: io.Discard},
+		slog:     slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{})),
 		gc:       true,
 		throttle: defThrottle,
 	}
@@ -65,7 +67,7 @@ func New(opts ...Opts) *OCIDir {
 		opt(&conf)
 	}
 	return &OCIDir{
-		log:         conf.log,
+		slog:        conf.slog,
 		gc:          conf.gc,
 		modRefs:     map[string]*ociGC{},
 		throttle:    map[string]*pqueue.Queue[reqmeta.Data]{},
@@ -81,11 +83,19 @@ func WithGC(gc bool) Opts {
 	}
 }
 
-// WithLog provides a logrus logger
-// By default logging is disabled
+// WithLog provides a logrus logger.
+// By default logging is disabled.
 func WithLog(log *logrus.Logger) Opts {
 	return func(c *ociConf) {
-		c.log = log
+		c.slog = slog.New(sloghandle.Logrus(log))
+	}
+}
+
+// WithSlog provides a slog logger.
+// By default logging is disabled.
+func WithSlog(slog *slog.Logger) Opts {
+	return func(c *ociConf) {
+		c.slog = slog
 	}
 }
 

--- a/scheme/reg/blob_test.go
+++ b/scheme/reg/blob_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -15,7 +16,6 @@ import (
 	"time"
 
 	"github.com/opencontainers/go-digest"
-	"github.com/sirupsen/logrus"
 
 	"github.com/regclient/regclient/config"
 	"github.com/regclient/regclient/internal/reqresp"
@@ -224,17 +224,12 @@ func TestBlobGet(t *testing.T) {
 			TLS:      config.TLSDisabled,
 		},
 	}
-	log := &logrus.Logger{
-		Out:       os.Stderr,
-		Formatter: new(logrus.TextFormatter),
-		Hooks:     make(logrus.LevelHooks),
-		Level:     logrus.WarnLevel,
-	}
+	log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
 	delayInit, _ := time.ParseDuration("0.05s")
 	delayMax, _ := time.ParseDuration("0.10s")
 	reg := New(
 		WithConfigHosts(rcHosts),
-		WithLog(log),
+		WithSlog(log),
 		WithDelay(delayInit, delayMax),
 	)
 
@@ -1377,18 +1372,13 @@ func TestBlobPut(t *testing.T) {
 			BlobMax:   int64(-1),
 		},
 	}
-	log := &logrus.Logger{
-		Out:       os.Stderr,
-		Formatter: new(logrus.TextFormatter),
-		Hooks:     make(logrus.LevelHooks),
-		Level:     logrus.WarnLevel,
-	}
+	log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
 	// use short delays for fast tests
 	delayInit, _ := time.ParseDuration("0.05s")
 	delayMax, _ := time.ParseDuration("0.10s")
 	reg := New(
 		WithConfigHosts(rcHosts),
-		WithLog(log),
+		WithSlog(log),
 		WithDelay(delayInit, delayMax),
 	)
 

--- a/scheme/reg/manifest.go
+++ b/scheme/reg/manifest.go
@@ -5,12 +5,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strconv"
 
 	"github.com/opencontainers/go-digest"
-	"github.com/sirupsen/logrus"
 
 	"github.com/regclient/regclient/internal/limitread"
 	"github.com/regclient/regclient/internal/reghttp"
@@ -214,9 +214,8 @@ func (reg *Reg) ManifestPut(ctx context.Context, r ref.Ref, m manifest.Manifest,
 	} else if r.Tag != "" {
 		tagOrDigest = r.Tag
 	} else {
-		reg.log.WithFields(logrus.Fields{
-			"ref": r.Reference,
-		}).Warn("Manifest put requires a tag")
+		reg.slog.Warn("Manifest put requires a tag",
+			slog.String("ref", r.Reference))
 		return errs.ErrMissingTag
 	}
 	// dedup warnings
@@ -227,10 +226,9 @@ func (reg *Reg) ManifestPut(ctx context.Context, r ref.Ref, m manifest.Manifest,
 	// create the request body
 	mj, err := m.MarshalJSON()
 	if err != nil {
-		reg.log.WithFields(logrus.Fields{
-			"ref": r.Reference,
-			"err": err,
-		}).Warn("Error marshaling manifest")
+		reg.slog.Warn("Error marshaling manifest",
+			slog.String("ref", r.Reference),
+			slog.String("err", err.Error()))
 		return fmt.Errorf("error marshalling manifest for %s: %w", r.CommonName(), err)
 	}
 

--- a/scheme/reg/manifest_test.go
+++ b/scheme/reg/manifest_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -15,7 +16,6 @@ import (
 	"time"
 
 	"github.com/opencontainers/go-digest"
-	"github.com/sirupsen/logrus"
 
 	"github.com/regclient/regclient/config"
 	"github.com/regclient/regclient/internal/reqresp"
@@ -337,23 +337,18 @@ func TestManifest(t *testing.T) {
 			},
 		},
 	}
-	log := &logrus.Logger{
-		Out:       os.Stderr,
-		Formatter: new(logrus.TextFormatter),
-		Hooks:     make(logrus.LevelHooks),
-		Level:     logrus.WarnLevel,
-	}
+	log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
 	delayInit, _ := time.ParseDuration("0.05s")
 	delayMax, _ := time.ParseDuration("0.10s")
 	reg := New(
 		WithConfigHosts(rcHosts),
-		WithLog(log),
+		WithSlog(log),
 		WithDelay(delayInit, delayMax),
 		WithRetryLimit(3),
 	)
 	regCache := New(
 		WithConfigHosts(rcHosts),
-		WithLog(log),
+		WithSlog(log),
 		WithDelay(delayInit, delayMax),
 		WithCache(time.Minute*5, 500),
 	)

--- a/scheme/reg/ping_test.go
+++ b/scheme/reg/ping_test.go
@@ -4,14 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
 	"testing"
 	"time"
-
-	"github.com/sirupsen/logrus"
 
 	"github.com/regclient/regclient/config"
 	"github.com/regclient/regclient/internal/reqresp"
@@ -109,17 +108,12 @@ func TestPing(t *testing.T) {
 			TLS:      config.TLSDisabled,
 		},
 	}
-	log := &logrus.Logger{
-		Out:       os.Stderr,
-		Formatter: new(logrus.TextFormatter),
-		Hooks:     make(logrus.LevelHooks),
-		Level:     logrus.WarnLevel,
-	}
+	log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
 	delayInit, _ := time.ParseDuration("0.05s")
 	delayMax, _ := time.ParseDuration("0.10s")
 	reg := New(
 		WithConfigHosts(rcHosts),
-		WithLog(log),
+		WithSlog(log),
 		WithDelay(delayInit, delayMax),
 		WithRetryLimit(3),
 	)

--- a/scheme/reg/referrer_test.go
+++ b/scheme/reg/referrer_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -12,7 +13,6 @@ import (
 	"time"
 
 	"github.com/opencontainers/go-digest"
-	"github.com/sirupsen/logrus"
 
 	"github.com/regclient/regclient/config"
 	"github.com/regclient/regclient/internal/reqresp"
@@ -809,17 +809,12 @@ func TestReferrer(t *testing.T) {
 			TLS:      config.TLSDisabled,
 		},
 	}
-	log := &logrus.Logger{
-		Out:       os.Stderr,
-		Formatter: new(logrus.TextFormatter),
-		Hooks:     make(logrus.LevelHooks),
-		Level:     logrus.WarnLevel,
-	}
+	log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
 	delayInit, _ := time.ParseDuration("0.05s")
 	delayMax, _ := time.ParseDuration("0.10s")
 	reg := New(
 		WithConfigHosts(rcHosts),
-		WithLog(log),
+		WithSlog(log),
 		WithDelay(delayInit, delayMax),
 		WithCache(time.Minute*5, 500),
 	)

--- a/scheme/reg/reg.go
+++ b/scheme/reg/reg.go
@@ -2,6 +2,7 @@
 package reg
 
 import (
+	"log/slog"
 	"net/http"
 	"sync"
 	"time"
@@ -13,6 +14,7 @@ import (
 	"github.com/regclient/regclient/internal/pqueue"
 	"github.com/regclient/regclient/internal/reghttp"
 	"github.com/regclient/regclient/internal/reqmeta"
+	"github.com/regclient/regclient/internal/sloghandle"
 	"github.com/regclient/regclient/types/manifest"
 	"github.com/regclient/regclient/types/ref"
 	"github.com/regclient/regclient/types/referrer"
@@ -43,7 +45,7 @@ const (
 type Reg struct {
 	reghttp         *reghttp.Client
 	reghttpOpts     []reghttp.Opts
-	log             *logrus.Logger
+	slog            *slog.Logger
 	hosts           map[string]*config.Host
 	hostDefault     *config.Host
 	features        map[featureKey]*featureVal
@@ -238,8 +240,8 @@ func WithHTTPClient(hc *http.Client) Opts {
 // WithLog injects a logrus Logger configuration
 func WithLog(log *logrus.Logger) Opts {
 	return func(r *Reg) {
-		r.log = log
-		r.reghttpOpts = append(r.reghttpOpts, reghttp.WithLog(log))
+		r.slog = slog.New(sloghandle.Logrus(log))
+		r.reghttpOpts = append(r.reghttpOpts, reghttp.WithLog(r.slog))
 	}
 }
 
@@ -255,6 +257,14 @@ func WithManifestMax(push, pull int64) Opts {
 func WithRetryLimit(l int) Opts {
 	return func(r *Reg) {
 		r.reghttpOpts = append(r.reghttpOpts, reghttp.WithRetryLimit(l))
+	}
+}
+
+// WithSlog injects a slog Logger configuration
+func WithSlog(slog *slog.Logger) Opts {
+	return func(r *Reg) {
+		r.slog = slog
+		r.reghttpOpts = append(r.reghttpOpts, reghttp.WithLog(slog))
 	}
 }
 

--- a/scheme/reg/repo.go
+++ b/scheme/reg/repo.go
@@ -4,11 +4,10 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strconv"
-
-	"github.com/sirupsen/logrus"
 
 	"github.com/regclient/regclient/internal/reghttp"
 	"github.com/regclient/regclient/internal/reqmeta"
@@ -57,10 +56,9 @@ func (reg *Reg) RepoList(ctx context.Context, hostname string, opts ...scheme.Re
 
 	respBody, err := io.ReadAll(resp)
 	if err != nil {
-		reg.log.WithFields(logrus.Fields{
-			"err":  err,
-			"host": hostname,
-		}).Warn("Failed to read repo list")
+		reg.slog.Warn("Failed to read repo list",
+			slog.String("err", err.Error()),
+			slog.String("host", hostname))
 		return nil, fmt.Errorf("failed to read repo list for %s: %w", hostname, err)
 	}
 	mt := mediatype.Base(resp.HTTPResponse().Header.Get("Content-Type"))
@@ -71,11 +69,10 @@ func (reg *Reg) RepoList(ctx context.Context, hostname string, opts ...scheme.Re
 		repo.WithHeaders(resp.HTTPResponse().Header),
 	)
 	if err != nil {
-		reg.log.WithFields(logrus.Fields{
-			"err":  err,
-			"body": string(respBody),
-			"host": hostname,
-		}).Warn("Failed to unmarshal repo list")
+		reg.slog.Warn("Failed to unmarshal repo list",
+			slog.String("err", err.Error()),
+			slog.String("body", string(respBody)),
+			slog.String("host", hostname))
 		return nil, fmt.Errorf("failed to parse repo list for %s: %w", hostname, err)
 	}
 	return rl, nil

--- a/scheme/reg/repo_test.go
+++ b/scheme/reg/repo_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -11,8 +12,6 @@ import (
 	"strings"
 	"testing"
 	"time"
-
-	"github.com/sirupsen/logrus"
 
 	"github.com/regclient/regclient/config"
 	"github.com/regclient/regclient/internal/reqresp"
@@ -150,17 +149,12 @@ func TestRepo(t *testing.T) {
 		})
 	}
 	// setup the reg
-	log := &logrus.Logger{
-		Out:       os.Stderr,
-		Formatter: new(logrus.TextFormatter),
-		Hooks:     make(logrus.LevelHooks),
-		Level:     logrus.WarnLevel,
-	}
+	log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
 	delayInit, _ := time.ParseDuration("0.05s")
 	delayMax, _ := time.ParseDuration("0.10s")
 	reg := New(
 		WithConfigHosts(rcHosts),
-		WithLog(log),
+		WithSlog(log),
 		WithDelay(delayInit, delayMax),
 	)
 	// empty list

--- a/scheme/reg/tag_test.go
+++ b/scheme/reg/tag_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -14,7 +15,6 @@ import (
 	"time"
 
 	"github.com/opencontainers/go-digest"
-	"github.com/sirupsen/logrus"
 
 	"github.com/regclient/regclient/config"
 	"github.com/regclient/regclient/internal/reqresp"
@@ -252,17 +252,12 @@ func TestTag(t *testing.T) {
 			TLS:      config.TLSDisabled,
 		},
 	}
-	log := &logrus.Logger{
-		Out:       os.Stderr,
-		Formatter: new(logrus.TextFormatter),
-		Hooks:     make(logrus.LevelHooks),
-		Level:     logrus.WarnLevel,
-	}
+	log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
 	delayInit, _ := time.ParseDuration("0.05s")
 	delayMax, _ := time.ParseDuration("0.10s")
 	reg := New(
 		WithConfigHosts(rcHosts),
-		WithLog(log),
+		WithSlog(log),
 		WithDelay(delayInit, delayMax),
 	)
 

--- a/tag_test.go
+++ b/tag_test.go
@@ -2,6 +2,7 @@ package regclient
 
 import (
 	"context"
+	"log/slog"
 	"net/http/httptest"
 	"net/url"
 	"os"
@@ -10,7 +11,6 @@ import (
 
 	"github.com/olareg/olareg"
 	oConfig "github.com/olareg/olareg/config"
-	"github.com/sirupsen/logrus"
 
 	"github.com/regclient/regclient/config"
 	"github.com/regclient/regclient/internal/copyfs"
@@ -66,17 +66,12 @@ func TestTag(t *testing.T) {
 			TLS:      config.TLSDisabled,
 		},
 	}
-	log := &logrus.Logger{
-		Out:       os.Stderr,
-		Formatter: new(logrus.TextFormatter),
-		Hooks:     make(logrus.LevelHooks),
-		Level:     logrus.WarnLevel,
-	}
+	log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
 	delayInit, _ := time.ParseDuration("0.05s")
 	delayMax, _ := time.ParseDuration("0.10s")
 	rc := New(
 		WithConfigHost(rcHosts...),
-		WithLog(log),
+		WithSlog(log),
 		WithRetryDelay(delayInit, delayMax),
 	)
 	tempDir := t.TempDir()

--- a/types/warning/warning_test.go
+++ b/types/warning/warning_test.go
@@ -3,10 +3,9 @@ package warning
 import (
 	"bytes"
 	"context"
+	"log/slog"
 	"strings"
 	"testing"
-
-	"github.com/sirupsen/logrus"
 )
 
 func TestWarning(t *testing.T) {
@@ -15,19 +14,13 @@ func TestWarning(t *testing.T) {
 	msg2 := "test 2"
 	ctxBase := context.Background()
 	bufBase := &bytes.Buffer{}
-	logBase := logrus.New()
-	logBase.SetOutput(bufBase)
-	logBase.SetLevel(logrus.InfoLevel)
+	logBase := slog.New(slog.NewTextHandler(bufBase, &slog.HandlerOptions{Level: slog.LevelInfo}))
 	bufWarn := &bytes.Buffer{}
-	logWarn := logrus.New()
-	logWarn.SetOutput(bufWarn)
-	logWarn.SetLevel(logrus.InfoLevel)
+	logWarn := slog.New(slog.NewTextHandler(bufWarn, &slog.HandlerOptions{Level: slog.LevelInfo}))
 	wWarn := &Warning{Hook: NewHook(logWarn)}
 	ctxWarn := NewContext(ctxBase, wWarn)
 	bufEmpty := &bytes.Buffer{}
-	logEmpty := logrus.New()
-	logEmpty.SetOutput(bufEmpty)
-	logEmpty.SetLevel(logrus.InfoLevel)
+	logEmpty := slog.New(slog.NewTextHandler(bufEmpty, &slog.HandlerOptions{Level: slog.LevelInfo}))
 
 	// run without context
 	Handle(ctxBase, logBase, msg1)


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Partial fix for #749.

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This updates the `regclient` Go library. Existing users of `logrus` (including `regctl`, `regsync`, and `regbot`) will continue to work using a `logrus` handler to `slog`. Updates to the various commands will be made in a future commit.

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Feat: Refactor logging to use log/slog.
- Breaking: Warning handlers switched from `logrus` to `slog` which will only impact those with a custom warning handler.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
