### PR TITLE
Fix: Interval overrides a default schedule in regsync and regbot

### DIFF
--- a/cmd/regbot/config.go
+++ b/cmd/regbot/config.go
@@ -57,6 +57,9 @@ func ConfigLoadReader(r io.Reader) (*Config, error) {
 		return nil, err
 	}
 	// verify loaded version is not higher than supported version
+	if c.Version == 0 {
+		c.Version = 1
+	}
 	if c.Version > 1 {
 		return c, ErrUnsupportedConfigVersion
 	}
@@ -124,11 +127,12 @@ func configExpandTemplates(c *Config) error {
 
 // updates script entry with defaults
 func scriptSetDefaults(s *ConfigScript, d ConfigDefaults) {
-	if s.Schedule == "" && d.Schedule != "" {
-		s.Schedule = d.Schedule
-	}
-	if s.Interval == 0 && s.Schedule == "" && d.Interval != 0 {
-		s.Interval = d.Interval
+	if s.Schedule == "" && s.Interval == 0 {
+		if d.Schedule != "" {
+			s.Schedule = d.Schedule
+		} else if d.Interval != 0 {
+			s.Interval = d.Interval
+		}
 	}
 	if s.Timeout == 0 && d.Timeout != 0 {
 		s.Timeout = d.Timeout

--- a/cmd/regbot/testdata/config1.yml
+++ b/cmd/regbot/testdata/config1.yml
@@ -1,0 +1,17 @@
+version: 1
+creds:
+  - registry: registry:5000
+    tls: disabled
+defaults:
+  parallel: 2
+  interval: 60m
+  timeout: 600s
+scripts:
+  - name: hello world
+    timeout: 1m
+    script: |
+      log("hello world")
+  - name: top of the hour
+    schedule: "0 * * * *"
+    script: |
+      log("ding")

--- a/cmd/regbot/testdata/config2.yml
+++ b/cmd/regbot/testdata/config2.yml
@@ -1,0 +1,14 @@
+creds:
+  - registry: registry:5000
+    tls: disabled
+defaults:
+  schedule: "15 3 * * *"
+scripts:
+  - name: hello world
+    timeout: 1m
+    interval: 12h
+    script: |
+      log("hello world")
+  - name: default schedule
+    script: |
+      log("test")

--- a/cmd/regsync/config.go
+++ b/cmd/regsync/config.go
@@ -126,6 +126,9 @@ func ConfigLoadReader(r io.Reader) (*Config, error) {
 		return nil, err
 	}
 	// verify loaded version is not higher than supported version
+	if c.Version == 0 {
+		c.Version = 1
+	}
 	if c.Version > 1 {
 		return c, ErrUnsupportedConfigVersion
 	}
@@ -240,11 +243,12 @@ func syncSetDefaults(s *ConfigSync, d ConfigDefaults) {
 	if s.Backup == "" && d.Backup != "" {
 		s.Backup = d.Backup
 	}
-	if s.Schedule == "" && d.Schedule != "" {
-		s.Schedule = d.Schedule
-	}
-	if s.Interval == 0 && s.Schedule == "" && d.Interval != 0 {
-		s.Interval = d.Interval
+	if s.Schedule == "" && s.Interval == 0 {
+		if d.Schedule != "" {
+			s.Schedule = d.Schedule
+		} else if d.Interval != 0 {
+			s.Interval = d.Interval
+		}
 	}
 	if s.RateLimit.Min == 0 && d.RateLimit.Min != 0 {
 		s.RateLimit.Min = d.RateLimit.Min

--- a/cmd/regsync/testdata/config1.yml
+++ b/cmd/regsync/testdata/config1.yml
@@ -1,0 +1,39 @@
+version: 1
+creds:
+  - registry: registry:5000
+    tls: disabled
+  - registry: docker.io
+defaults:
+  ratelimit:
+    min: 100
+    retry: 15m
+  parallel: 2
+  interval: 60m
+  backup: "bkup-{{.Ref.Tag}}"
+  cacheCount: 500
+  cacheTime: "5m"
+x-sync-hub: &sync-hub
+  target: registry:5000/hub/{{ .Sync.Source }}
+x-sync-gcr: &sync-gcr
+  target: registry:5000/gcr/{{ index (split .Sync.Source "gcr.io/") 1 }}
+sync:
+  - source: busybox:latest
+    target: registry:5000/library/busybox:latest
+    type: image
+    schedule: "15 3 * * *"
+  - <<: *sync-hub
+    source: alpine
+    type: repository
+    tags:
+      allow:
+      - 3
+      - 3.9
+      - latest
+  - <<: *sync-gcr
+    source: gcr.io/example/repo
+    type: repository
+    tags:
+      allow:
+      - 3
+      - 3.9
+      - latest

--- a/cmd/regsync/testdata/config2.yml
+++ b/cmd/regsync/testdata/config2.yml
@@ -1,0 +1,15 @@
+creds:
+  - registry: registry:5000
+    tls: disabled
+defaults:
+  schedule: "15 3 * * *"
+sync:
+  - source: busybox:latest
+    target: registry:5000/library/busybox:latest
+    type: image
+    interval: 12h
+  - source: alpine:latest
+    target: registry:5000/library/alpine:latest
+    type: image
+    ratelimit:
+      retry: 1m


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

This affects both regbot and regsync where setting a default schedule would override a sync/script specific interval.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This only sets the schedule to a default value when a sync/script specific interval is not defined.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
make test
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Fix: Interval overrides a default schedule in regsync and regbot.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
