### PR TITLE
add "ns" query param to registry mirror requests

### DIFF
--- a/internal/reghttp/http.go
+++ b/internal/reghttp/http.go
@@ -324,9 +324,14 @@ func (resp *Resp) next() error {
 				if h.config.TLS == config.TLSDisabled {
 					u.Scheme = "http"
 				}
+				query := url.Values{}
 				if req.Query != nil {
-					u.RawQuery = req.Query.Encode()
+					query = req.Query
 				}
+				if h.config.Hostname != reqHost.config.Hostname {
+					query.Set("ns", reqHost.config.Hostname)
+				}
+				u.RawQuery = query.Encode()
 			}
 			// close previous response
 			if resp.resp != nil && resp.resp.Body != nil {


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->
N/A (I didn't create a separate issue)

### Describe the change

Adds a `ns` query param to registry mirror requests. This matches the behavior of Containerd's own [Registry Host Namespace](https://github.com/containerd/containerd/blob/main/docs/hosts.md#registry-host-namespace) implementation, and has become a common convention in registry-server implementations providing mirror functionality.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

<!-- Include steps that can be taken to verify the change -->
Perform a registry request against a configured mirror (where the host does not match the namespace), and verify that the request includes the `ns` query parameter corresponding to the namespace.

### Changelog text

<!-- If the release changelog should have an entry for this, include it here -->
- Add "ns" query param to registry mirror requests.

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
