### PR TITLE
Fix: Validate registry names

### DIFF
--- a/cmd/regctl/registry.go
+++ b/cmd/regctl/registry.go
@@ -225,6 +225,9 @@ func (registryOpts *registryCmd) runRegistryLogin(cmd *cobra.Command, args []str
 	if len(args) < 1 {
 		args = []string{regclient.DockerRegistry}
 	}
+	if !config.HostValidate(args[0]) {
+		return fmt.Errorf("invalid registry name provided: %s", args[0])
+	}
 	h := config.HostNewName(args[0])
 	if curH, ok := c.Hosts[h.Name]; ok {
 		h = curH
@@ -329,6 +332,9 @@ func (registryOpts *registryCmd) runRegistryLogout(cmd *cobra.Command, args []st
 	if len(args) < 1 {
 		args = []string{regclient.DockerRegistry}
 	}
+	if !config.HostValidate(args[0]) {
+		return fmt.Errorf("invalid registry name provided: %s", args[0])
+	}
 	h := config.HostNewName(args[0])
 	if curH, ok := c.Hosts[h.Name]; ok {
 		h = curH
@@ -359,6 +365,9 @@ func (registryOpts *registryCmd) runRegistrySet(cmd *cobra.Command, args []strin
 	}
 	if len(args) < 1 {
 		args = []string{regclient.DockerRegistry}
+	}
+	if !config.HostValidate(args[0]) {
+		return fmt.Errorf("invalid registry name provided: %s", args[0])
 	}
 	h := config.HostNewName(args[0])
 	if curH, ok := c.Hosts[h.Name]; ok {

--- a/config/credhelper.go
+++ b/config/credhelper.go
@@ -86,6 +86,9 @@ func (ch *credHelper) list() ([]Host, error) {
 	}
 	hostList := []Host{}
 	for host, user := range credList {
+		if !HostValidate(host) {
+			continue
+		}
 		h := HostNewName(host)
 		h.User = user
 		h.CredHelper = ch.prog

--- a/config/credhelper_test.go
+++ b/config/credhelper_test.go
@@ -49,6 +49,7 @@ func TestCredHelper(t *testing.T) {
 		},
 		{
 			name:       "missing helper",
+			host:       "missing.example.org",
 			credHelper: "./testdata/docker-credential-missing",
 			expectErr:  true,
 		},

--- a/config/docker.go
+++ b/config/docker.go
@@ -85,6 +85,9 @@ func dockerParse(cf *conffile.File) ([]Host, error) {
 	}
 	hosts := []Host{}
 	for name, auth := range dc.AuthConfigs {
+		if !HostValidate(name) {
+			continue
+		}
 		h, err := dockerAuthToHost(name, dc, auth)
 		if err != nil {
 			continue
@@ -93,9 +96,12 @@ func dockerParse(cf *conffile.File) ([]Host, error) {
 	}
 	// also include default entries for credential helpers
 	for name, helper := range dc.CredentialHelpers {
+		if !HostValidate(name) {
+			continue
+		}
 		h := HostNewName(name)
 		h.CredHelper = dockerHelperPre + helper
-		if _, ok := dc.AuthConfigs[h.Name]; ok {
+		if _, ok := dc.AuthConfigs[name]; ok {
 			continue // skip fields with auth config
 		}
 		hosts = append(hosts, *h)

--- a/config/docker_test.go
+++ b/config/docker_test.go
@@ -86,21 +86,41 @@ func TestDocker(t *testing.T) {
 		},
 		{
 			name:          "missing-from-repo.example.com", // entries with a repository are ignored
+			hostname:      "missing-from-repo.example.com",
 			expectMissing: true,
 		},
 		{
 			name:          "index.docker.io", // verify access-token and refresh-token entries are ignored
+			hostname:      "index.docker.io",
+			expectMissing: true,
+		},
+		{
+			name:          "https://index.docker.io/v1/access-token",
+			hostname:      "https://index.docker.io/v1/access-token",
+			expectMissing: true,
+		},
+		{
+			name:          "https://index.docker.io/v1/test-token",
+			hostname:      "https://index.docker.io/v1/test-token",
+			expectMissing: true,
+		},
+		{
+			name:          "https://index.docker.io/v1/helper-token",
+			hostname:      "https://index.docker.io/v1/helper-token",
 			expectMissing: true,
 		},
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			h, ok := hostMap[tc.hostname]
-			if !ok {
-				if !tc.expectMissing {
-					t.Fatalf("host not found: %s", tc.hostname)
+			if tc.expectMissing {
+				if ok {
+					t.Fatalf("entry found that should be missing: %s", tc.hostname)
 				}
 				return
+			}
+			if !ok {
+				t.Fatalf("host not found: %s", tc.hostname)
 			}
 			if tc.expectUser != h.User {
 				t.Errorf("user mismatch, expect %s, received %s", tc.expectUser, h.User)

--- a/config/testdata/config.json
+++ b/config/testdata/config.json
@@ -19,7 +19,9 @@
   "credHelpers": {
     "testhost.example.com": "test",
     "https://index.docker.io/v1/": "test",
-    "http://http.example.com/": "test"
+    "http://http.example.com/": "test",
+    "https://index.docker.io/v1/test-token": "test",
+    "https://index.docker.io/v1/access-token": "test"
   },
   "credsStore": "teststore"
 }

--- a/config/testdata/docker-credential-teststore
+++ b/config/testdata/docker-credential-teststore
@@ -3,7 +3,8 @@
 list='{
   "http://storehttp.example.com/": "hello",
   "storehost.example.com": "hello",
-  "storetoken.example.com": "<token>"
+  "storetoken.example.com": "<token>",
+  "https://index.docker.io/v1/helper-token": "<token>"
 }'
 
 registry_http='
@@ -24,6 +25,12 @@ registry_testtoken='
   "Secret": "deadbeefcafe"
 }
 '
+registry_testhelper_token='
+{ "ServerURL": "https://index.docker.io/v1/helper-token",
+  "Username": "<token>",
+  "Secret": "deadbeefcafe"
+}
+'
 
 if [ "$1" = "get" ]; then
   read hostname
@@ -38,6 +45,10 @@ if [ "$1" = "get" ]; then
       ;;
     storetoken.example.com)
       echo "${registry_testtoken}"
+      exit 0
+      ;;
+    https://index.docker.io/v1/helper-token)
+      echo "${registry_testhelper_token}"
       exit 0
       ;;
   esac


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Warnings for changing registry configurations are still returned in some scenarios.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

The previous fix only validated registry names in the auths section of the docker config. This also validates names listed in the credential helper or returned from the credential store.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Run `regctl` commands with a `~/.docker/config.json` that lists non-registry entries in the credential helpers or are returned from the credential store. Warnings for those entries should no longer be displayed.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Fix: Validate registry names.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
