### PR TITLE
Fix: Allow duplicate keys in yaml config

### DIFF
--- a/cmd/regbot/config.go
+++ b/cmd/regbot/config.go
@@ -53,7 +53,7 @@ func ConfigNew() *Config {
 // ConfigLoadReader reads the config from an io.Reader
 func ConfigLoadReader(r io.Reader) (*Config, error) {
 	c := ConfigNew()
-	if err := yaml.NewDecoder(r).Decode(c); err != nil && !errors.Is(err, io.EOF) {
+	if err := yaml.NewDecoder(r, yaml.AllowDuplicateMapKey()).Decode(c); err != nil && !errors.Is(err, io.EOF) {
 		return nil, err
 	}
 	// verify loaded version is not higher than supported version

--- a/cmd/regbot/testdata/config1.yml
+++ b/cmd/regbot/testdata/config1.yml
@@ -6,9 +6,12 @@ defaults:
   parallel: 2
   interval: 60m
   timeout: 600s
+x-anchor: &anchor
+  name: this is overridden
+  timeout: 1m
 scripts:
-  - name: hello world
-    timeout: 1m
+  - <<: *anchor
+    name: hello world
     script: |
       log("hello world")
   - name: top of the hour

--- a/cmd/regsync/config.go
+++ b/cmd/regsync/config.go
@@ -122,7 +122,7 @@ func ConfigNew() *Config {
 // ConfigLoadReader reads the config from an io.Reader
 func ConfigLoadReader(r io.Reader) (*Config, error) {
 	c := ConfigNew()
-	if err := yaml.NewDecoder(r).Decode(c); err != nil && !errors.Is(err, io.EOF) {
+	if err := yaml.NewDecoder(r, yaml.AllowDuplicateMapKey()).Decode(c); err != nil && !errors.Is(err, io.EOF) {
 		return nil, err
 	}
 	// verify loaded version is not higher than supported version

--- a/cmd/regsync/testdata/config1.yml
+++ b/cmd/regsync/testdata/config1.yml
@@ -14,6 +14,7 @@ defaults:
   cacheTime: "5m"
 x-sync-hub: &sync-hub
   target: registry:5000/hub/{{ .Sync.Source }}
+  type: image
 x-sync-gcr: &sync-gcr
   target: registry:5000/gcr/{{ index (split .Sync.Source "gcr.io/") 1 }}
 sync:


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

A duplicate key error can be triggered when parsing certain yaml files, particularly with the anchor/alias syntax where a default is overridden.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Updates yaml config decoders to allow duplicate keys.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

See the updated config examples in the tests.

```shell
make test
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Fix: Allow duplicate keys in yaml config.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
