### PR TITLE
Feat: Include source in referrers response

### DIFF
--- a/referrer.go
+++ b/referrer.go
@@ -14,20 +14,20 @@ import (
 
 // ReferrerList retrieves a list of referrers to a manifest.
 // The descriptor list should contain manifests that each have a subject field matching the requested ref.
-func (rc *RegClient) ReferrerList(ctx context.Context, r ref.Ref, opts ...scheme.ReferrerOpts) (referrer.ReferrerList, error) {
-	if !r.IsSet() {
-		return referrer.ReferrerList{}, fmt.Errorf("ref is not set: %s%.0w", r.CommonName(), errs.ErrInvalidReference)
+func (rc *RegClient) ReferrerList(ctx context.Context, rSubject ref.Ref, opts ...scheme.ReferrerOpts) (referrer.ReferrerList, error) {
+	if !rSubject.IsSet() {
+		return referrer.ReferrerList{}, fmt.Errorf("ref is not set: %s%.0w", rSubject.CommonName(), errs.ErrInvalidReference)
 	}
 	// dedup warnings
 	if w := warning.FromContext(ctx); w == nil {
 		ctx = warning.NewContext(ctx, &warning.Warning{Hook: warning.DefaultHook()})
 	}
-	// resolve ref to a digest
+	// set the digest on the subject reference
 	config := scheme.ReferrerConfig{}
 	for _, opt := range opts {
 		opt(&config)
 	}
-	if r.Digest == "" || config.Platform != "" {
+	if rSubject.Digest == "" || config.Platform != "" {
 		mo := []ManifestOpts{WithManifestRequireDigest()}
 		if config.Platform != "" {
 			p, err := platform.Parse(config.Platform)
@@ -36,19 +36,22 @@ func (rc *RegClient) ReferrerList(ctx context.Context, r ref.Ref, opts ...scheme
 			}
 			mo = append(mo, WithManifestPlatform(p))
 		}
-		m, err := rc.ManifestHead(ctx, r, mo...)
+		m, err := rc.ManifestHead(ctx, rSubject, mo...)
 		if err != nil {
 			return referrer.ReferrerList{}, fmt.Errorf("failed to get digest for subject: %w", err)
 		}
-		r = r.SetDigest(m.GetDescriptor().Digest.String())
+		rSubject = rSubject.SetDigest(m.GetDescriptor().Digest.String())
 	}
-	// update for a new referrer source repo if requested
-	if !config.SrcRepo.IsZero() {
-		r = config.SrcRepo.SetDigest(r.Digest)
+	// lookup the scheme for the appropriate ref
+	var r ref.Ref
+	if config.SrcRepo.IsSet() {
+		r = config.SrcRepo
+	} else {
+		r = rSubject
 	}
 	schemeAPI, err := rc.schemeGet(r.Scheme)
 	if err != nil {
 		return referrer.ReferrerList{}, err
 	}
-	return schemeAPI.ReferrerList(ctx, r, opts...)
+	return schemeAPI.ReferrerList(ctx, rSubject, opts...)
 }

--- a/scheme/scheme.go
+++ b/scheme/scheme.go
@@ -175,6 +175,7 @@ func WithReferrerSort(annotation string, desc bool) ReferrerOpts {
 func ReferrerFilter(config ReferrerConfig, rlIn referrer.ReferrerList) referrer.ReferrerList {
 	return referrer.ReferrerList{
 		Subject:     rlIn.Subject,
+		Source:      rlIn.Source,
 		Manifest:    rlIn.Manifest,
 		Annotations: rlIn.Annotations,
 		Tags:        rlIn.Tags,


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Include the source in the referrers response when the referrers are pulled from a location other than the subject repository. This simplifies handling external sources.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
$ echo "Alpine Linux" | regctl artifact put --subject alpine ocidir://test/external:alpine-info --artifact-type application/example.contents

$ regctl artifact list alpine --external ocidir://test/external
Subject:        docker.io/library/alpine@sha256:1e42bbe2508154c9126d48c2b8a75420c3544343bf86fd041fb7527e017a4b4a
Source:         ocidir://test/external

Referrers:

  Name:         ocidir://test/external@sha256:5f685e999e50aecd719512de9443c9bac27f60056580f6c3bdaf18d75c1c9ab3
  Digest:       sha256:5f685e999e50aecd719512de9443c9bac27f60056580f6c3bdaf18d75c1c9ab3
  MediaType:    application/vnd.oci.image.manifest.v1+json
  ArtifactType: application/example.contents
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Feat: Include source in referrers response.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
