### PR TITLE
Feat: Add external flag to regctl artifact put

### DIFF
--- a/cmd/regctl/artifact_test.go
+++ b/cmd/regctl/artifact_test.go
@@ -232,9 +232,31 @@ func TestArtifactPut(t *testing.T) {
 			in:   testData,
 		},
 		{
-			name: "Put external subject",
+			name: "Put subject to external repo",
+			args: []string{"artifact", "put", "--artifact-type", "application/vnd.example", "--subject", "ocidir://" + testDir + ":put-example-at", "--external", "ocidir://" + testDir + "/external"},
+			in:   testData,
+		},
+		{
+			name: "Put subject to external name",
 			args: []string{"artifact", "put", "--artifact-type", "application/vnd.example", "--subject", "ocidir://" + testDir + ":put-example-at", "ocidir://" + testDir + "/external:external-subj"},
 			in:   testData,
+		},
+		{
+			name: "Put subject to external repo and name",
+			args: []string{"artifact", "put", "--artifact-type", "application/vnd.example", "--subject", "ocidir://" + testDir + ":put-example-at", "--external", "ocidir://" + testDir + "/external", "ocidir://" + testDir + "/external:external-subj"},
+			in:   testData,
+		},
+		{
+			name:      "Put external name without subject",
+			args:      []string{"artifact", "put", "--artifact-type", "application/vnd.example", "--external", "ocidir://" + testDir + "/external", "ocidir://" + testDir + "/external:external-subj"},
+			in:        testData,
+			expectErr: errs.ErrUnsupported,
+		},
+		{
+			name:      "Put subject to external repo and different name",
+			args:      []string{"artifact", "put", "--artifact-type", "application/vnd.example", "--subject", "ocidir://" + testDir + ":put-example-at", "--external", "ocidir://" + testDir + "/external", "ocidir://" + testDir + "/copy:copy-subj"},
+			in:        testData,
+			expectErr: errs.ErrUnsupported,
 		},
 		{
 			name: "Put create index",


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This adds a `--external` flag to `regctl artifact put`, aligning it with other `regctl artifact` commands.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
echo "hello external artifact" | regctl artifact put --subject alpine --external ocidir://test/external --artifact-type applicaiton/example.test 
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Feat: Add external flag to regctl artifact put.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
