### PR TITLE
Feat: regctl flag to ignore missing images on delete

### DIFF
--- a/cmd/regctl/manifest_test.go
+++ b/cmd/regctl/manifest_test.go
@@ -1,12 +1,25 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/olareg/olareg"
+	oConfig "github.com/olareg/olareg/config"
+	"github.com/opencontainers/go-digest"
+
+	"github.com/regclient/regclient"
+	"github.com/regclient/regclient/config"
+	"github.com/regclient/regclient/scheme/reg"
 	"github.com/regclient/regclient/types/errs"
+	"github.com/regclient/regclient/types/ref"
 )
 
 func TestManifestHead(t *testing.T) {
@@ -53,6 +66,122 @@ func TestManifestHead(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			out, err := cobraTest(t, nil, tc.args...)
+			if tc.expectErr != nil {
+				if err == nil {
+					t.Errorf("did not receive expected error: %v", tc.expectErr)
+				} else if !errors.Is(err, tc.expectErr) && err.Error() != tc.expectErr.Error() {
+					t.Errorf("unexpected error, received %v, expected %v", err, tc.expectErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("returned unexpected error: %v", err)
+			}
+			if (!tc.outContains && out != tc.expectOut) || (tc.outContains && !strings.Contains(out, tc.expectOut)) {
+				t.Errorf("unexpected output, expected %s, received %s", tc.expectOut, out)
+			}
+		})
+	}
+}
+
+func TestManifestRm(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	boolT := true
+	regHandler := olareg.New(oConfig.Config{
+		Storage: oConfig.ConfigStorage{
+			StoreType: oConfig.StoreMem,
+			RootDir:   "../../testdata",
+		},
+		API: oConfig.ConfigAPI{
+			DeleteEnabled: &boolT,
+		},
+	})
+	ts := httptest.NewServer(regHandler)
+	tsURL, _ := url.Parse(ts.URL)
+	tsHost := tsURL.Host
+	t.Cleanup(func() {
+		ts.Close()
+		_ = regHandler.Close()
+	})
+	rcOpts := []regclient.Opt{
+		regclient.WithConfigHost(
+			config.Host{
+				Name: tsHost,
+				TLS:  config.TLSDisabled,
+			},
+			config.Host{
+				Name:     "invalid-tls." + tsHost,
+				Hostname: tsHost,
+				TLS:      config.TLSEnabled,
+			},
+		),
+		regclient.WithRegOpts(reg.WithDelay(time.Millisecond*10, time.Millisecond*100), reg.WithRetryLimit(2)),
+	}
+	rb, err := ref.New("ocidir://../../testdata/testrepo:v3")
+	if err != nil {
+		t.Fatalf("failed to parse ref: %v", err)
+	}
+	rc := regclient.New(rcOpts...)
+	mb, err := rc.ManifestHead(ctx, rb, regclient.WithManifestRequireDigest())
+	if err != nil {
+		t.Fatalf("failed to head ref %s: %v", rb.CommonName(), err)
+	}
+	dig := mb.GetDescriptor().Digest.String()
+	missing := digest.Canonical.FromString("missing").String()
+
+	tt := []struct {
+		name        string
+		args        []string
+		expectErr   error
+		expectOut   string
+		outContains bool
+	}{
+		{
+			name:      "Missing arg",
+			args:      []string{"manifest", "rm"},
+			expectErr: fmt.Errorf("accepts 1 arg(s), received 0"),
+		},
+		{
+			name: "Delete v3 by digest",
+			args: []string{"manifest", "rm", tsHost + "/testrepo@" + dig},
+		},
+		{
+			name:      "Delete v1 without deref",
+			args:      []string{"manifest", "rm", tsHost + "/testrepo:v1"},
+			expectErr: errs.ErrMissingDigest,
+		},
+		{
+			name: "Delete v1 with deref",
+			args: []string{"manifest", "rm", tsHost + "/testrepo:v1", "--force-tag-dereference"},
+		},
+		{
+			name:      "Delete missing digest",
+			args:      []string{"manifest", "rm", tsHost + "/testrepo@" + missing, "--force-tag-dereference"},
+			expectErr: errs.ErrNotFound,
+		},
+		{
+			name: "Delete missing digest with ignore missing",
+			args: []string{"manifest", "rm", tsHost + "/testrepo@" + missing, "--ignore-missing"},
+		},
+		{
+			name:      "Delete missing tag with deref",
+			args:      []string{"manifest", "rm", tsHost + "/testrepo:missing", "--force-tag-dereference"},
+			expectErr: errs.ErrNotFound,
+		},
+		{
+			name: "Delete missing tag with deref and ignore missing",
+			args: []string{"manifest", "rm", tsHost + "/testrepo:missing", "--force-tag-dereference", "--ignore-missing"},
+		},
+		{
+			name:      "Delete tls error with ignore missing",
+			args:      []string{"manifest", "rm", "invalid-tls." + tsHost + "/testrepo@" + missing, "--ignore-missing"},
+			expectErr: http.ErrSchemeMismatch,
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := cobraTest(t, &cobraTestOpts{rcOpts: rcOpts}, tc.args...)
 			if tc.expectErr != nil {
 				if err == nil {
 					t.Errorf("did not receive expected error: %v", tc.expectErr)

--- a/cmd/regctl/tag_test.go
+++ b/cmd/regctl/tag_test.go
@@ -4,13 +4,25 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/olareg/olareg"
+	oConfig "github.com/olareg/olareg/config"
+	"github.com/opencontainers/go-digest"
+
+	"github.com/regclient/regclient"
+	"github.com/regclient/regclient/config"
+	"github.com/regclient/regclient/scheme/reg"
 	"github.com/regclient/regclient/types/errs"
 )
 
 func TestTagList(t *testing.T) {
+	t.Parallel()
 	tt := []struct {
 		name        string
 		args        []string
@@ -61,6 +73,98 @@ func TestTagList(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			out, err := cobraTest(t, nil, tc.args...)
+			if tc.expectErr != nil {
+				if err == nil {
+					t.Errorf("did not receive expected error: %v", tc.expectErr)
+				} else if !errors.Is(err, tc.expectErr) && err.Error() != tc.expectErr.Error() {
+					t.Errorf("unexpected error, received %v, expected %v", err, tc.expectErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("returned unexpected error: %v", err)
+			}
+			if (!tc.outContains && out != tc.expectOut) || (tc.outContains && !strings.Contains(out, tc.expectOut)) {
+				t.Errorf("unexpected output, expected %s, received %s", tc.expectOut, out)
+			}
+		})
+	}
+}
+
+func TestTagRm(t *testing.T) {
+	t.Parallel()
+	boolT := true
+	regHandler := olareg.New(oConfig.Config{
+		Storage: oConfig.ConfigStorage{
+			StoreType: oConfig.StoreMem,
+			RootDir:   "../../testdata",
+		},
+		API: oConfig.ConfigAPI{
+			DeleteEnabled: &boolT,
+		},
+	})
+	ts := httptest.NewServer(regHandler)
+	tsURL, _ := url.Parse(ts.URL)
+	tsHost := tsURL.Host
+	t.Cleanup(func() {
+		ts.Close()
+		_ = regHandler.Close()
+	})
+	rcOpts := []regclient.Opt{
+		regclient.WithConfigHost(
+			config.Host{
+				Name: tsHost,
+				TLS:  config.TLSDisabled,
+			},
+			config.Host{
+				Name:     "invalid-tls." + tsHost,
+				Hostname: tsHost,
+				TLS:      config.TLSEnabled,
+			},
+		),
+		regclient.WithRegOpts(reg.WithDelay(time.Millisecond*10, time.Millisecond*100), reg.WithRetryLimit(2)),
+	}
+	dig := digest.Canonical.FromString("test digest").String()
+
+	tt := []struct {
+		name        string
+		args        []string
+		expectErr   error
+		expectOut   string
+		outContains bool
+	}{
+		{
+			name:      "Missing arg",
+			args:      []string{"tag", "rm"},
+			expectErr: fmt.Errorf("accepts 1 arg(s), received 0"),
+		},
+		{
+			name:      "Delete digest",
+			args:      []string{"tag", "rm", tsHost + "/testrepo@" + dig},
+			expectErr: errs.ErrMissingTag,
+		},
+		{
+			name: "Delete v1",
+			args: []string{"tag", "rm", tsHost + "/testrepo:v1"},
+		},
+		{
+			name:      "Delete missing",
+			args:      []string{"tag", "rm", tsHost + "/testrepo:missing"},
+			expectErr: errs.ErrNotFound,
+		},
+		{
+			name: "Delete missing with ignore missing",
+			args: []string{"tag", "rm", tsHost + "/testrepo:missing", "--ignore-missing"},
+		},
+		{
+			name:      "Delete tls error with ignore missing",
+			args:      []string{"tag", "rm", "invalid-tls." + tsHost + "/testrepo:missing", "--ignore-missing"},
+			expectErr: http.ErrSchemeMismatch,
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := cobraTest(t, &cobraTestOpts{rcOpts: rcOpts}, tc.args...)
 			if tc.expectErr != nil {
 				if err == nil {
 					t.Errorf("did not receive expected error: %v", tc.expectErr)


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Fixes #928.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Add a flag to `regctl tag rm` and `regctl manifest rm` to ignore a missing image if the delete API fails.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
regctl tag rm registry.example.org/repo:missing
```

<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Feat: regctl flag to ignore missing images on delete.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
