### PR TITLE
Feat: Move logrus calls into files excluded by wasm

### DIFF
--- a/cmd/regsync/root.go
+++ b/cmd/regsync/root.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/opencontainers/go-digest"
 	"github.com/robfig/cron/v3"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/regclient/regclient"
@@ -120,7 +119,7 @@ sync step is finished.`,
 	}
 
 	rootTopCmd.PersistentFlags().StringVarP(&rootOpts.confFile, "config", "c", "", "Config file")
-	rootTopCmd.PersistentFlags().StringVarP(&rootOpts.verbosity, "verbosity", "v", logrus.InfoLevel.String(), "Log level (debug, info, warn, error, fatal, panic)")
+	rootTopCmd.PersistentFlags().StringVarP(&rootOpts.verbosity, "verbosity", "v", slog.LevelInfo.String(), "Log level (debug, info, warn, error, fatal, panic)")
 	rootTopCmd.PersistentFlags().StringArrayVar(&rootOpts.logopts, "logopt", []string{}, "Log options")
 	versionCmd.Flags().StringVar(&rootOpts.format, "format", "{{printPretty .}}", "Format output with go template syntax")
 	onceCmd.Flags().BoolVar(&rootOpts.missing, "missing", false, "Only copy tags that are missing on target")

--- a/internal/sloghandle/logrus.go
+++ b/internal/sloghandle/logrus.go
@@ -1,3 +1,6 @@
+//go:build !wasm
+// +build !wasm
+
 // Package sloghandle provides a transition handler for migrating from logrus to slog.
 package sloghandle
 

--- a/internal/sloghandle/logrus_test.go
+++ b/internal/sloghandle/logrus_test.go
@@ -1,3 +1,6 @@
+//go:build !wasm
+// +build !wasm
+
 package sloghandle
 
 import (

--- a/regclient.go
+++ b/regclient.go
@@ -8,10 +8,7 @@ import (
 
 	"fmt"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/regclient/regclient/config"
-	"github.com/regclient/regclient/internal/sloghandle"
 	"github.com/regclient/regclient/internal/version"
 	"github.com/regclient/regclient/scheme"
 	"github.com/regclient/regclient/scheme/ocidir"
@@ -171,14 +168,6 @@ func WithDockerCredsFile(fname string) Opt {
 			return
 		}
 		rc.hostLoad("docker-file", configHosts)
-	}
-}
-
-// WithLog configuring logging with a logrus Logger.
-// Note that regclient has switched to log/slog for logging and my eventually deprecate logrus support.
-func WithLog(log *logrus.Logger) Opt {
-	return func(rc *RegClient) {
-		rc.slog = slog.New(sloghandle.Logrus(log))
 	}
 }
 

--- a/regclient_nowasm.go
+++ b/regclient_nowasm.go
@@ -1,0 +1,20 @@
+//go:build !wasm
+// +build !wasm
+
+package regclient
+
+import (
+	"log/slog"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/regclient/regclient/internal/sloghandle"
+)
+
+// WithLog configuring logging with a logrus Logger.
+// Note that regclient has switched to log/slog for logging and my eventually deprecate logrus support.
+func WithLog(log *logrus.Logger) Opt {
+	return func(rc *RegClient) {
+		rc.slog = slog.New(sloghandle.Logrus(log))
+	}
+}

--- a/scheme/ocidir/ocidir.go
+++ b/scheme/ocidir/ocidir.go
@@ -13,11 +13,8 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/regclient/regclient/internal/pqueue"
 	"github.com/regclient/regclient/internal/reqmeta"
-	"github.com/regclient/regclient/internal/sloghandle"
 	"github.com/regclient/regclient/types/descriptor"
 	"github.com/regclient/regclient/types/errs"
 	"github.com/regclient/regclient/types/mediatype"
@@ -80,14 +77,6 @@ func New(opts ...Opts) *OCIDir {
 func WithGC(gc bool) Opts {
 	return func(c *ociConf) {
 		c.gc = gc
-	}
-}
-
-// WithLog provides a logrus logger.
-// By default logging is disabled.
-func WithLog(log *logrus.Logger) Opts {
-	return func(c *ociConf) {
-		c.slog = slog.New(sloghandle.Logrus(log))
 	}
 }
 

--- a/scheme/ocidir/ocidir_nowasm.go
+++ b/scheme/ocidir/ocidir_nowasm.go
@@ -1,0 +1,20 @@
+//go:build !wasm
+// +build !wasm
+
+package ocidir
+
+import (
+	"log/slog"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/regclient/regclient/internal/sloghandle"
+)
+
+// WithLog provides a logrus logger.
+// By default logging is disabled.
+func WithLog(log *logrus.Logger) Opts {
+	return func(c *ociConf) {
+		c.slog = slog.New(sloghandle.Logrus(log))
+	}
+}

--- a/scheme/reg/reg.go
+++ b/scheme/reg/reg.go
@@ -7,14 +7,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/regclient/regclient/config"
 	"github.com/regclient/regclient/internal/cache"
 	"github.com/regclient/regclient/internal/pqueue"
 	"github.com/regclient/regclient/internal/reghttp"
 	"github.com/regclient/regclient/internal/reqmeta"
-	"github.com/regclient/regclient/internal/sloghandle"
 	"github.com/regclient/regclient/types/manifest"
 	"github.com/regclient/regclient/types/ref"
 	"github.com/regclient/regclient/types/referrer"
@@ -234,14 +231,6 @@ func WithDelay(delayInit time.Duration, delayMax time.Duration) Opts {
 func WithHTTPClient(hc *http.Client) Opts {
 	return func(r *Reg) {
 		r.reghttpOpts = append(r.reghttpOpts, reghttp.WithHTTPClient(hc))
-	}
-}
-
-// WithLog injects a logrus Logger configuration
-func WithLog(log *logrus.Logger) Opts {
-	return func(r *Reg) {
-		r.slog = slog.New(sloghandle.Logrus(log))
-		r.reghttpOpts = append(r.reghttpOpts, reghttp.WithLog(r.slog))
 	}
 }
 

--- a/scheme/reg/reg_nowasm.go
+++ b/scheme/reg/reg_nowasm.go
@@ -1,0 +1,21 @@
+//go:build !wasm
+// +build !wasm
+
+package reg
+
+import (
+	"log/slog"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/regclient/regclient/internal/reghttp"
+	"github.com/regclient/regclient/internal/sloghandle"
+)
+
+// WithLog injects a logrus Logger configuration
+func WithLog(log *logrus.Logger) Opts {
+	return func(r *Reg) {
+		r.slog = slog.New(sloghandle.Logrus(log))
+		r.reghttpOpts = append(r.reghttpOpts, reghttp.WithLog(r.slog))
+	}
+}


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Fixes #749.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This is the last part of the changes to move from logrus to slog. wasm binaries will now compile. Note that the project does not explicitly support wasm since it requires filesystem and network access typically blocked by the wasm sandbox.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
GOOS=wasip1 GOARCH=wasm go build -o bin/regctl.wasm ./cmd/regctl/
```

<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Feat: Move logrus calls into files excluded by wasm.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
