### PR TITLE
Feat: regsync option to abort on errors

### DIFF
--- a/cmd/regsync/regsync_test.go
+++ b/cmd/regsync/regsync_test.go
@@ -55,6 +55,16 @@ func TestProcess(t *testing.T) {
 	ts := httptest.NewServer(regHandler)
 	tsURL, _ := url.Parse(ts.URL)
 	tsHost := tsURL.Host
+	regROHandler := olareg.New(oConfig.Config{
+		Storage: oConfig.ConfigStorage{
+			StoreType: oConfig.StoreMem,
+			RootDir:   "../../testdata",
+			ReadOnly:  &boolT,
+		},
+	})
+	tsRO := httptest.NewServer(regROHandler)
+	tsROURL, _ := url.Parse(tsRO.URL)
+	tsROHost := tsROURL.Host
 	t.Cleanup(func() {
 		ts.Close()
 		_ = regHandler.Close()
@@ -63,6 +73,11 @@ func TestProcess(t *testing.T) {
 		{
 			Name:     tsHost,
 			Hostname: tsHost,
+			TLS:      config.TLSDisabled,
+		},
+		{
+			Name:     tsROHost,
+			Hostname: tsROHost,
 			TLS:      config.TLSDisabled,
 		},
 		{
@@ -189,13 +204,14 @@ defaults:
 
 	// run process on each entry
 	tt := []struct {
-		name    string
-		sync    ConfigSync
-		action  actionType
-		expect  map[string]digest.Digest
-		exists  []string
-		missing []string
-		expErr  error
+		name       string
+		sync       ConfigSync
+		action     actionType
+		abortOnErr bool
+		expect     map[string]digest.Digest
+		exists     []string
+		missing    []string
+		expErr     error
 	}{
 		{
 			name: "Action Missing",
@@ -233,6 +249,17 @@ defaults:
 				tsHost + "/test2:v3": d3,
 			},
 			expErr: nil,
+		},
+		{
+			name: "ReadOnly Error Abort",
+			sync: ConfigSync{
+				Source: tsHost + "/testrepo",
+				Target: tsROHost + "/test-readonly",
+				Type:   "repository",
+			},
+			action:     actionCopy,
+			abortOnErr: true,
+			expErr:     errs.ErrHTTPStatus,
 		},
 		{
 			name: "Overwrite",
@@ -699,10 +726,11 @@ defaults:
 		t.Run(tc.name, func(t *testing.T) {
 			// run each test
 			rootOpts := rootOpts{
-				conf:     conf,
-				rc:       rc,
-				throttle: pq,
-				log:      slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo})),
+				conf:       conf,
+				rc:         rc,
+				throttle:   pq,
+				log:        slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo})),
+				abortOnErr: tc.abortOnErr,
 			}
 			syncSetDefaults(&tc.sync, conf.Defaults)
 			err = rootOpts.process(ctx, tc.sync, tc.action)


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Fixes #922.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Add a regsync option to abort on errors. This stops regsync from retrying with backoffs when a registry is failing. Multiple errors are also joined using "errors.Join". Errors from the canceled context are not propagated up.

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Use `--abort-on-error` on a failing registry, e.g. a registry without write access due to auth or or being in read-only mode.

```shell
regsync once --abort-on-error --config regsync.yml
```

<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Feat: regsync option to abort on errors.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
