### PR TITLE
Fix: Ignore unsupported entries in docker config

### DIFF
--- a/config/docker.go
+++ b/config/docker.go
@@ -130,6 +130,10 @@ func dockerAuthToHost(name string, conf dockerConfig, auth dockerAuthConfig) (Ho
 	}
 
 	h := HostNewName(name)
+	// ignore unknown names
+	if h.Name != DockerRegistry && !strings.HasSuffix(strings.TrimSuffix(name, "/"), h.Name) {
+		return Host{}, fmt.Errorf("rejecting entry with repository: %s", name)
+	}
 	h.User = auth.Username
 	h.Pass = auth.Password
 	h.Token = auth.IdentityToken

--- a/config/testdata/config.json
+++ b/config/testdata/config.json
@@ -5,6 +5,15 @@
     },
     "hub-tool-token": {
       "identitytoken": "MTIzNDUK"
+    },
+    "https://index.docker.io/v1/access-token": {
+    },
+    "https://index.docker.io/v1/": {
+    },
+    "https://index.docker.io/v1/refresh-token": {
+    },
+    "http://missing-from-repo.example.com/foo": {
+      "auth": "aGVsbG86ZG9ja2Vy"
     }
   },
   "credHelpers": {


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

The docker config may contain auth entries that are not registries. This ignores those entries rather than attempting to parse them.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Tests have been added. Including an entry for `example.org/foo` in `~/.docker/config.json` will no longer modify the host config for `example.org`.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Fix: Ignore unsupported entries in docker config.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
