### PR TITLE
Feat: Improve regctl image check-base output

### DIFF
--- a/cmd/regctl/main.go
+++ b/cmd/regctl/main.go
@@ -26,7 +26,9 @@ func main() {
 	godbg.SignalTrace()
 
 	if err := cmd.ExecuteContext(ctx); err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
+		if err.Error() != "" {
+			fmt.Fprintf(os.Stderr, "%s\n", err.Error())
+		}
 		// provide tips for common error messages
 		switch {
 		case strings.Contains(err.Error(), "http: server gave HTTP response to HTTPS client"):

--- a/cmd/regctl/main_test.go
+++ b/cmd/regctl/main_test.go
@@ -5,17 +5,23 @@ import (
 	"io"
 	"strings"
 	"testing"
+
+	"github.com/regclient/regclient"
 )
 
 type cobraTestOpts struct {
-	stdin io.Reader
+	stdin  io.Reader
+	rcOpts []regclient.Opt
 }
 
 func cobraTest(t *testing.T, opts *cobraTestOpts, args ...string) (string, error) {
 	t.Helper()
 
 	buf := new(bytes.Buffer)
-	rootTopCmd, _ := NewRootCmd()
+	rootTopCmd, rootOpts := NewRootCmd()
+	if opts != nil && opts.rcOpts != nil {
+		rootOpts.rcOpts = opts.rcOpts
+	}
 	if opts != nil && opts.stdin != nil {
 		rootTopCmd.SetIn(opts.stdin)
 	}

--- a/cmd/regctl/root.go
+++ b/cmd/regctl/root.go
@@ -25,12 +25,13 @@ const (
 )
 
 type rootOpts struct {
+	hosts     []string
 	name      string
-	verbosity string
 	logopts   []string
 	log       *slog.Logger
-	hosts     []string
+	rcOpts    []regclient.Opt
 	userAgent string
+	verbosity string
 }
 
 type versionOpts struct {
@@ -159,6 +160,9 @@ func (opts *rootOpts) newRegClient() *regclient.RegClient {
 	rcOpts := []regclient.Opt{
 		regclient.WithSlog(opts.log),
 		regclient.WithRegOpts(reg.WithCache(time.Minute*5, 500)),
+	}
+	if len(opts.rcOpts) > 0 {
+		rcOpts = append(rcOpts, opts.rcOpts...)
 	}
 	if opts.userAgent != "" {
 		rcOpts = append(rcOpts, regclient.WithUserAgent(opts.userAgent))


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

The new output makes it more apparent when the base image has changed to casual users. Tests were added, which required some work to pass through `regclient.Opts`. The empty error message is also suppressed to avoid an extra linefeed to stderr.

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
# report if base image has changed using annotations
regctl image check-base ghcr.io/regclient/regctl:alpine

# suppress the normal output with --quiet for scripts
if ! regctl image check-base ghcr.io/regclient/regctl:alpine --quiet; then
  echo build a new image here
fi
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Feat: Improve `regctl image check-base` output.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
