### PR TITLE
Add -o option to image export and export of multiple images

### DIFF
--- a/cmd/regbot/sandbox/image.go
+++ b/cmd/regbot/sandbox/image.go
@@ -250,7 +250,7 @@ func (s *Sandbox) imageExportTar(ls *lua.LState) int {
 	if err != nil {
 		ls.RaiseError("Failed to open \"%s\": %v", file, err)
 	}
-	err = s.rc.ImageExport(s.ctx, src.r, fh)
+	err = s.rc.ImageExport(s.ctx, []ref.Ref{src.r}, fh)
 	if err != nil {
 		ls.RaiseError("Failed to export image \"%s\" to \"%s\": %v", src.r.CommonName(), file, err)
 	}

--- a/cmd/regctl/image_test.go
+++ b/cmd/regctl/image_test.go
@@ -97,7 +97,9 @@ func TestImageCreate(t *testing.T) {
 
 func TestImageExportImport(t *testing.T) {
 	tmpDir := t.TempDir()
-	srcRef := "ocidir://../../testdata/testrepo:v2"
+	testRepo := "ocidir://../../testdata/testrepo"
+	srcRef := testRepo + ":v2"
+	srcRef2 := testRepo + ":v3"
 	exportFile := tmpDir + "/export.tar"
 	exportName := "registry.example.com/repo:v2"
 	importRefA := fmt.Sprintf("ocidir://%s/repo:v2", tmpDir)
@@ -119,6 +121,14 @@ func TestImageExportImport(t *testing.T) {
 	}
 
 	out, err = cobraTest(t, nil, "image", "export", "--name", exportName, "--platform", "linux/amd64", srcRef, exportFile)
+	if err != nil {
+		t.Fatalf("failed to run image export: %v", err)
+	}
+	if out != "" {
+		t.Errorf("unexpected output: %v", out)
+	}
+
+	out, err = cobraTest(t, nil, "image", "export", "--platform", "linux/amd64", "-o", exportFile, srcRef, srcRef2)
 	if err != nil {
 		t.Fatalf("failed to run image export: %v", err)
 	}

--- a/image.go
+++ b/image.go
@@ -1012,9 +1012,11 @@ func imageSeenOrWait(ctx context.Context, opt *imageOpt, tag string, dig digest.
 //   - blobs/$algo/$hash: each content addressable object (manifest, config, or layer), created recursively
 //
 // [OCI Layout]: https://github.com/opencontainers/image-spec/blob/master/image-layout.md
-func (rc *RegClient) ImageExport(ctx context.Context, r ref.Ref, outStream io.Writer, opts ...ImageOpts) error {
-	if !r.IsSet() {
-		return fmt.Errorf("ref is not set: %s%.0w", r.CommonName(), errs.ErrInvalidReference)
+func (rc *RegClient) ImageExport(ctx context.Context, refs []ref.Ref, outStream io.Writer, opts ...ImageOpts) error {
+	for _, r := range refs {
+		if !r.IsSet() {
+			return fmt.Errorf("ref is not set: %s%.0w", r.CommonName(), errs.ErrInvalidReference)
+		}
 	}
 	var ociIndex v1.Index
 
@@ -1022,8 +1024,8 @@ func (rc *RegClient) ImageExport(ctx context.Context, r ref.Ref, outStream io.Wr
 	for _, optFn := range opts {
 		optFn(&opt)
 	}
-	if opt.exportRef.IsZero() {
-		opt.exportRef = r
+	if !opt.exportRef.IsZero() && len(refs) > 1 {
+		return fmt.Errorf("multiple refs are not supported with export ref: %s", opt.exportRef.CommonName())
 	}
 
 	// dedup warnings
@@ -1046,83 +1048,101 @@ func (rc *RegClient) ImageExport(ctx context.Context, r ref.Ref, outStream io.Wr
 		mode:  0644,
 	}
 
-	// retrieve image manifest
-	m, err := rc.ManifestGet(ctx, r)
-	if err != nil {
-		rc.slog.Warn("Failed to get manifest",
-			slog.String("ref", r.CommonName()),
-			slog.String("err", err.Error()))
-		return err
-	}
-
 	// build/write oci-layout
 	ociLayout := v1.ImageLayout{Version: ociLayoutVersion}
-	err = twd.tarWriteFileJSON(ociLayoutFilename, ociLayout)
+	err := twd.tarWriteFileJSON(ociLayoutFilename, ociLayout)
 	if err != nil {
 		return err
 	}
 
-	// create a manifest descriptor
-	mDesc := m.GetDescriptor()
-	if mDesc.Annotations == nil {
-		mDesc.Annotations = map[string]string{}
-	}
-	mDesc.Annotations[annotationImageName] = opt.exportRef.CommonName()
-	mDesc.Annotations[annotationRefName] = opt.exportRef.Tag
-
-	// generate/write an OCI index
+	// generate an OCI index
 	ociIndex.Versioned = v1.IndexSchemaVersion
-	ociIndex.Manifests = []descriptor.Descriptor{mDesc} // initialize with the descriptor to the manifest list
+	ociIndex.Manifests = []descriptor.Descriptor{} // initialize with the descriptor to the manifest list
+
+	// generate legacy docker manifests
+	dockerManifests := []dockerTarManifest{}
+
+	for _, r := range refs {
+		// retrieve image manifest
+		m, err := rc.ManifestGet(ctx, r)
+		if err != nil {
+			rc.slog.Warn("Failed to get manifest",
+				slog.String("ref", r.CommonName()),
+				slog.String("err", err.Error()))
+			return err
+		}
+
+		var er ref.Ref
+		if opt.exportRef.IsZero() {
+			// Clear the Digest
+			er = r.SetTag(r.Tag)
+		} else {
+			er = opt.exportRef
+		}
+		// create a manifest descriptor
+		mDesc := m.GetDescriptor()
+		if mDesc.Annotations == nil {
+			mDesc.Annotations = map[string]string{}
+		}
+		mDesc.Annotations[annotationImageName] = er.CommonName()
+		mDesc.Annotations[annotationRefName] = er.Tag
+		ociIndex.Manifests = append(ociIndex.Manifests, mDesc)
+
+		// append to docker manifest with tag, config filename, each layer filename, and layer descriptors
+		if mi, ok := m.(manifest.Imager); ok {
+			conf, err := mi.GetConfig()
+			if err != nil {
+				return err
+			}
+			if err = conf.Digest.Validate(); err != nil {
+				return err
+			}
+			refTag := er.ToReg()
+			if refTag.Digest != "" {
+				refTag.Digest = ""
+			}
+			if refTag.Tag == "" {
+				refTag.Tag = "latest"
+			}
+			dockerManifest := dockerTarManifest{
+				RepoTags:     []string{refTag.CommonName()},
+				Config:       tarOCILayoutDescPath(conf),
+				Layers:       []string{},
+				LayerSources: map[digest.Digest]descriptor.Descriptor{},
+			}
+			dl, err := mi.GetLayers()
+			if err != nil {
+				return err
+			}
+			for _, d := range dl {
+				if err = d.Digest.Validate(); err != nil {
+					return err
+				}
+				dockerManifest.Layers = append(dockerManifest.Layers, tarOCILayoutDescPath(d))
+				dockerManifest.LayerSources[d.Digest] = d
+			}
+			dockerManifests = append(dockerManifests, dockerManifest)
+		}
+
+		// recursively include manifests and nested blobs
+		err = rc.imageExportDescriptor(ctx, r, mDesc, twd)
+		if err != nil {
+			return err
+		}
+	}
+
+	// write an OCI index
 	err = twd.tarWriteFileJSON(ociIndexFilename, ociIndex)
 	if err != nil {
 		return err
 	}
 
-	// append to docker manifest with tag, config filename, each layer filename, and layer descriptors
-	if mi, ok := m.(manifest.Imager); ok {
-		conf, err := mi.GetConfig()
+	// marshal manifest and write manifest.json
+	if len(dockerManifests) > 1 {
+		err = twd.tarWriteFileJSON(dockerManifestFilename, dockerManifests)
 		if err != nil {
 			return err
 		}
-		if err = conf.Digest.Validate(); err != nil {
-			return err
-		}
-		refTag := opt.exportRef.ToReg()
-		if refTag.Digest != "" {
-			refTag.Digest = ""
-		}
-		if refTag.Tag == "" {
-			refTag.Tag = "latest"
-		}
-		dockerManifest := dockerTarManifest{
-			RepoTags:     []string{refTag.CommonName()},
-			Config:       tarOCILayoutDescPath(conf),
-			Layers:       []string{},
-			LayerSources: map[digest.Digest]descriptor.Descriptor{},
-		}
-		dl, err := mi.GetLayers()
-		if err != nil {
-			return err
-		}
-		for _, d := range dl {
-			if err = d.Digest.Validate(); err != nil {
-				return err
-			}
-			dockerManifest.Layers = append(dockerManifest.Layers, tarOCILayoutDescPath(d))
-			dockerManifest.LayerSources[d.Digest] = d
-		}
-
-		// marshal manifest and write manifest.json
-		err = twd.tarWriteFileJSON(dockerManifestFilename, []dockerTarManifest{dockerManifest})
-		if err != nil {
-			return err
-		}
-	}
-
-	// recursively include manifests and nested blobs
-	err = rc.imageExportDescriptor(ctx, r, mDesc, twd)
-	if err != nil {
-		return err
 	}
 
 	return nil

--- a/image_test.go
+++ b/image_test.go
@@ -447,7 +447,7 @@ func TestExportImport(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create output tar: %v", err)
 	}
-	err = rc.ImageExport(ctx, rIn1, fileOut1)
+	err = rc.ImageExport(ctx, []ref.Ref{rIn1}, fileOut1)
 	fileOut1.Close()
 	if err != nil {
 		t.Errorf("failed to export: %v", err)
@@ -456,7 +456,7 @@ func TestExportImport(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create output tar: %v", err)
 	}
-	err = rc.ImageExport(ctx, rIn3, fileOut3, ImageWithExportCompress())
+	err = rc.ImageExport(ctx, []ref.Ref{rIn3}, fileOut3, ImageWithExportCompress())
 	fileOut3.Close()
 	if err != nil {
 		t.Errorf("failed to export: %v", err)


### PR DESCRIPTION
### Fixes issue

Fixes #710 of packing multiple images in one tar.

### Describe the change

Add option `-o` or `--output` for the output. With this option it uses all arguments as image references to export. Without the option it maintains backwards compatibility by taking the second argument of two arguments as output file name.

The `--name` option is rejected if multiple images are exported.

### How to verify it

Test with commands like

```
regctl image export --platform amd64 alpine | tar xvvf - -O index.json manifest.json| jq
regctl image export --platform amd64 -o - alpine alpine:edge | tar xvvf - -O index.json manifest.json| jq
regctl image export --platform amd64 -o - alpine alpine:edge alpine:3.19 | tar xvvf - -O index.json manifest.json | jq
regctl image export --platform amd64 -o - alpine alpine:edge alpine:3.19 | docker image load
```

Without the `--platform` option the manifest.json is empty and I left it out. The docker may require "containerd-snapshotter" feature to be turned on to import OCI tar without manifest.json.

### Changelog text

Add image export -o/--output option and support for exporting multiple images.

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
