### PR TITLE
Add image save to export multiple images in same tar

### DIFF
--- a/cmd/regctl/image_test.go
+++ b/cmd/regctl/image_test.go
@@ -227,3 +227,19 @@ func TestImageMod(t *testing.T) {
 		})
 	}
 }
+
+func TestImageSave(t *testing.T) {
+	tmpDir := t.TempDir()
+	testRepo := "ocidir://../../testdata/testrepo"
+	srcRef := testRepo + ":v2"
+	srcRef2 := testRepo + ":v3"
+	exportFile := tmpDir + "/export.tar"
+
+	out, err := cobraTest(t, nil, "image", "save", "--platform", "linux/amd64", "-o", exportFile, srcRef, srcRef2)
+	if err != nil {
+		t.Fatalf("failed to run image export: %v", err)
+	}
+	if out != "" {
+		t.Errorf("unexpected output: %v", out)
+	}
+}


### PR DESCRIPTION
### Fixes issue

Fixes #710 of packing multiple images in one tar.

Implements the changes requested in the closed PR #857.

### Describe the change

Add new subcommand `save` with option `-o` or `--output` for the output file.

### How to verify it

Test with commands like

```
regctl image save --platform amd64 alpine | tar xvvf - -O index.json manifest.json | jq
regctl image save --platform amd64 alpine alpine:edge alpine:3.19 | tar xvvf - -O index.json manifest.json | jq
regctl image save --platform amd64 alpine alpine:edge alpine:3.19 | docker image load
```

Without the `--platform` option the manifest.json is empty and I left it out. The docker may require "containerd-snapshotter" feature to be turned on to import OCI tar without manifest.json.

### Changelog text

Add image save subcommand for exporting multiple images in same tar.

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
