### PR TITLE
Feat: Adding a whoami command

### DIFF
--- a/cmd/regctl/registry_test.go
+++ b/cmd/regctl/registry_test.go
@@ -52,6 +52,11 @@ func TestRegistry(t *testing.T) {
 		expectOut   string
 		outContains bool
 	}{
+		{
+			name:      "whoami to an unknown server",
+			args:      []string{"registry", "whoami", tsGoodHost},
+			expectErr: errs.ErrNoLogin,
+		},
 		// disable tls
 		{
 			name:        "set no TLS",
@@ -76,6 +81,11 @@ func TestRegistry(t *testing.T) {
 			args:        []string{"registry", "config", tsGoodHost},
 			expectOut:   `"tls": "disabled",`,
 			outContains: true,
+		},
+		{
+			name:      "whoami to an known server without logging in",
+			args:      []string{"registry", "whoami", tsGoodHost},
+			expectErr: errs.ErrNoLogin,
 		},
 		{
 			name:        "query unauth host",
@@ -114,6 +124,11 @@ func TestRegistry(t *testing.T) {
 			expectOut: `testgooduser`,
 		},
 		{
+			name:      "whoami to an known server",
+			args:      []string{"registry", "whoami", tsGoodHost},
+			expectOut: "testgooduser",
+		},
+		{
 			name:      "query unauth host",
 			args:      []string{"registry", "config", tsUnauthHost, "--format", "{{.User}}"},
 			expectOut: `testunauthuser`,
@@ -147,6 +162,11 @@ func TestRegistry(t *testing.T) {
 			name:      "check logout on good host",
 			args:      []string{"registry", "config", tsGoodHost, "--format", "{{.User}}"},
 			expectOut: ``,
+		},
+		{
+			name:      "whoami to an known server after logout",
+			args:      []string{"registry", "whoami", tsGoodHost},
+			expectErr: errs.ErrNoLogin,
 		},
 		{
 			name:      "check logout on unauth host",

--- a/types/errs/error.go
+++ b/types/errs/error.go
@@ -50,6 +50,8 @@ var (
 	ErrMismatch = errors.New("content does not match")
 	// ErrMountReturnedLocation when a blob mount fails but a location header is received
 	ErrMountReturnedLocation = errors.New("blob mount returned a location to upload")
+	// ErrNoLogin indicates there is no user login defined for a registry
+	ErrNoLogin = errors.New("no login found")
 	// ErrNoNewChallenge indicates a challenge update did not result in any change
 	ErrNoNewChallenge = errors.New("no new challenge")
 	// ErrNotFound isn't there, search for your value elsewhere


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This adds the command:

```shell
regctl registry whoami
```

which returns the current logged in user, if configured. It also updates `regctl registry config` to call the credential helper to set the username in `regctl registry config`.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
regctl registry whoami
regctl registry whoami ghcr.io
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Feat: Adding a whoami command.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [ ] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
