### PR TITLE
Fix: Do not request offline refresh token

### DIFF
--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"io"
@@ -93,6 +94,12 @@ func TestParseAuthHeader(t *testing.T) {
 // TestAuth checks the auth interface using a mock http server
 func TestAuth(t *testing.T) {
 	t.Parallel()
+	user := "user"
+	pass := "pass"
+	userPassEnc := base64.StdEncoding.EncodeToString([]byte(user + ":" + pass))
+	credsFn := func(s string) Cred {
+		return Cred{User: user, Password: pass}
+	}
 	clientID := "testClient"
 	token1Resp, _ := json.Marshal(bearerToken{
 		Token:     "token1",
@@ -109,11 +116,35 @@ func TestAuth(t *testing.T) {
 	rrs := []reqresp.ReqResp{
 		{
 			ReqEntry: reqresp.ReqEntry{
-				Name:   "req token1",
+				Name:   "req token1 POST",
 				Method: "POST",
 				Path:   "/token1",
+			},
+			RespEntry: reqresp.RespEntry{
+				Status: http.StatusNotFound,
+			},
+		},
+		{
+			ReqEntry: reqresp.ReqEntry{
+				Name:   "req token2 POST",
+				Method: "POST",
+				Path:   "/token2",
+			},
+			RespEntry: reqresp.RespEntry{
+				Status: http.StatusNotFound,
+			},
+		},
+		{
+			ReqEntry: reqresp.ReqEntry{
+				Name:   "req token1 GET",
+				Method: "GET",
+				Path:   "/token1",
 				Headers: http.Header{
-					"User-Agent": []string{clientID},
+					"Authorization": {"Basic " + userPassEnc},
+					"User-Agent":    []string{clientID},
+				},
+				Query: map[string][]string{
+					"scope": {"repository:reponame:pull"},
 				},
 			},
 			RespEntry: reqresp.RespEntry{
@@ -123,24 +154,11 @@ func TestAuth(t *testing.T) {
 		},
 		{
 			ReqEntry: reqresp.ReqEntry{
-				Name:   "req token2 POST",
-				Method: "POST",
-				Path:   "/token2",
-				Headers: http.Header{
-					"User-Agent": []string{clientID},
-				},
-			},
-			RespEntry: reqresp.RespEntry{
-				Status: http.StatusNotFound,
-			},
-		},
-		{
-			ReqEntry: reqresp.ReqEntry{
 				Name:   "req token2 GET",
 				Method: "GET",
 				Path:   "/token2",
 				Headers: http.Header{
-					"Authorization": {"Basic dXNlcjpwYXNz"},
+					"Authorization": {"Basic " + userPassEnc},
 					"User-Agent":    []string{clientID},
 				},
 				Query: map[string][]string{
@@ -187,9 +205,7 @@ func TestAuth(t *testing.T) {
 		{
 			name: "basic",
 			auth: NewAuth(
-				WithCreds(func(s string) Cred {
-					return Cred{User: "user", Password: "pass"}
-				}),
+				WithCreds(credsFn),
 			),
 			handleResponse: &http.Response{
 				Request: &http.Request{
@@ -204,15 +220,13 @@ func TestAuth(t *testing.T) {
 				URL:    tsURL,
 				Header: http.Header{},
 			},
-			wantAuthHeader: "Basic dXNlcjpwYXNz",
+			wantAuthHeader: "Basic " + userPassEnc,
 		},
 		{
 			name: "bearer1",
 			auth: NewAuth(
 				WithClientID(clientID),
-				WithCreds(func(s string) Cred {
-					return Cred{User: "user", Password: "pass"}
-				}),
+				WithCreds(credsFn),
 			),
 			handleResponse: &http.Response{
 				Request: &http.Request{
@@ -235,9 +249,7 @@ func TestAuth(t *testing.T) {
 			name: "bearer2",
 			auth: NewAuth(
 				WithClientID(clientID),
-				WithCreds(func(s string) Cred {
-					return Cred{User: "user", Password: "pass"}
-				}),
+				WithCreds(credsFn),
 			),
 			handleResponse: &http.Response{
 				Request: &http.Request{
@@ -321,14 +333,7 @@ func TestBearer(t *testing.T) {
 		Scope:        "repository:reponame:pull",
 		RefreshToken: "refresh-token-value",
 	})
-	tokenPassForm := url.Values{}
-	tokenPassForm.Set("scope", "repository:reponame:pull")
-	tokenPassForm.Set("service", "test")
-	tokenPassForm.Set("client_id", useragent)
-	tokenPassForm.Set("grant_type", "password")
-	tokenPassForm.Set("username", user)
-	tokenPassForm.Set("password", pass)
-	tokenPassBody := tokenPassForm.Encode()
+	userPassEnc := base64.StdEncoding.EncodeToString([]byte(user + ":" + pass))
 	tokenRefreshForm := url.Values{}
 	tokenRefreshForm.Set("scope", "repository:reponame:pull")
 	tokenRefreshForm.Set("service", "test")
@@ -343,21 +348,25 @@ func TestBearer(t *testing.T) {
 		Scope:        "repository:reponame:pull,push",
 		RefreshToken: "refresh-token-value",
 	})
-	token2PassForm := url.Values{}
-	token2PassForm.Set("scope", "repository:reponame:pull,push")
-	token2PassForm.Set("service", "test")
-	token2PassForm.Set("client_id", useragent)
-	token2PassForm.Set("grant_type", "password")
-	token2PassForm.Set("username", user)
-	token2PassForm.Set("password", pass)
-	token2PassBody := token2PassForm.Encode()
+	token2RefreshForm := url.Values{}
+	token2RefreshForm.Set("scope", "repository:reponame:pull,push")
+	token2RefreshForm.Set("service", "test")
+	token2RefreshForm.Set("client_id", useragent)
+	token2RefreshForm.Set("grant_type", "refresh_token")
+	token2RefreshForm.Set("refresh_token", "refresh-token-value")
+	token2RefreshBody := token2RefreshForm.Encode()
 	rrs := []reqresp.ReqResp{
 		{
 			ReqEntry: reqresp.ReqEntry{
 				Name:   "req token1",
-				Method: "POST",
+				Method: "GET",
 				Path:   "/tokens",
-				Body:   []byte(tokenPassBody),
+				Headers: http.Header{
+					"Authorization": {"Basic " + userPassEnc},
+				},
+				Query: map[string][]string{
+					"scope": {"repository:reponame:pull"},
+				},
 			},
 			RespEntry: reqresp.RespEntry{
 				Status: 200,
@@ -381,7 +390,7 @@ func TestBearer(t *testing.T) {
 				Name:   "req token2",
 				Method: "POST",
 				Path:   "/tokens",
-				Body:   []byte(token2PassBody),
+				Body:   []byte(token2RefreshBody),
 			},
 			RespEntry: reqresp.RespEntry{
 				Status: 200,

--- a/internal/reghttp/http_test.go
+++ b/internal/reghttp/http_test.go
@@ -51,79 +51,48 @@ func TestRegHttp(t *testing.T) {
 	pass := "testpass"
 	userAuth := base64.StdEncoding.EncodeToString([]byte(user + ":" + pass))
 	reqPerSec := 50.0
-	token1GForm := url.Values{}
-	token1GForm.Set("scope", "repository:project:pull")
-	token1GForm.Set("service", "test")
-	token1GForm.Set("client_id", useragent)
-	token1GForm.Set("grant_type", "password")
-	token1GForm.Set("username", user)
-	token1GForm.Set("password", pass)
-	token1GBody := token1GForm.Encode()
 	token1GValue := "token1GValue"
 	token1GResp, _ := json.Marshal(testBearerToken{
-		Token:        token1GValue,
-		ExpiresIn:    900,
-		IssuedAt:     time.Now(),
-		RefreshToken: "refresh1GValue",
-		Scope:        "repository:project:pull",
+		Token:     token1GValue,
+		ExpiresIn: 900,
+		IssuedAt:  time.Now(),
+		Scope:     "repository:project:pull",
 	})
-	token1PForm := url.Values{}
-	token1PForm.Set("scope", "repository:project:pull,push")
-	token1PForm.Set("service", "test")
-	token1PForm.Set("client_id", useragent)
-	token1PForm.Set("grant_type", "password")
-	token1PForm.Set("username", user)
-	token1PForm.Set("password", pass)
-	token1PBody := token1PForm.Encode()
 	token1PValue := "token1PValue"
 	token1PResp, _ := json.Marshal(testBearerToken{
-		Token:        token1PValue,
-		ExpiresIn:    900,
-		IssuedAt:     time.Now(),
-		RefreshToken: "refresh1PValue",
-		Scope:        "repository:project:pull,push",
+		Token:     token1PValue,
+		ExpiresIn: 900,
+		IssuedAt:  time.Now(),
+		Scope:     "repository:project:pull,push",
 	})
-	token2GForm := url.Values{}
-	token2GForm.Set("scope", "repository:project2:pull")
-	token2GForm.Set("service", "test")
-	token2GForm.Set("client_id", useragent)
-	token2GForm.Set("grant_type", "password")
-	token2GForm.Set("username", user)
-	token2GForm.Set("password", pass)
-	token2GBody := token2GForm.Encode()
 	token2GValue := "token2GValue"
 	token2GResp, _ := json.Marshal(testBearerToken{
-		Token:        token2GValue,
-		ExpiresIn:    900,
-		IssuedAt:     time.Now(),
-		RefreshToken: "refresh2GValue",
-		Scope:        "repository:project2:pull",
+		Token:     token2GValue,
+		ExpiresIn: 900,
+		IssuedAt:  time.Now(),
+		Scope:     "repository:project2:pull",
 	})
-	token2PForm := url.Values{}
-	token2PForm.Set("scope", "repository:project2:pull,push")
-	token2PForm.Set("service", "test")
-	token2PForm.Set("client_id", useragent)
-	token2PForm.Set("grant_type", "password")
-	token2PForm.Set("username", user)
-	token2PForm.Set("password", pass)
-	token2PBody := token2PForm.Encode()
 	token2PValue := "token2PValue"
 	token2PResp, _ := json.Marshal(testBearerToken{
-		Token:        token2PValue,
-		ExpiresIn:    900,
-		IssuedAt:     time.Now(),
-		RefreshToken: "refresh2PValue",
-		Scope:        "repository:project2:pull,push",
+		Token:     token2PValue,
+		ExpiresIn: 900,
+		IssuedAt:  time.Now(),
+		Scope:     "repository:project2:pull,push",
 	})
 	warnMsg1 := "test warning 1"
 	warnMsg2 := "test warning 2"
 	rrsToken := []reqresp.ReqResp{
 		{
 			ReqEntry: reqresp.ReqEntry{
-				Name:   "req token1G",
-				Method: "POST",
+				Name:   "req token1G GET",
+				Method: "GET",
 				Path:   "/token",
-				Body:   []byte(token1GBody),
+				Headers: http.Header{
+					"Authorization": {"Basic " + userAuth},
+				},
+				Query: map[string][]string{
+					"scope": {"repository:project:pull"},
+				},
 			},
 			RespEntry: reqresp.RespEntry{
 				Status: 200,
@@ -132,10 +101,15 @@ func TestRegHttp(t *testing.T) {
 		},
 		{
 			ReqEntry: reqresp.ReqEntry{
-				Name:   "req token1P",
-				Method: "POST",
+				Name:   "req token1P GET",
+				Method: "GET",
 				Path:   "/token",
-				Body:   []byte(token1PBody),
+				Headers: http.Header{
+					"Authorization": {"Basic " + userAuth},
+				},
+				Query: map[string][]string{
+					"scope": {"repository:project:pull,push"},
+				},
 			},
 			RespEntry: reqresp.RespEntry{
 				Status: 200,
@@ -144,10 +118,15 @@ func TestRegHttp(t *testing.T) {
 		},
 		{
 			ReqEntry: reqresp.ReqEntry{
-				Name:   "req token2G",
-				Method: "POST",
+				Name:   "req token2G GET",
+				Method: "GET",
 				Path:   "/token",
-				Body:   []byte(token2GBody),
+				Headers: http.Header{
+					"Authorization": {"Basic " + userAuth},
+				},
+				Query: map[string][]string{
+					"scope": {"repository:project2:pull"},
+				},
 			},
 			RespEntry: reqresp.RespEntry{
 				Status: 200,
@@ -156,10 +135,15 @@ func TestRegHttp(t *testing.T) {
 		},
 		{
 			ReqEntry: reqresp.ReqEntry{
-				Name:   "req token2P",
-				Method: "POST",
+				Name:   "req token2P GET",
+				Method: "GET",
 				Path:   "/token",
-				Body:   []byte(token2PBody),
+				Headers: http.Header{
+					"Authorization": {"Basic " + userAuth},
+				},
+				Query: map[string][]string{
+					"scope": {"repository:project2:pull,push"},
+				},
 			},
 			RespEntry: reqresp.RespEntry{
 				Status: 200,


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Fixes #865.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This removes an auth hop that was defaulting to a POST even when a refresh token isn't available, where many token servers do not support the POST. In the GET for a token, the request for an offline refresh token is removed. Requesting a new token will send the original credentials again rather than the refresh token. This improves compatibility with broken auth token servers.

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Tests have been updated, and trace logs should show auth going directly to the GET request.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Fix: Do not request offline refresh token.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
