### PR TITLE
Chore: Cleanup version output

### DIFF
--- a/cmd/regbot/root.go
+++ b/cmd/regbot/root.go
@@ -71,9 +71,15 @@ returns after the last script completes.`,
 	versionCmd := &cobra.Command{
 		Use:   "version",
 		Short: "Show the version",
-		Long:  `Show the version`,
-		Args:  cobra.RangeArgs(0, 0),
-		RunE:  opts.runVersion,
+		Long:  fmt.Sprintf(`Show the version of %s. Note that docker image builds will always be marked "dirty".`, cmd.Name()),
+		Example: fmt.Sprintf(`
+# display full version details
+%[1]s version
+
+# retrieve the version number
+%[1]s version --format '{{.VCSTag}}'`, cmd.Name()),
+		Args: cobra.ExactArgs(0),
+		RunE: opts.runVersion,
 	}
 
 	cmd.PersistentFlags().StringArrayVar(&opts.logopts, "logopt", []string{}, "Log options")

--- a/cmd/regctl/root.go
+++ b/cmd/regctl/root.go
@@ -107,13 +107,13 @@ func newVersionCmd(rOpts *rootOpts) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "Show the version",
-		Long:  fmt.Sprintf(`Show the version of %s`, opts.rootOpts.name),
-		Example: `
+		Long:  fmt.Sprintf(`Show the version of %s. Note that docker image builds will always be marked "dirty".`, opts.rootOpts.name),
+		Example: fmt.Sprintf(`
 # display full version details
-regctl version
+%[1]s version
 
 # retrieve the version number
-regctl version --format '{{.VCSTag}}'`,
+%[1]s version --format '{{.VCSTag}}'`, opts.rootOpts.name),
 		Args: cobra.ExactArgs(0),
 		RunE: opts.runVersion,
 	}

--- a/cmd/regsync/root.go
+++ b/cmd/regsync/root.go
@@ -80,14 +80,14 @@ More details at <https://github.com/regclient/regclient>`,
 	cmd.PersistentFlags().StringVarP(&opts.verbosity, "verbosity", "v", slog.LevelInfo.String(), "Log level (trace, debug, info, warn, error)")
 	cmd.PersistentFlags().StringArrayVar(&opts.logopts, "logopt", []string{}, "Log options")
 
-	var serverCmd = &cobra.Command{
+	serverCmd := &cobra.Command{
 		Use:   "server",
 		Short: "run the regsync server",
 		Long:  `Sync registries according to the configuration.`,
 		Args:  cobra.RangeArgs(0, 0),
 		RunE:  opts.runServer,
 	}
-	var checkCmd = &cobra.Command{
+	checkCmd := &cobra.Command{
 		Use:   "check",
 		Short: "processes each sync command once but skip actual copy",
 		Long: `Processes each sync command in the configuration file in order.
@@ -97,7 +97,7 @@ sync step is finished.`,
 		Args: cobra.RangeArgs(0, 0),
 		RunE: opts.runCheck,
 	}
-	var onceCmd = &cobra.Command{
+	onceCmd := &cobra.Command{
 		Use:   "once",
 		Short: "processes each sync command once, ignoring cron schedule",
 		Long: `Processes each sync command in the configuration file in order.
@@ -107,7 +107,7 @@ sync step is finished.`,
 		RunE: opts.runOnce,
 	}
 	onceCmd.Flags().BoolVar(&opts.missing, "missing", false, "Only copy tags that are missing on target")
-	var configCmd = &cobra.Command{
+	configCmd := &cobra.Command{
 		Use:   "config",
 		Short: "Show the config",
 		Long:  `Show the config`,
@@ -123,12 +123,18 @@ sync step is finished.`,
 		curCmd.Flags().BoolVar(&opts.abortOnErr, "abort-on-error", false, "Immediately abort on any errors")
 	}
 
-	var versionCmd = &cobra.Command{
+	versionCmd := &cobra.Command{
 		Use:   "version",
 		Short: "Show the version",
-		Long:  `Show the version`,
-		Args:  cobra.RangeArgs(0, 0),
-		RunE:  opts.runVersion,
+		Long:  fmt.Sprintf(`Show the version of %s. Note that docker image builds will always be marked "dirty".`, cmd.Name()),
+		Example: fmt.Sprintf(`
+# display full version details
+%[1]s version
+
+# retrieve the version number
+%[1]s version --format '{{.VCSTag}}'`, cmd.Name()),
+		Args: cobra.ExactArgs(0),
+		RunE: opts.runVersion,
 	}
 	versionCmd.Flags().StringVar(&opts.format, "format", "{{printPretty .}}", "Format output with go template syntax")
 	_ = versionCmd.RegisterFlagCompletionFunc("format", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This makes the version output consistent between commands.
The `.dockerignore` causes all docker builds to be marked as "dirty" even when there are no changes to the repo.

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Chore: Cleanup version output.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
