### PR TITLE
Feat: Allow plus in ocidir path

### DIFF
--- a/types/ref/ref.go
+++ b/types/ref/ref.go
@@ -29,7 +29,7 @@ var (
 	hostUpperS  = `(?:[a-zA-Z0-9]*[A-Z][a-zA-Z0-9-]*[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[A-Z][a-zA-Z0-9]*)`
 	registryS   = `(?:` + hostDomainS + `|` + hostPortS + `|` + hostUpperS + `|localhost(?:` + regexp.QuoteMeta(`:`) + `[0-9]+)?)`
 	repoPartS   = `[a-z0-9]+(?:(?:\.|_|__|-+)[a-z0-9]+)*`
-	pathS       = `[/a-zA-Z0-9_\-. ~]+`
+	pathS       = `[/a-zA-Z0-9_\-. ~\+]+`
 	tagS        = `[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}`
 	digestS     = `[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,}`
 	schemeRE    = regexp.MustCompile(`^([a-z]+)://(.+)$`)

--- a/types/ref/ref_test.go
+++ b/types/ref/ref_test.go
@@ -305,13 +305,13 @@ func TestNew(t *testing.T) {
 		},
 		{
 			name:       "OCI dir with tilde",
-			ref:        "ocidir://path/2/~dir~/rules_oci~/examples:latest",
+			ref:        "ocidir://path/2/~dir~/+rules_oci+/examples:latest",
 			scheme:     "ocidir",
 			registry:   "",
 			repository: "",
 			tag:        "latest",
 			digest:     "",
-			path:       "path/2/~dir~/rules_oci~/examples",
+			path:       "path/2/~dir~/+rules_oci+/examples",
 			wantE:      nil,
 		},
 		{


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Fixes #855.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This adds a plus to the list of allowed path characters in an OCI Layout reference.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
regctl image copy ocidir://output/regctl:scratch ocidir://test/path+with+plus:latest
```

<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Feat: Allow plus in ocidir path.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
