### PR TITLE
Feat: Copy image with external referrers

### DIFF
--- a/cmd/regctl/image_test.go
+++ b/cmd/regctl/image_test.go
@@ -62,6 +62,11 @@ func TestImageCopy(t *testing.T) {
 			args:      []string{"image", "copy", "--platform", "linux/amd64", tsHost + "/testrepo:v3", tsHost + "/newrepo:v3"},
 			expectOut: tsHost + "/newrepo:v3",
 		},
+		{
+			name:      "ocidir-to-reg-external-referrers",
+			args:      []string{"image", "copy", srcRef, tsHost + "/newrepo:v4", "--referrers", "--referrers-src", "ocidir://../../testdata/external", "--referrers-tgt", tsHost + "/external"},
+			expectOut: tsHost + "/newrepo:v4",
+		},
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {

--- a/image_test.go
+++ b/image_test.go
@@ -290,6 +290,14 @@ func TestCopy(t *testing.T) {
 			TLS:      config.TLSDisabled,
 		},
 	}
+	rReferrerSrc, err := ref.New("ocidir://./testdata/external")
+	if err != nil {
+		t.Fatalf("failed to parse referrer src repo: %v", err)
+	}
+	rReferrerTgt, err := ref.New(tsHost + "/dest-external")
+	if err != nil {
+		t.Fatalf("failed to parse referrer tgt repo: %v", err)
+	}
 	log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
 	delayInit, _ := time.ParseDuration("0.05s")
 	delayMax, _ := time.ParseDuration("0.10s")
@@ -348,6 +356,12 @@ func TestCopy(t *testing.T) {
 			src:  tsHost + "/testrepo:v2",
 			tgt:  tsHost + "/dest-reg:v2",
 			opts: []ImageOpts{ImageWithReferrers(), ImageWithDigestTags()},
+		},
+		{
+			name: "ocidir to registry with external referrers and digest tags",
+			src:  "ocidir://./testdata/testrepo:v2",
+			tgt:  tsHost + "/dest-ocidir:v2",
+			opts: []ImageOpts{ImageWithReferrers(), ImageWithDigestTags(), ImageWithReferrerSrc(rReferrerSrc), ImageWithReferrerTgt(rReferrerTgt)},
 		},
 		{
 			name: "ocidir to registry with fast check",


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Add the ability to copy images with external source and/or target referrer repositories.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
echo "hello external artifact" | regctl artifact put --subject alpine --external ocidir://test/external --artifact-type application/example.test
regctl image copy alpine localhost:5002/library/alpine --referrers --referrers-src ocidir://test/external --referrers-tgt localhost:5002/external
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Feat: Copy image with external referrers.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
