### PR TITLE
Chore: Fix CLI lint errors

### DIFF
--- a/cmd/regctl/image.go
+++ b/cmd/regctl/image.go
@@ -107,7 +107,7 @@ func newImageCheckBaseCmd(rOpts *rootOpts) *cobra.Command {
 If the base name is not provided, annotations will be checked in the image.
 If the digest is available, this checks if that matches the base name.
 If the digest is not available, layers of each manifest are compared.
-If the layers match, the config (history and roots) are optionally compared.	
+If the layers match, the config (history and roots) are optionally compared.
 If the base image does not match, the command exits with a non-zero status.`,
 		Example: `
 # report if base image has changed using annotations

--- a/cmd/regctl/manifest.go
+++ b/cmd/regctl/manifest.go
@@ -60,7 +60,7 @@ func newManifestDeleteCmd(rOpts *rootOpts) *cobra.Command {
 		Aliases: []string{"del", "rm", "remove"},
 		Short:   "delete a manifest",
 		Long: `Delete a manifest. This will delete the manifest, and all tags pointing to that
-manifest. You must specify a digest, not a tag on this command (e.g. 
+manifest. You must specify a digest, not a tag on this command (e.g.
 image_name@sha256:1234abc...). It is up to the registry whether the delete
 API is supported. Additionally, registries may garbage collect the filesystem
 layers (blobs) separately or not at all. See also the "tag delete" command.`,


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Remove trailing whitespace that was throwing lint errors in the regclient.org markdown.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

<!-- Include steps that can be taken to verify the change -->

### Changelog text

<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [ ] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
