### PR TITLE
Feat: Support incomplete subject descriptor

### DIFF
--- a/scheme/ocidir/manifest.go
+++ b/scheme/ocidir/manifest.go
@@ -49,7 +49,7 @@ func (o *OCIDir) ManifestDelete(ctx context.Context, r ref.Ref, opts ...scheme.M
 	if mc.Manifest != nil {
 		if ms, ok := mc.Manifest.(manifest.Subjecter); ok {
 			sDesc, err := ms.GetSubject()
-			if err == nil && sDesc != nil && sDesc.MediaType != "" && sDesc.Size > 0 {
+			if err == nil && sDesc != nil && sDesc.Digest != "" {
 				// attempt to delete the referrer, but ignore if the referrer entry wasn't found
 				err = o.referrerDelete(ctx, r, mc.Manifest)
 				if err != nil && !errors.Is(err, errs.ErrNotFound) && !errors.Is(err, fs.ErrNotExist) {
@@ -288,7 +288,7 @@ func (o *OCIDir) manifestPut(ctx context.Context, r ref.Ref, m manifest.Manifest
 		if err != nil {
 			return err
 		}
-		if mDesc != nil && mDesc.MediaType != "" && mDesc.Size > 0 {
+		if mDesc != nil && mDesc.Digest != "" {
 			err = o.referrerPut(ctx, r, m)
 			if err != nil {
 				return err

--- a/scheme/ocidir/referrer.go
+++ b/scheme/ocidir/referrer.go
@@ -90,7 +90,7 @@ func (o *OCIDir) referrerDelete(ctx context.Context, r ref.Ref, m manifest.Manif
 		return err
 	}
 	// validate/set subject descriptor
-	if subject == nil || subject.MediaType == "" || subject.Digest == "" || subject.Size <= 0 {
+	if subject == nil || subject.Digest == "" {
 		return fmt.Errorf("subject is not set%.0w", errs.ErrNotFound)
 	}
 
@@ -134,7 +134,7 @@ func (o *OCIDir) referrerPut(ctx context.Context, r ref.Ref, m manifest.Manifest
 		return err
 	}
 	// validate/set subject descriptor
-	if subject == nil || subject.MediaType == "" || subject.Digest == "" || subject.Size <= 0 {
+	if subject == nil || subject.Digest == "" {
 		return fmt.Errorf("subject is not set%.0w", errs.ErrNotFound)
 	}
 

--- a/scheme/ocidir/referrer_test.go
+++ b/scheme/ocidir/referrer_test.go
@@ -93,6 +93,10 @@ func TestReferrer(t *testing.T) {
 		extraAnnot: extraValueB,
 		timeAnnot:  "2021-02-03T04:05:06Z",
 	}
+	// test with a partial subject descriptor containing only the digest
+	mDescPartial := descriptor.Descriptor{
+		Digest: mDesc.Digest,
+	}
 	artifactB := v1.ArtifactManifest{
 		MediaType:    mediatype.OCI1Artifact,
 		ArtifactType: bType,
@@ -104,7 +108,7 @@ func TestReferrer(t *testing.T) {
 			},
 		},
 		Annotations: artifactBAnnot,
-		Subject:     &mDesc,
+		Subject:     &mDescPartial,
 	}
 	artifactBM, err := manifest.New(manifest.WithOrig(artifactB))
 	if err != nil {

--- a/scheme/reg/manifest.go
+++ b/scheme/reg/manifest.go
@@ -49,7 +49,7 @@ func (reg *Reg) ManifestDelete(ctx context.Context, r ref.Ref, opts ...scheme.Ma
 	if mc.Manifest != nil {
 		if mr, ok := mc.Manifest.(manifest.Subjecter); ok {
 			sDesc, err := mr.GetSubject()
-			if err == nil && sDesc != nil && sDesc.MediaType != "" && sDesc.Size > 0 {
+			if err == nil && sDesc != nil && sDesc.Digest != "" {
 				// attempt to delete the referrer, but ignore if the referrer entry wasn't found
 				err = reg.referrerDelete(ctx, r, mc.Manifest)
 				if err != nil && !errors.Is(err, errs.ErrNotFound) {
@@ -279,7 +279,7 @@ func (reg *Reg) ManifestPut(ctx context.Context, r ref.Ref, m manifest.Manifest,
 		if err != nil {
 			return err
 		}
-		if mDesc != nil && mDesc.MediaType != "" && mDesc.Size > 0 && mDesc.Digest.String() != "" {
+		if mDesc != nil && mDesc.Digest.String() != "" {
 			rSubj := r.SetDigest(mDesc.Digest.String())
 			reg.cacheRL.Delete(rSubj)
 			if mDesc.Digest.String() != resp.HTTPResponse().Header.Get(OCISubjectHeader) {

--- a/scheme/reg/referrer.go
+++ b/scheme/reg/referrer.go
@@ -246,7 +246,7 @@ func (reg *Reg) referrerDelete(ctx context.Context, r ref.Ref, m manifest.Manife
 		return err
 	}
 	// validate/set subject descriptor
-	if subject == nil || subject.MediaType == "" || subject.Digest == "" || subject.Size <= 0 {
+	if subject == nil || subject.Digest == "" {
 		return fmt.Errorf("refers is not set%.0w", errs.ErrNotFound)
 	}
 
@@ -299,7 +299,7 @@ func (reg *Reg) referrerPut(ctx context.Context, r ref.Ref, m manifest.Manifest)
 		return err
 	}
 	// validate/set subject descriptor
-	if subject == nil || subject.MediaType == "" || subject.Digest == "" || subject.Size <= 0 {
+	if subject == nil || subject.Digest == "" {
 		return fmt.Errorf("subject is not set%.0w", errs.ErrNotFound)
 	}
 
@@ -322,7 +322,7 @@ func (reg *Reg) referrerPut(ctx context.Context, r ref.Ref, m manifest.Manifest)
 		if err != nil {
 			return err
 		}
-		if mDesc != nil && mDesc.MediaType != "" && mDesc.Size > 0 {
+		if mDesc != nil && mDesc.Digest != "" {
 			return fmt.Errorf("fallback referrers manifest should not have a subject: %s", rSubject.CommonName())
 		}
 	}

--- a/scheme/reg/referrer_test.go
+++ b/scheme/reg/referrer_test.go
@@ -109,9 +109,8 @@ func TestReferrer(t *testing.T) {
 		},
 		Annotations: artifact2Annot,
 		Subject: &descriptor.Descriptor{
-			MediaType: mediatype.Docker2Manifest,
-			Size:      int64(mLen),
-			Digest:    mDigest,
+			// handle spec violations (images without a media type and size on the subject)
+			Digest: mDigest,
 		},
 	}
 	artifact2M, err := manifest.New(manifest.WithOrig(artifact2))


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

While the descriptor requires a size and media type, the referrer API does not. This makes regclient more tolerant of non-conformant implementations by only requiring the digest to consume the subject field.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
go test ./scheme/...
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Feat: Support incomplete subject descriptor.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
