### PR TITLE
Breaking: Disable legacy packages by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ VCS_VERSION?=$(shell vcs_describe="$$(git describe --all)"; \
   echo "$${vcs_version}" | sed -r 's#/+#-#g')
 VCS_TAG?=$(shell git describe --tags --abbrev=0 2>/dev/null || true)
 LD_FLAGS?=-s -w -extldflags -static -buildid= -X \"github.com/regclient/regclient/internal/version.vcsTag=$(VCS_TAG)\"
-GO_BUILD_FLAGS?=-trimpath -ldflags "$(LD_FLAGS)" -tags nolegacy
+GO_BUILD_FLAGS?=-trimpath -ldflags "$(LD_FLAGS)"
 DOCKERFILE_EXT?=$(shell if docker build --help 2>/dev/null | grep -q -- '--progress'; then echo ".buildkit"; fi)
 DOCKER_ARGS?=--build-arg "VCS_REF=$(VCS_REF)" --build-arg "VCS_VERSION=$(VCS_VERSION)"
 GOPATH?=$(shell go env GOPATH)

--- a/internal/retryable/error.go
+++ b/internal/retryable/error.go
@@ -1,5 +1,5 @@
-//go:build !nolegacy
-// +build !nolegacy
+//go:build legacy
+// +build legacy
 
 package retryable
 

--- a/internal/retryable/retryable.go
+++ b/internal/retryable/retryable.go
@@ -1,5 +1,5 @@
-//go:build !nolegacy
-// +build !nolegacy
+//go:build legacy
+// +build legacy
 
 // Package retryable is a legacy package, functionality has been moved to reghttp
 package retryable

--- a/regclient/blob/blob.go
+++ b/regclient/blob/blob.go
@@ -1,5 +1,5 @@
-//go:build !nolegacy
-// +build !nolegacy
+//go:build legacy
+// +build legacy
 
 // Package blob is a legacy package, this has been moved to the types/blob package
 package blob

--- a/regclient/config.go
+++ b/regclient/config.go
@@ -1,5 +1,5 @@
-//go:build !nolegacy
-// +build !nolegacy
+//go:build legacy
+// +build legacy
 
 // Legacy package, this has been moved to the config package
 

--- a/regclient/config/host.go
+++ b/regclient/config/host.go
@@ -1,5 +1,5 @@
-//go:build !nolegacy
-// +build !nolegacy
+//go:build legacy
+// +build legacy
 
 // Package config is a legacy package, this has been moved to the config package
 package config

--- a/regclient/error.go
+++ b/regclient/error.go
@@ -1,5 +1,5 @@
-//go:build !nolegacy
-// +build !nolegacy
+//go:build legacy
+// +build legacy
 
 // Legacy package, this has been moved to the types/error.go package
 

--- a/regclient/manifest/manifest.go
+++ b/regclient/manifest/manifest.go
@@ -1,5 +1,5 @@
-//go:build !nolegacy
-// +build !nolegacy
+//go:build legacy
+// +build legacy
 
 // Package manifest is a legacy package, this has been moved to the types/manifest package
 package manifest

--- a/regclient/mediatype.go
+++ b/regclient/mediatype.go
@@ -1,5 +1,5 @@
-//go:build !nolegacy
-// +build !nolegacy
+//go:build legacy
+// +build legacy
 
 // Legacy package, this has been moved to the top level types/mediatype.go package
 

--- a/regclient/regclient.go
+++ b/regclient/regclient.go
@@ -1,5 +1,5 @@
-//go:build !nolegacy
-// +build !nolegacy
+//go:build legacy
+// +build legacy
 
 //lint:file-ignore SA1019 Ignore deprecations since this entire package is deprecated
 

--- a/regclient/template.go
+++ b/regclient/template.go
@@ -1,5 +1,5 @@
-//go:build !nolegacy
-// +build !nolegacy
+//go:build legacy
+// +build legacy
 
 // Legacy package, this has been moved to the pkg/template package
 

--- a/regclient/types/error.go
+++ b/regclient/types/error.go
@@ -1,5 +1,5 @@
-//go:build !nolegacy
-// +build !nolegacy
+//go:build legacy
+// +build legacy
 
 // Legacy package, this has been moved to top level types package
 

--- a/regclient/types/mediatype.go
+++ b/regclient/types/mediatype.go
@@ -1,5 +1,5 @@
-//go:build !nolegacy
-// +build !nolegacy
+//go:build legacy
+// +build legacy
 
 // Legacy package, this has been moved to top level types package
 

--- a/regclient/types/ratelimit.go
+++ b/regclient/types/ratelimit.go
@@ -1,5 +1,5 @@
-//go:build !nolegacy
-// +build !nolegacy
+//go:build legacy
+// +build legacy
 
 // Legacy package, this has been moved to top level types package
 

--- a/regclient/types/ref.go
+++ b/regclient/types/ref.go
@@ -1,5 +1,5 @@
-//go:build !nolegacy
-// +build !nolegacy
+//go:build legacy
+// +build legacy
 
 // Legacy package, this has been moved to the types/ref package
 

--- a/regclient/types/types.go
+++ b/regclient/types/types.go
@@ -1,5 +1,5 @@
-//go:build !nolegacy
-// +build !nolegacy
+//go:build legacy
+// +build legacy
 
 // Package types is a legacy package, using the top level types package is recommended
 package types


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

This is a prerequisite for #749.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This switches the default build tag from `!nolegacy` to `legacy` so the packages are disabled by default. Legacy packages may still be used with `-tags legacy` added to the build. However, they may be permanently removed in a future release, and migrating to the newer packages is recommended.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

No changes should be visible for users that have moved off of deprecated packages.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Breaking: Disable legacy packages by default.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
