### PR TITLE
Chore: Update to SLSA v1 provenance

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -111,6 +111,7 @@ jobs:
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/ppc64le,linux/s390x
         target: release-${{ matrix.type }}
         outputs: type=oci,oci-artifact=true,dest=output/${{matrix.image}}-${{matrix.type}}.tar
+        provenance: version=v1,mode=max
         build-args: |
           SOURCE_DATE_EPOCH=${{ steps.prep.outputs.vcs_sec }}
           BUILD_DATE=${{ steps.prep.outputs.created }}

--- a/build/oci-image.sh
+++ b/build/oci-image.sh
@@ -82,6 +82,7 @@ fi
 docker buildx build --platform="$platforms" \
   -f "build/Dockerfile.${image}.buildkit" \
   -o "type=oci,oci-artifact=true,dest=output/${image}-${release}.tar" \
+  --provenance version=v1,mode=max \
   --target "release-${release}" \
   --build-arg "SOURCE_DATE_EPOCH=${vcs_sec}" \
   --build-arg "BUILD_DATE=${vcs_date}" \


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Update to SLSA v1 provenance in buildkit. See <https://github.com/moby/buildkit/pull/6005> for more details.

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

After merging and GHA finishes, with a buildkit version of 0.23 or greater, the following should now show a full SLSA v1 attestation:

```shell
regctl artifact get --platform local --filter-artifact-type application/vnd.docker.attestation.manifest.v1+json --subject ghcr.io/regclient/regctl:edge
```

Note, the current buildkit version in GHA is still v0.22.0.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Chore: Update to SLSA v1 provenance.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
