### PR TITLE
Chore: Convert the build to use OCI style attestations

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -110,7 +110,7 @@ jobs:
         file: ./build/Dockerfile.${{ matrix.image }}.buildkit
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/ppc64le,linux/s390x
         target: release-${{ matrix.type }}
-        outputs: type=oci,dest=output/${{matrix.image}}-${{matrix.type}}.tar
+        outputs: type=oci,oci-artifact=true,dest=output/${{matrix.image}}-${{matrix.type}}.tar
         build-args: |
           SOURCE_DATE_EPOCH=${{ steps.prep.outputs.vcs_sec }}
           BUILD_DATE=${{ steps.prep.outputs.created }}

--- a/build/oci-image.sh
+++ b/build/oci-image.sh
@@ -81,7 +81,7 @@ if [ "${opt_c}" = "0" ]; then
 fi
 docker buildx build --platform="$platforms" \
   -f "build/Dockerfile.${image}.buildkit" \
-  -o "type=oci,dest=output/${image}-${release}.tar" \
+  -o "type=oci,oci-artifact=true,dest=output/${image}-${release}.tar" \
   --target "release-${release}" \
   --build-arg "SOURCE_DATE_EPOCH=${vcs_sec}" \
   --build-arg "BUILD_DATE=${vcs_date}" \


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Using `oci-artifact=true` now that #949 is fixed.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Chore: Convert the build to use OCI style attestations.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
