### PR TITLE
Feat: Add a script to reproduce regclient images

### DIFF
--- a/build/reproduce.sh
+++ b/build/reproduce.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+
+set -e
+cd "$(dirname $0)/.."
+
+if [ $# != 1 ] || [ "$1" !=  "${1##-}" ]; then
+  echo "usage: $0 [regclient_image_name]" >&2
+  exit 1
+fi
+
+image_info="$(regctl manifest get "$1" --format '
+  {{- println ( index .Annotations "org.opencontainers.image.revision" ) }} 
+  {{- println ( index .Annotations "org.opencontainers.image.title" ) }} 
+  {{- println ( index .Annotations "org.opencontainers.image.description" ) }} 
+  {{- println .GetDescriptor.Digest }}')"
+
+commit="$(echo "${image_info}" | sed -n 1p)"
+sub_image="$(echo "${image_info}" | sed -n 2p)"
+description="$(echo "${image_info}" | sed -n 3p)"
+digest="$(echo "${image_info}" | sed -n 4p)"
+
+# checkout the repo at the commit to reproduce
+git switch -d "$commit" >/dev/null
+
+# make the oci images
+make "oci-image-${sub_image}"
+
+scratch_desc="$(regctl manifest get ocidir://output/${sub_image}:scratch --format '{{ index .Annotations "org.opencontainers.image.description" }}')"
+scratch_digest="$(regctl image digest ocidir://output/${sub_image}:scratch)"
+alpine_desc="$(regctl manifest get ocidir://output/${sub_image}:alpine --format '{{ index .Annotations "org.opencontainers.image.description" }}')"
+alpine_digest="$(regctl image digest ocidir://output/${sub_image}:alpine)"
+
+rc=0
+if [ "$description" = "$scratch_desc" ] && [ "$digest" = "$scratch_digest" ]; then
+  echo "\033[32mScratch image reproduced.\033[0m"
+  echo "$digest: $description"
+elif [ "$description" = "$alpine_desc" ] && [ "$digest" = "$alpine_digest" ]; then
+  echo "\033[32mAlpine image reproduced.\033[0m"
+  echo "$digest: $description"
+else
+  echo "\033[31mFailed to reproduce!\033[0m"
+  echo "Expected: $digest: $description"
+  echo "Found:    $scratch_digest: $scratch_desc"
+  echo "Found:    $alpine_digest: $alpine_desc"
+  rc=2
+fi
+
+# revert the git repo
+git switch - >/dev/null
+
+exit $rc


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This adds a script that takes a given image and verifies it can be reproduced by rebuilding the given git commit. It is a bit slow since caching is disabled, and both images (scratch and alpine) are built as part of a reproducible build, and artifacts (SBOMs) are included in the build.

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
./build/reproduce.sh ghcr.io/regclient/regctl:v0.8.1
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Feat: Add a script to reproduce regclient images.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

A separate doc PR will be made to the website.
<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [ ] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
