### PR TITLE
Chore: Add go:fix lines to deprecated code

### DIFF
--- a/internal/auth/error.go
+++ b/internal/auth/error.go
@@ -8,33 +8,41 @@ var (
 	// ErrEmptyChallenge indicates an issue with the received challenge in the WWW-Authenticate header
 	//
 	// Deprecated: replace with [errs.ErrEmptyChallenge].
+	//go:fix inline
 	ErrEmptyChallenge = errs.ErrEmptyChallenge
 	// ErrInvalidChallenge indicates an issue with the received challenge in the WWW-Authenticate header
 	//
 	// Deprecated: replace with [errs.ErrInvalidChallenge].
+	//go:fix inline
 	ErrInvalidChallenge = errs.ErrInvalidChallenge
 	// ErrNoNewChallenge indicates a challenge update did not result in any change
 	//
 	// Deprecated: replace with [errs.ErrNoNewChallenge].
+	//go:fix inline
 	ErrNoNewChallenge = errs.ErrNoNewChallenge
 	// ErrNotFound indicates no credentials found for basic auth
 	//
 	// Deprecated: replace with [errs.ErrNotFound].
+	//go:fix inline
 	ErrNotFound = errs.ErrNotFound
 	// ErrNotImplemented returned when method has not been implemented yet
 	//
 	// Deprecated: replace with [errs.ErrNotImplemented].
+	//go:fix inline
 	ErrNotImplemented = errs.ErrNotImplemented
 	// ErrParseFailure indicates the WWW-Authenticate header could not be parsed
 	//
 	// Deprecated: replace with [errs.ErrParseFailure].
+	//go:fix inline
 	ErrParseFailure = errs.ErrParsingFailed
 	// ErrUnauthorized request was not authorized
 	//
 	// Deprecated: replace with [errs.ErrUnauthorized].
+	//go:fix inline
 	ErrUnauthorized = errs.ErrHTTPUnauthorized
 	// ErrUnsupported indicates the request was unsupported
 	//
 	// Deprecated: replace with [errs.ErrUnsupported].
+	//go:fix inline
 	ErrUnsupported = errs.ErrUnsupported
 )

--- a/mod/config.go
+++ b/mod/config.go
@@ -225,47 +225,17 @@ func WithConfigTimestamp(optTime OptTime) Opts {
 // WithConfigTimestampFromLabel sets the max timestamp in the config to match a label value.
 //
 // Deprecated: replace with [WithConfigTimestamp].
+//
+//go:fix inline
 func WithConfigTimestampFromLabel(label string) Opts {
-	return func(dc *dagConfig, dm *dagManifest) error {
-		dc.stepsOCIConfig = append(dc.stepsOCIConfig, func(c context.Context, rc *regclient.RegClient, rSrc, rTgt ref.Ref, doc *dagOCIConfig) error {
-			var err error
-			changed := false
-			oc := doc.oc.GetConfig()
-			tl, ok := oc.Config.Labels[label]
-			if !ok {
-				return fmt.Errorf("label not found: %s", label)
-			}
-			t, err := time.Parse(time.RFC3339, tl)
-			if err != nil {
-				// TODO: add fallbacks
-				return fmt.Errorf("could not parse time %s from %s: %w", tl, label, err)
-			}
-			if oc.Created != nil && t.Before(*oc.Created) {
-				*oc.Created = t
-				changed = true
-			}
-			if oc.History != nil {
-				for i, h := range oc.History {
-					if h.Created != nil && t.Before(*h.Created) {
-						*oc.History[i].Created = t
-						changed = true
-					}
-				}
-			}
-			if changed {
-				doc.oc.SetConfig(oc)
-				doc.newDesc = doc.oc.GetDescriptor()
-				doc.modified = true
-			}
-			return nil
-		})
-		return nil
-	}
+	return WithConfigTimestamp(OptTime{FromLabel: label})
 }
 
 // WithConfigTimestampMax sets the max timestamp on any config objects.
 //
 // Deprecated: replace with [WithConfigTimestamp].
+//
+//go:fix inline
 func WithConfigTimestampMax(t time.Time) Opts {
 	return WithConfigTimestamp(OptTime{
 		Set:   t,

--- a/regclient.go
+++ b/regclient.go
@@ -93,28 +93,28 @@ func New(opts ...Opt) *RegClient {
 // WithBlobLimit sets the max size for chunked blob uploads which get stored in memory.
 //
 // Deprecated: replace with WithRegOpts(reg.WithBlobLimit(limit)), see [WithRegOpts] and [reg.WithBlobLimit].
+//
+//go:fix inline
 func WithBlobLimit(limit int64) Opt {
-	return func(rc *RegClient) {
-		rc.regOpts = append(rc.regOpts, reg.WithBlobLimit(limit))
-	}
+	return WithRegOpts(reg.WithBlobLimit(limit))
 }
 
 // WithBlobSize overrides default blob sizes.
 //
 // Deprecated: replace with WithRegOpts(reg.WithBlobSize(chunk, max)), see [WithRegOpts] and [reg.WithBlobSize].
+//
+//go:fix inline
 func WithBlobSize(chunk, max int64) Opt {
-	return func(rc *RegClient) {
-		rc.regOpts = append(rc.regOpts, reg.WithBlobSize(chunk, max))
-	}
+	return WithRegOpts(reg.WithBlobSize(chunk, max))
 }
 
 // WithCertDir adds a path of certificates to trust similar to Docker's /etc/docker/certs.d.
 //
 // Deprecated: replace with WithRegOpts(reg.WithCertDirs(path)), see [WithRegOpts] and [reg.WithCertDirs].
+//
+//go:fix inline
 func WithCertDir(path ...string) Opt {
-	return func(rc *RegClient) {
-		rc.regOpts = append(rc.regOpts, reg.WithCertDirs(path))
-	}
+	return WithRegOpts(reg.WithCertDirs(path))
 }
 
 // WithConfigHost adds a list of config host settings.
@@ -134,13 +134,15 @@ func WithConfigHostDefault(configHost config.Host) Opt {
 // WithConfigHosts adds a list of config host settings.
 //
 // Deprecated: replace with [WithConfigHost].
+//
+//go:fix inline
 func WithConfigHosts(configHosts []config.Host) Opt {
 	return WithConfigHost(configHosts...)
 }
 
 // WithDockerCerts adds certificates trusted by docker in /etc/docker/certs.d.
 func WithDockerCerts() Opt {
-	return WithCertDir(DockerCertDir)
+	return WithRegOpts(reg.WithCertDirs([]string{DockerCertDir}))
 }
 
 // WithDockerCreds adds configuration from users docker config with registry logins.
@@ -184,19 +186,19 @@ func WithRegOpts(opts ...reg.Opts) Opt {
 // WithRetryDelay specifies the time permitted for retry delays.
 //
 // Deprecated: replace with WithRegOpts(reg.WithDelay(delayInit, delayMax)), see [WithRegOpts] and [reg.WithDelay].
+//
+//go:fix inline
 func WithRetryDelay(delayInit, delayMax time.Duration) Opt {
-	return func(rc *RegClient) {
-		rc.regOpts = append(rc.regOpts, reg.WithDelay(delayInit, delayMax))
-	}
+	return WithRegOpts(reg.WithDelay(delayInit, delayMax))
 }
 
 // WithRetryLimit specifies the number of retries for non-fatal errors.
 //
 // Deprecated: replace with WithRegOpts(reg.WithRetryLimit(retryLimit)), see [WithRegOpts] and [reg.WithRetryLimit].
+//
+//go:fix inline
 func WithRetryLimit(retryLimit int) Opt {
-	return func(rc *RegClient) {
-		rc.regOpts = append(rc.regOpts, reg.WithRetryLimit(retryLimit))
-	}
+	return WithRegOpts(reg.WithRetryLimit(retryLimit))
 }
 
 // WithSlog configures the slog Logger.

--- a/regclient/blob/blob.go
+++ b/regclient/blob/blob.go
@@ -12,18 +12,22 @@ type (
 	// Blob specifies a generic blob.
 	//
 	// Deprecated: replace with [blob.Blob].
+	//go:fix inline
 	Blob = topBlob.Blob
 	// OCIConfig is an interface for an OCI Config.
 	//
 	// Deprecated: replace with [blob.OCIConfig].
+	//go:fix inline
 	OCIConfig = topBlob.OCIConfig
 	// Common is an interface of common methods for blobs.
 	//
 	// Deprecated: replace with [blob.Common].
+	//go:fix inline
 	Common = topBlob.Common
 	// Reader is an interface for blob reader methods.
 	//
 	// Deprecated: replace with [blob.Reader].
+	//go:fix inline
 	Reader = topBlob.Reader
 )
 
@@ -31,9 +35,11 @@ var (
 	// NewOCIConfig
 	//
 	// Deprecated: replace with [blob.NewOCIConfig].
+	//go:fix inline
 	NewOCIConfig = topBlob.NewOCIConfig
 	// NewReader
 	//
 	// Deprecated: replace with [blob.NewReader].
+	//go:fix inline
 	NewReader = topBlob.NewReader
 )

--- a/regclient/config.go
+++ b/regclient/config.go
@@ -13,10 +13,12 @@ type (
 	// ConfigHost defines settings for connecting to a registry.
 	//
 	// Deprecated: replace with [config.Host].
+	//go:fix inline
 	ConfigHost = config.Host
 	// TLSConf specifies whether TLS is enabled and verified for a host.
 	//
 	// Deprecated: replace with [config.TLSConf].
+	//go:fix inline
 	TLSConf = config.TLSConf
 )
 
@@ -24,6 +26,7 @@ var (
 	// ConfigHostNewName
 	//
 	// Deprecated: replace with [config.ConfigHostNewName].
+	//go:fix inline
 	ConfigHostNewName = config.HostNewName
 )
 
@@ -31,17 +34,21 @@ const (
 	// TLSUndefined
 	//
 	// Deprecated: replace with [config.TLSUndefined].
+	//go:fix inline
 	TLSUndefined = config.TLSUndefined
 	// TLSEnabled
 	//
 	// Deprecated: replace with [config.TLSEnabled].
+	//go:fix inline
 	TLSEnabled = config.TLSEnabled
 	// TLSInsecure
 	//
 	// Deprecated: replace with [config.TLSInsecure].
+	//go:fix inline
 	TLSInsecure = config.TLSInsecure
 	// TLSDisabled
 	//
 	// Deprecated: replace with [config.TLSDisabled].
+	//go:fix inline
 	TLSDisabled = config.TLSDisabled
 )

--- a/regclient/error.go
+++ b/regclient/error.go
@@ -13,74 +13,92 @@ var (
 	// ErrAPINotFound
 	//
 	// Deprecated: replace with [errs.ErrAPINotFound].
+	//go:fix inline
 	ErrAPINotFound = errs.ErrAPINotFound
 	// ErrCanceled
 	//
 	// Deprecated: replace with [errs.ErrCanceled].
+	//go:fix inline
 	ErrCanceled = errs.ErrCanceled
 	//lint:ignore ST1003 exported field cannot be changed for legacy reasons
 	// ErrHttpStatus
 	//
 	// Deprecated: replace with [errs.ErrHttpStatus].
+	//go:fix inline
 	ErrHttpStatus = errs.ErrHTTPStatus
 	// ErrMissingDigest
 	//
 	// Deprecated: replace with [errs.ErrMissingDigest].
+	//go:fix inline
 	ErrMissingDigest = errs.ErrMissingDigest
 	// ErrMissingLocation
 	//
 	// Deprecated: replace with [errs.ErrMissingLocation].
+	//go:fix inline
 	ErrMissingLocation = errs.ErrMissingLocation
 	// ErrMissingName
 	//
 	// Deprecated: replace with [errs.ErrMissingName].
+	//go:fix inline
 	ErrMissingName = errs.ErrMissingName
 	// ErrMissingTag
 	//
 	// Deprecated: replace with [errs.ErrMissingTag].
+	//go:fix inline
 	ErrMissingTag = errs.ErrMissingTag
 	// ErrMissingTagOrDigest
 	//
 	// Deprecated: replace with [errs.ErrMissingTagOrDigest].
+	//go:fix inline
 	ErrMissingTagOrDigest = errs.ErrMissingTagOrDigest
 	// ErrMountReturnedLocation
 	//
 	// Deprecated: replace with [errs.ErrMountReturnedLocation].
+	//go:fix inline
 	ErrMountReturnedLocation = errs.ErrMountReturnedLocation
 	// ErrNotFound
 	//
 	// Deprecated: replace with [errs.ErrNotFound].
+	//go:fix inline
 	ErrNotFound = errs.ErrNotFound
 	// ErrNotImplemented
 	//
 	// Deprecated: replace with [errs.ErrNotImplemented].
+	//go:fix inline
 	ErrNotImplemented = errs.ErrNotImplemented
 	// ErrParsingFailed
 	//
 	// Deprecated: replace with [errs.ErrParsingFailed].
+	//go:fix inline
 	ErrParsingFailed = errs.ErrParsingFailed
 	// ErrRateLimit
 	//
 	// Deprecated: replace with [errs.ErrRateLimit].
+	//go:fix inline
 	ErrRateLimit = errs.ErrHTTPRateLimit
 	// ErrUnavailable
 	//
 	// Deprecated: replace with [errs.ErrUnavailable].
+	//go:fix inline
 	ErrUnavailable = errs.ErrUnavailable
 	// ErrUnauthorized
 	//
 	// Deprecated: replace with [errs.ErrUnauthorized].
+	//go:fix inline
 	ErrUnauthorized = errs.ErrHTTPUnauthorized
 	// ErrUnsupportedAPI
 	//
 	// Deprecated: replace with [errs.ErrUnsupportedAPI].
+	//go:fix inline
 	ErrUnsupportedAPI = errs.ErrUnsupportedAPI
 	// ErrUnsupportedConfigVersion
 	//
 	// Deprecated: replace with [errs.ErrUnsupportedConfigVersion].
+	//go:fix inline
 	ErrUnsupportedConfigVersion = errs.ErrUnsupportedConfigVersion
 	// ErrUnsupportedMediaType
 	//
 	// Deprecated: replace with [errs.ErrUnsupportedMediaType].
+	//go:fix inline
 	ErrUnsupportedMediaType = errs.ErrUnsupportedMediaType
 )

--- a/regclient/manifest/manifest.go
+++ b/regclient/manifest/manifest.go
@@ -18,50 +18,62 @@ const (
 	// MediaTypeDocker1Manifest
 	//
 	// Deprecated: replace with [mediatype.Docker1Manifest].
+	//go:fix inline
 	MediaTypeDocker1Manifest = mediatype.Docker1Manifest
 	// MediaTypeDocker1ManifestSigned
 	//
 	// Deprecated: replace with [mediatype.Docker1ManifestSigned].
+	//go:fix inline
 	MediaTypeDocker1ManifestSigned = mediatype.Docker1ManifestSigned
 	// MediaTypeDocker2Manifest
 	//
 	// Deprecated: replace with [mediatype.Docker2Manifest].
+	//go:fix inline
 	MediaTypeDocker2Manifest = mediatype.Docker2Manifest
 	// MediaTypeDocker2ManifestList
 	//
 	// Deprecated: replace with [mediatype.Docker2ManifestList].
+	//go:fix inline
 	MediaTypeDocker2ManifestList = mediatype.Docker2ManifestList
 	// MediaTypeDocker2ImageConfig
 	//
 	// Deprecated: replace with [mediatype.Docker2ImageConfig].
+	//go:fix inline
 	MediaTypeDocker2ImageConfig = mediatype.Docker2ImageConfig
 	// MediaTypeOCI1Manifest
 	//
 	// Deprecated: replace with [mediatype.OCI1Manifest].
+	//go:fix inline
 	MediaTypeOCI1Manifest = mediatype.OCI1Manifest
 	// MediaTypeOCI1ManifestList
 	//
 	// Deprecated: replace with [mediatype.OCI1ManifestList].
+	//go:fix inline
 	MediaTypeOCI1ManifestList = mediatype.OCI1ManifestList
 	// MediaTypeOCI1ImageConfig
 	//
 	// Deprecated: replace with [mediatype.OCI1ImageConfig].
+	//go:fix inline
 	MediaTypeOCI1ImageConfig = mediatype.OCI1ImageConfig
 	// MediaTypeDocker2Layer
 	//
 	// Deprecated: replace with [mediatype.Docker2Layer].
+	//go:fix inline
 	MediaTypeDocker2Layer = mediatype.Docker2LayerGzip
 	// MediaTypeOCI1Layer
 	//
 	// Deprecated: replace with [mediatype.OCI1Layer].
+	//go:fix inline
 	MediaTypeOCI1Layer = mediatype.OCI1Layer
 	// MediaTypeOCI1LayerGzip
 	//
 	// Deprecated: replace with [mediatype.OCI1LayerGzip].
+	//go:fix inline
 	MediaTypeOCI1LayerGzip = mediatype.OCI1LayerGzip
 	// MediaTypeBuildkitCacheConfig
 	//
 	// Deprecated: replace with [mediatype.BuildkitCacheConfig].
+	//go:fix inline
 	MediaTypeBuildkitCacheConfig = mediatype.BuildkitCacheConfig
 )
 
@@ -70,6 +82,7 @@ type (
 	// many calls are only supported by certain underlying media types.
 	//
 	// Deprecated: replace with [manifest.Manifest].
+	//go:fix inline
 	Manifest = topManifest.Manifest
 )
 
@@ -77,24 +90,30 @@ var (
 	// ErrNotFound
 	//
 	// Deprecated: replace with [errs.ErrNotFound].
+	//go:fix inline
 	ErrNotFound = errs.ErrNotFound
 	// ErrNotImplemented
 	//
 	// Deprecated: replace with [errs.ErrNotImplemented].
+	//go:fix inline
 	ErrNotImplemented = errs.ErrNotImplemented
 	// ErrUnavailable
 	//
 	// Deprecated: replace with [errs.ErrUnavailable].
+	//go:fix inline
 	ErrUnavailable = errs.ErrUnavailable
 	// ErrUnsupportedMediaType
 	//
 	// Deprecated: replace with [errs.ErrUnsupportedMediaType].
+	//go:fix inline
 	ErrUnsupportedMediaType = errs.ErrUnsupported
 )
 
 // New creates a new manifest.
 //
 // Deprecated: replace with [manifest.New].
+//
+//go:fix inline
 func New(mediaType string, raw []byte, r ref.Ref, header http.Header) (Manifest, error) {
 	return topManifest.New(
 		topManifest.WithDesc(topTypes.Descriptor{
@@ -109,6 +128,8 @@ func New(mediaType string, raw []byte, r ref.Ref, header http.Header) (Manifest,
 // FromDescriptor creates a manifest from a descriptor.
 //
 // Deprecated: replace with [manifest.New].
+//
+//go:fix inline
 func FromDescriptor(desc topTypes.Descriptor, mBytes []byte) (Manifest, error) {
 	return topManifest.New(
 		topManifest.WithDesc(desc),
@@ -119,6 +140,8 @@ func FromDescriptor(desc topTypes.Descriptor, mBytes []byte) (Manifest, error) {
 // FromOrig creates a manifest from an underlying manifest struct.
 //
 // Deprecated: replace with [manifest.New].
+//
+//go:fix inline
 func FromOrig(orig interface{}) (Manifest, error) {
 	return topManifest.New(topManifest.WithOrig(orig))
 }

--- a/regclient/mediatype.go
+++ b/regclient/mediatype.go
@@ -11,49 +11,61 @@ var (
 	// MediaTypeDocker1Manifest
 	//
 	// Deprecated: replace with [mediatype.Docker1Manifest].
+	//go:fix inline
 	MediaTypeDocker1Manifest = mediatype.Docker1Manifest
 	// MediaTypeDocker1ManifestSigned
 	//
 	// Deprecated: replace with [mediatype.Docker1ManifestSigned]
+	//go:fix inline
 	MediaTypeDocker1ManifestSigned = mediatype.Docker1ManifestSigned
 	// MediaTypeDocker2Manifest
 	//
 	// Deprecated: replace with [mediatype.Docker2Manifest].
+	//go:fix inline
 	MediaTypeDocker2Manifest = mediatype.Docker2Manifest
 	// MediaTypeDocker2ManifestList
 	//
 	// Deprecated: replace with [mediatype.Docker2ManifestList].
+	//go:fix inline
 	MediaTypeDocker2ManifestList = mediatype.Docker2ManifestList
 	// MediaTypeDocker2ImageConfig
 	//
 	// Deprecated: replace with [mediatype.Docker2ImageConfig].
+	//go:fix inline
 	MediaTypeDocker2ImageConfig = mediatype.Docker2ImageConfig
 	// MediaTypeOCI1Manifest
 	//
 	// Deprecated: replace with [mediatype.OCI1Manifest].
+	//go:fix inline
 	MediaTypeOCI1Manifest = mediatype.OCI1Manifest
 	// MediaTypeOCI1ManifestList
 	//
 	// Deprecated: replace with [mediatype.OCI1ManifestList].
+	//go:fix inline
 	MediaTypeOCI1ManifestList = mediatype.OCI1ManifestList
 	// MediaTypeOCI1ImageConfig
 	//
 	// Deprecated: replace with [mediatype.OCI1ImageConfig].
+	//go:fix inline
 	MediaTypeOCI1ImageConfig = mediatype.OCI1ImageConfig
 	// MediaTypeDocker2Layer
 	//
 	// Deprecated: replace with [mediatype.Docker2Layer].
+	//go:fix inline
 	MediaTypeDocker2Layer = mediatype.Docker2LayerGzip
 	// MediaTypeOCI1Layer
 	//
 	// Deprecated: replace with [mediatype.OCI1Layer].
+	//go:fix inline
 	MediaTypeOCI1Layer = mediatype.OCI1Layer
 	// MediaTypeOCI1LayerGzip
 	//
 	// Deprecated: replace with [mediatype.OCI1LayerGzip].
+	//go:fix inline
 	MediaTypeOCI1LayerGzip = mediatype.OCI1LayerGzip
 	// MediaTypeBuildkitCacheConfig
 	//
 	// Deprecated: replace with [mediatype.BuildkitCacheConfig].
+	//go:fix inline
 	MediaTypeBuildkitCacheConfig = mediatype.BuildkitCacheConfig
 )

--- a/regclient/regclient.go
+++ b/regclient/regclient.go
@@ -37,42 +37,52 @@ type (
 	// RegClient is used to access OCI distribution-spec registries.
 	//
 	// Deprecated: replace with [regclient.RegClient]
+	//go:fix inline
 	RegClient = *rcTop.RegClient
 	// Client is used to access OCI distribution-spec registries.
 	//
 	// Deprecated: replace with [regclient.RegClient]
+	//go:fix inline
 	Client = *rcTop.RegClient
 	// Opt functions are used by [New] to create a [*RegClient].
 	//
 	// Deprecated: replace with [regclient.Opt]
+	//go:fix inline
 	Opt = rcTop.Opt
 	// ImageOpts functions are used by image methods.
 	//
 	// Deprecated: replace with [regclient.ImageOpts]
+	//go:fix inline
 	ImageOpts = rcTop.ImageOpts
 	// RepoList is the response for a registry listing.
 	//
 	// Deprecated: replace with [repo.RepoList]
+	//go:fix inline
 	RepoList = *repo.RepoList
 	// RepoDockerList is a list of repositories from the _catalog API
 	//
 	// Deprecated: replace with [repo.RepoRegistryList
+	//go:fix inline
 	RepoDockerList = repo.RepoRegistryList
 	// RepoOpts is a breaking change (struct to func opts)
 	//
 	// Deprecated: replace with [regclient.RepoOpts]
+	//go:fix inline
 	RepoOpts = scheme.RepoOpts
 	// TagList contains a tag list.
 	//
 	// Deprecated: replace with [tag.List]
+	//go:fix inline
 	TagList = *tag.List
 	// TagDockerList is returned from registry/2.0 API's
 	//
 	// Deprecated: replace with [tag.DockerList]
+	//go:fix inline
 	TagDockerList = tag.DockerList
 	// TagOpts is used to set options on tag APIs.
 	//
 	// Deprecated: replace with [scheme.TagOpts]
+	//go:fix inline
 	TagOpts = scheme.TagOpts
 )
 
@@ -80,73 +90,91 @@ var (
 	// NewRegClient creates a new regclient instance.
 	//
 	// Deprecated: replace with [regclient.New].
+	//go:fix inline
 	NewRegClient = rcTop.New
 	// WithCertDir adds a path of certificates to trust similar to Docker's /etc/docker/certs.d.
 	//
 	// Deprecated: replace with [regclient.WithCertDir].
+	//go:fix inline
 	WithCertDir = rcTop.WithCertDir
 	// WithDockerCerts adds certificates trusted by docker in /etc/docker/certs.d.
 	//
 	// Deprecated: replace with [regclient.WithDockerCerts].
+	//go:fix inline
 	WithDockerCerts = rcTop.WithDockerCerts
 	// WithDockerCreds adds configuration from users docker config with registry logins.
 	//
 	// Deprecated: replace with [regclient.WithDockerCreds].
+	//go:fix inline
 	WithDockerCreds = rcTop.WithDockerCreds
 	// WithConfigHosts adds a list of config host settings.
 	//
 	// Deprecated: replace with [regclient.WithConfigHosts].
+	//go:fix inline
 	WithConfigHosts = rcTop.WithConfigHosts
 	// WithConfigHost adds a list of config host settings.
 	//
 	// Deprecated: replace with [regclient.WithConfigHost].
+	//go:fix inline
 	WithConfigHost = rcTop.WithConfigHost
 	// WithBlobSize overrides default blob sizes.
 	//
 	// Deprecated: replace with [regclient.WithBlobSize].
+	//go:fix inline
 	WithBlobSize = rcTop.WithBlobSize
 	// WithLog overrides default logrus Logger.
 	//
 	// Deprecated: replace with [regclient.WithLog].
+	//go:fix inline
 	WithLog = rcTop.WithLog
 	// WithRetryDelay specifies the time permitted for retry delays.
 	//
 	// Deprecated: replace with [regclient.WithRetryDelay].
+	//go:fix inline
 	WithRetryDelay = rcTop.WithRetryDelay
 	// WithRetryLimit specifies the number of retries for non-fatal errors.
 	//
 	// Deprecated: replace with [regclient.WithRetryLimit].
+	//go:fix inline
 	WithRetryLimit = rcTop.WithRetryLimit
 	// WithUserAgent specifies the User-Agent http header.
 	//
 	// Deprecated: replace with [regclient.WithUserAgent].
+	//go:fix inline
 	WithUserAgent = rcTop.WithUserAgent
 	// ImageWithForceRecursive attempts to copy every manifest and blob even if parent manifests already exist in ImageCopy.
 	//
 	// Deprecated: replace with [regclient.ImageWithForceRecursive].
+	//go:fix inline
 	ImageWithForceRecursive = rcTop.ImageWithForceRecursive
 	// ImageWithDigestTags looks for "sha-<digest>.*" tags in the repo to copy with any manifest in ImageCopy.
 	//
 	// Deprecated: replace with [regclient.ImageWithDigestTags].
+	//go:fix inline
 	ImageWithDigestTags = rcTop.ImageWithDigestTags
 	// ImageWithPlatform requests specific platforms from a manifest list in ImageCheckBase.
 	//
 	// Deprecated: replace with [regclient.ImageWithPlatforms].
+	//go:fix inline
 	ImageWithPlatforms = rcTop.ImageWithPlatforms
 	// WithRepoLast passes the last received repository for requesting the next batch of repositories.
 	//
 	// Deprecated: replace with [scheme.WithRepoLast].
+	//go:fix inline
 	WithRepoLast = scheme.WithRepoLast
 	// WithRepoLimit passes a maximum number of repositories to return to the repository list API.
 	//
 	// Deprecated: replace with [scheme.WithRepoLimit].
+	//go:fix inline
 	WithRepoLimit = scheme.WithRepoLimit
 	// TagOptLast passes the last received tag for requesting the next batch of tags.
 	//
 	// Deprecated: replace with [scheme.WithTagLast].
+	//go:fix inline
 	TagOptLast = scheme.WithTagLast
 	// TagOptLimit passes a maximum number of tags to return to the tag list API.
 	//
 	// Deprecated: replace with [scheme.WithTagLimit].
+	//go:fix inline
 	TagOptLimit = scheme.WithTagLimit
 )

--- a/regclient/template.go
+++ b/regclient/template.go
@@ -12,4 +12,6 @@ import (
 // TemplateFuncs adds functions to a template.
 //
 // Deprecated: replace with [gotemplate.FuncMap].
+//
+//go:fix inline
 var TemplateFuncs = gotemplate.FuncMap{}

--- a/regclient/types/error.go
+++ b/regclient/types/error.go
@@ -13,106 +13,132 @@ var (
 	// ErrAllRequestsFailed
 	//
 	// Deprecated: replace with [errs.ErrAllRequestsFailed].
+	//go:fix inline
 	ErrAllRequestsFailed = errs.ErrAllRequestsFailed
 	// ErrAPINotFound
 	//
 	// Deprecated: replace with [errs.ErrAPINotFound].
+	//go:fix inline
 	ErrAPINotFound = errs.ErrAPINotFound
 	// ErrBackoffLimit
 	//
 	// Deprecated: replace with [errs.ErrBackoffLimit].
+	//go:fix inline
 	ErrBackoffLimit = errs.ErrBackoffLimit
 	// ErrCanceled
 	//
 	// Deprecated: replace with [errs.ErrCanceled].
+	//go:fix inline
 	ErrCanceled = errs.ErrCanceled
 	// ErrDigestMismatch
 	//
 	// Deprecated: replace with [errs.ErrDigestMismatch].
+	//go:fix inline
 	ErrDigestMismatch = errs.ErrDigestMismatch
 	// ErrEmptyChallenge
 	//
 	// Deprecated: replace with [errs.ErrEmptyChallenge].
+	//go:fix inline
 	ErrEmptyChallenge = errs.ErrEmptyChallenge
 	//lint:ignore ST1003 exported field cannot be changed for legacy reasons
 	// ErrHttpStatus
 	//
 	// Deprecated: replace with [errs.ErrHttpStatus].
+	//go:fix inline
 	ErrHttpStatus = errs.ErrHTTPStatus
 	// ErrInvalidChallenge
 	//
 	// Deprecated: replace with [errs.ErrInvalidChallenge].
+	//go:fix inline
 	ErrInvalidChallenge = errs.ErrInvalidChallenge
 	// ErrMissingDigest
 	//
 	// Deprecated: replace with [errs.ErrMissingDigest].
+	//go:fix inline
 	ErrMissingDigest = errs.ErrMissingDigest
 	// ErrMissingLocation
 	//
 	// Deprecated: replace with [errs.ErrMissingLocation].
+	//go:fix inline
 	ErrMissingLocation = errs.ErrMissingLocation
 	// ErrMissingName
 	//
 	// Deprecated: replace with [errs.ErrMissingName].
+	//go:fix inline
 	ErrMissingName = errs.ErrMissingName
 	// ErrMissingTag
 	//
 	// Deprecated: replace with [errs.ErrMissingTag].
+	//go:fix inline
 	ErrMissingTag = errs.ErrMissingTag
 	// ErrMissingTagOrDigest
 	//
 	// Deprecated: replace with [errs.ErrMissingTagOrDigest].
+	//go:fix inline
 	ErrMissingTagOrDigest = errs.ErrMissingTagOrDigest
 	// ErrMountReturnedLocation
 	//
 	// Deprecated: replace with [errs.ErrMountReturnedLocation].
+	//go:fix inline
 	ErrMountReturnedLocation = errs.ErrMountReturnedLocation
 	// ErrNoNewChallenge
 	//
 	// Deprecated: replace with [errs.ErrNoNewChallenge].
+	//go:fix inline
 	ErrNoNewChallenge = errs.ErrNoNewChallenge
 	// ErrNotFound
 	//
 	// Deprecated: replace with [errs.ErrNotFound].
+	//go:fix inline
 	ErrNotFound = errs.ErrNotFound
 	// ErrNotImplemented
 	//
 	// Deprecated: replace with [errs.ErrNotImplemented].
+	//go:fix inline
 	ErrNotImplemented = errs.ErrNotImplemented
 	// ErrParsingFailed
 	//
 	// Deprecated: replace with [errs.ErrParsingFailed].
+	//go:fix inline
 	ErrParsingFailed = errs.ErrParsingFailed
 	// ErrRateLimit
 	//
 	// Deprecated: replace with [errs.ErrRateLimit].
+	//go:fix inline
 	ErrRateLimit = errs.ErrHTTPRateLimit
 	// ErrRetryNeeded
 	//
 	// Deprecated: replace with [errs.ErrRetryNeeded].
+	//go:fix inline
 	ErrRetryNeeded = errs.ErrRetryNeeded
 	// ErrUnavailable
 	//
 	// Deprecated: replace with [errs.ErrUnavailable].
+	//go:fix inline
 	ErrUnavailable = errs.ErrUnavailable
 	// ErrUnauthorized
 	//
 	// Deprecated: replace with [errs.ErrUnauthorized].
+	//go:fix inline
 	ErrUnauthorized = errs.ErrHTTPUnauthorized
 	// ErrUnsupported
 	//
 	// Deprecated: replace with [errs.ErrUnsupported].
+	//go:fix inline
 	ErrUnsupported = errs.ErrUnsupported
 	// ErrUnsupportedAPI
 	//
 	// Deprecated: replace with [errs.ErrUnsupportedAPI].
+	//go:fix inline
 	ErrUnsupportedAPI = errs.ErrUnsupportedAPI
 	// ErrUnsupportedConfigVersion
 	//
 	// Deprecated: replace with [errs.ErrUnsupportedConfigVersion].
+	//go:fix inline
 	ErrUnsupportedConfigVersion = errs.ErrUnsupportedConfigVersion
 	// ErrUnsupportedMediaType
 	//
 	// Deprecated: replace with [errs.ErrUnsupportedMediaType].
+	//go:fix inline
 	ErrUnsupportedMediaType = errs.ErrUnsupportedMediaType
 )

--- a/regclient/types/mediatype.go
+++ b/regclient/types/mediatype.go
@@ -13,49 +13,61 @@ const (
 	// MediaTypeDocker1Manifest
 	//
 	// Deprecated: replaced by [mediatype.Docker1Manifest].
+	//go:fix inline
 	MediaTypeDocker1Manifest = mediatype.Docker1Manifest
 	// MediaTypeDocker1ManifestSigned
 	//
 	// Deprecated: replaced by [mediatype.Docker1ManifestSigned]
+	//go:fix inline
 	MediaTypeDocker1ManifestSigned = mediatype.Docker1ManifestSigned
 	// MediaTypeDocker2Manifest
 	//
 	// Deprecated: replaced by [mediatype.Docker2Manifest].
+	//go:fix inline
 	MediaTypeDocker2Manifest = mediatype.Docker2Manifest
 	// MediaTypeDocker2ManifestList
 	//
 	// Deprecated: replaced by [mediatype.Docker2ManifestList].
+	//go:fix inline
 	MediaTypeDocker2ManifestList = mediatype.Docker2ManifestList
 	// MediaTypeDocker2ImageConfig
 	//
 	// Deprecated: replaced by [mediatype.Docker2ImageConfig].
+	//go:fix inline
 	MediaTypeDocker2ImageConfig = mediatype.Docker2ImageConfig
 	// MediaTypeOCI1Manifest
 	//
 	// Deprecated: replaced by [mediatype.OCI1Manifest].
+	//go:fix inline
 	MediaTypeOCI1Manifest = mediatype.OCI1Manifest
 	// MediaTypeOCI1ManifestList
 	//
 	// Deprecated: replaced by [mediatype.OCI1ManifestList].
+	//go:fix inline
 	MediaTypeOCI1ManifestList = mediatype.OCI1ManifestList
 	// MediaTypeOCI1ImageConfig
 	//
 	// Deprecated: replaced by [mediatype.OCI1ImageConfig].
+	//go:fix inline
 	MediaTypeOCI1ImageConfig = mediatype.OCI1ImageConfig
 	// MediaTypeDocker2Layer
 	//
 	// Deprecated: replaced by [mediatype.Docker2Layer].
+	//go:fix inline
 	MediaTypeDocker2Layer = mediatype.Docker2LayerGzip
 	// MediaTypeOCI1Layer
 	//
 	// Deprecated: replaced by [mediatype.OCI1Layer].
+	//go:fix inline
 	MediaTypeOCI1Layer = mediatype.OCI1Layer
 	// MediaTypeOCI1LayerGzip
 	//
 	// Deprecated: replaced by [mediatype.OCI1LayerGzip].
+	//go:fix inline
 	MediaTypeOCI1LayerGzip = mediatype.OCI1LayerGzip
 	// MediaTypeBuildkitCacheConfig
 	//
 	// Deprecated: replaced by [mediatype.BuildkitCacheConfig].
+	//go:fix inline
 	MediaTypeBuildkitCacheConfig = mediatype.BuildkitCacheConfig
 )

--- a/regclient/types/ratelimit.go
+++ b/regclient/types/ratelimit.go
@@ -12,4 +12,6 @@ import (
 // RateLimit is returned from some http requests
 //
 // Deprecated: replace with [types.RateLimit].
+//
+//go:fix inline
 type RateLimit = topTypes.RateLimit

--- a/regclient/types/ref.go
+++ b/regclient/types/ref.go
@@ -12,9 +12,13 @@ import (
 // Ref is used for a reference to an image or repository.
 //
 // Deprecated: replace with [ref.Ref].
+//
+//go:fix inline
 type Ref = ref.Ref
 
 // NewRef create a new [Ref].
 //
 // Deprecated: replace with [ref.New].
+//
+//go:fix inline
 var NewRef = ref.New

--- a/scheme/scheme.go
+++ b/scheme/scheme.go
@@ -117,7 +117,7 @@ type ReferrerOpts func(*ReferrerConfig)
 // WithReferrerMatchOpt filters results using [descriptor.MatchOpt].
 func WithReferrerMatchOpt(mo descriptor.MatchOpt) ReferrerOpts {
 	return func(config *ReferrerConfig) {
-		config.MatchOpt = mo
+		config.MatchOpt = config.MatchOpt.Merge(mo)
 	}
 }
 
@@ -140,35 +140,28 @@ func WithReferrerSource(r ref.Ref) ReferrerOpts {
 // WithReferrerAT filters by a specific artifactType value.
 //
 // Deprecated: replace with [WithReferrerMatchOpt].
+//
+//go:fix inline
 func WithReferrerAT(at string) ReferrerOpts {
-	return func(config *ReferrerConfig) {
-		config.MatchOpt.ArtifactType = at
-	}
+	return WithReferrerMatchOpt(descriptor.MatchOpt{ArtifactType: at})
 }
 
 // WithReferrerAnnotations filters by a list of annotations, all of which must match.
 //
 // Deprecated: replace with [WithReferrerMatchOpt].
+//
+//go:fix inline
 func WithReferrerAnnotations(annotations map[string]string) ReferrerOpts {
-	return func(config *ReferrerConfig) {
-		if config.MatchOpt.Annotations == nil {
-			config.MatchOpt.Annotations = annotations
-		} else {
-			for k, v := range annotations {
-				config.MatchOpt.Annotations[k] = v
-			}
-		}
-	}
+	return WithReferrerMatchOpt(descriptor.MatchOpt{Annotations: annotations})
 }
 
 // WithReferrerSort orders the resulting referrers listing according to a specified annotation.
 //
 // Deprecated: replace with [WithReferrerMatchOpt].
+//
+//go:fix inline
 func WithReferrerSort(annotation string, desc bool) ReferrerOpts {
-	return func(config *ReferrerConfig) {
-		config.MatchOpt.SortAnnotation = annotation
-		config.MatchOpt.SortDesc = desc
-	}
+	return WithReferrerMatchOpt(descriptor.MatchOpt{SortAnnotation: annotation, SortDesc: desc})
 }
 
 // ReferrerFilter filters the referrer list according to the config.

--- a/types/blob/common.go
+++ b/types/blob/common.go
@@ -33,6 +33,8 @@ func (c *BCommon) GetDescriptor() descriptor.Descriptor {
 // Digest returns the provided or calculated digest of the blob.
 //
 // Deprecated: Digest should be replaced by GetDescriptor().Digest, see [GetDescriptor].
+//
+//go:fix inline
 func (c *BCommon) Digest() digest.Digest {
 	return c.desc.Digest
 }
@@ -40,6 +42,8 @@ func (c *BCommon) Digest() digest.Digest {
 // Length returns the provided or calculated length of the blob.
 //
 // Deprecated: Length should be replaced by GetDescriptor().Size, see [GetDescriptor].
+//
+//go:fix inline
 func (c *BCommon) Length() int64 {
 	return c.desc.Size
 }
@@ -47,6 +51,8 @@ func (c *BCommon) Length() int64 {
 // MediaType returns the Content-Type header received from the registry.
 //
 // Deprecated: MediaType should be replaced by GetDescriptor().MediaType, see [GetDescriptor].
+//
+//go:fix inline
 func (c *BCommon) MediaType() string {
 	return c.desc.MediaType
 }

--- a/types/descriptor.go
+++ b/types/descriptor.go
@@ -6,10 +6,12 @@ type (
 	// Descriptor is used in manifests to refer to content by media type, size, and digest.
 	//
 	// Deprecated: replace with [descriptor.Descriptor].
+	//go:fix inline
 	Descriptor = descriptor.Descriptor
 	// MatchOpt defines conditions for a match descriptor.
 	//
 	// Deprecated: replace with [descriptor.MatchOpt].
+	//go:fix inline
 	MatchOpt = descriptor.MatchOpt
 )
 
@@ -17,11 +19,22 @@ var (
 	// EmptyData is the content of the empty JSON descriptor. See [mediatype.OCI1Empty].
 	//
 	// Deprecated: replace with [descriptor.EmptyData].
+	//go:fix inline
 	EmptyData = descriptor.EmptyData
 	// EmptyDigest is the digest of the empty JSON descriptor. See [mediatype.OCI1Empty].
 	//
 	// Deprecated: replace with [descriptor.EmptyDigest].
-	EmptyDigest          = descriptor.EmptyDigest
+	//go:fix inline
+	EmptyDigest = descriptor.EmptyDigest
+	// DescriptorListFilter returns a list of descriptors from the list matching the search options.
+	// When opt.SortAnnotation is set, the order of descriptors with matching annotations is undefined.
+	//
+	// Deprecated: replace with [descriptor.DescriptorListFilter]
+	//go:fix inline
 	DescriptorListFilter = descriptor.DescriptorListFilter
+	// DescriptorListSearch returns the first descriptor from the list matching the search options.
+	//
+	// Deprecated: replace with [descriptor.DescriptorListSearch]
+	//go:fix inline
 	DescriptorListSearch = descriptor.DescriptorListSearch
 )

--- a/types/descriptor/descriptor.go
+++ b/types/descriptor/descriptor.go
@@ -3,6 +3,7 @@ package descriptor
 
 import (
 	"fmt"
+	"maps"
 	"sort"
 	"strings"
 	"text/tabwriter"
@@ -218,6 +219,42 @@ type MatchOpt struct {
 	Annotations    map[string]string  // Match each of the specified annotations and their value, an empty value verifies the key is set
 	SortAnnotation string             // Sort the results by an annotation, string based comparison, descriptors without the annotation are sorted last
 	SortDesc       bool               // Set to true to sort in descending order
+}
+
+// Merge applies changes to a MatchOpt, overwriting existing values, and returning a new MatchOpt.
+func (mo MatchOpt) Merge(changes MatchOpt) MatchOpt {
+	ret := MatchOpt{
+		ArtifactType:   changes.ArtifactType,
+		SortAnnotation: changes.SortAnnotation,
+		SortDesc:       changes.SortDesc,
+	}
+	if ret.ArtifactType == "" {
+		ret.ArtifactType = mo.ArtifactType
+	}
+	if changes.Platform != nil {
+		p := *changes.Platform
+		ret.Platform = &p
+	} else if mo.Platform != nil {
+		p := *mo.Platform
+		ret.Platform = &p
+	}
+	if ret.SortAnnotation == "" {
+		ret.SortAnnotation = mo.SortAnnotation
+	}
+	if !ret.SortDesc {
+		ret.SortDesc = mo.SortDesc
+	}
+	if len(mo.Annotations) > 0 {
+		ret.Annotations = maps.Clone(mo.Annotations)
+	}
+	if len(changes.Annotations) > 0 {
+		if ret.Annotations == nil {
+			ret.Annotations = changes.Annotations
+		} else {
+			maps.Copy(ret.Annotations, changes.Annotations)
+		}
+	}
+	return ret
 }
 
 // Match returns true if the descriptor matches the options, including compatible platforms.

--- a/types/error.go
+++ b/types/error.go
@@ -6,145 +6,181 @@ var (
 	// ErrAllRequestsFailed when there are no mirrors left to try
 	//
 	// Deprecated: replace with [errs.ErrAllRequestsFailed].
+	//go:fix inline
 	ErrAllRequestsFailed = errs.ErrAllRequestsFailed
 	// ErrAPINotFound if an api is not available for the host
 	//
 	// Deprecated: replace with [errs.ErrAPINotFound].
+	//go:fix inline
 	ErrAPINotFound = errs.ErrAPINotFound
 	// ErrBackoffLimit maximum backoff attempts reached
 	//
 	// Deprecated: replace with [errs.ErrBackoffLimit].
+	//go:fix inline
 	ErrBackoffLimit = errs.ErrBackoffLimit
 	// ErrCanceled if the context was canceled
 	//
 	// Deprecated: replace with [errs.ErrCanceled].
+	//go:fix inline
 	ErrCanceled = errs.ErrCanceled
 	// ErrDigestMismatch if the expected digest wasn't received
 	//
 	// Deprecated: replace with [errs.ErrDigestMismatch].
+	//go:fix inline
 	ErrDigestMismatch = errs.ErrDigestMismatch
 	// ErrEmptyChallenge indicates an issue with the received challenge in the WWW-Authenticate header
 	//
 	// Deprecated: replace with [errs.ErrEmptyChallenge].
+	//go:fix inline
 	ErrEmptyChallenge = errs.ErrEmptyChallenge
 	// ErrFileDeleted indicates a requested file has been deleted
 	//
 	// Deprecated: replace with [errs.ErrFileDeleted].
+	//go:fix inline
 	ErrFileDeleted = errs.ErrFileDeleted
 	// ErrFileNotFound indicates a requested file is not found
 	//
 	// Deprecated: replace with [errs.ErrFileNotFound].
+	//go:fix inline
 	ErrFileNotFound = errs.ErrFileNotFound
 	// ErrHTTPStatus if the http status code was unexpected
 	//
 	// Deprecated: replace with [errs.ErrHTTPStatus].
+	//go:fix inline
 	ErrHTTPStatus = errs.ErrHTTPStatus
 	// ErrInvalidChallenge indicates an issue with the received challenge in the WWW-Authenticate header
 	//
 	// Deprecated: replace with [errs.ErrInvalidChallenge].
+	//go:fix inline
 	ErrInvalidChallenge = errs.ErrInvalidChallenge
 	// ErrInvalidReference indicates the reference to an image is has an invalid syntax
 	//
 	// Deprecated: replace with [errs.ErrInvalidReference].
+	//go:fix inline
 	ErrInvalidReference = errs.ErrInvalidReference
 	// ErrLoopDetected indicates a child node points back to the parent
 	//
 	// Deprecated: replace with [errs.ErrLoopDetected].
+	//go:fix inline
 	ErrLoopDetected = errs.ErrLoopDetected
 	// ErrManifestNotSet indicates the manifest is not set, it must be pulled with a ManifestGet first
 	//
 	// Deprecated: replace with [errs.ErrManifestNotSet].
+	//go:fix inline
 	ErrManifestNotSet = errs.ErrManifestNotSet
 	// ErrMissingAnnotation returned when a needed annotation is not found
 	//
 	// Deprecated: replace with [errs.ErrMissingAnnotation].
+	//go:fix inline
 	ErrMissingAnnotation = errs.ErrMissingAnnotation
 	// ErrMissingDigest returned when image reference does not include a digest
 	//
 	// Deprecated: replace with [errs.ErrMissingDigest].
+	//go:fix inline
 	ErrMissingDigest = errs.ErrMissingDigest
 	// ErrMissingLocation returned when the location header is missing
 	//
 	// Deprecated: replace with [errs.ErrMissingLocation].
+	//go:fix inline
 	ErrMissingLocation = errs.ErrMissingLocation
 	// ErrMissingName returned when name missing for host
 	//
 	// Deprecated: replace with [errs.ErrMissingName].
+	//go:fix inline
 	ErrMissingName = errs.ErrMissingName
 	// ErrMissingTag returned when image reference does not include a tag
 	//
 	// Deprecated: replace with [errs.ErrMissingTag].
+	//go:fix inline
 	ErrMissingTag = errs.ErrMissingTag
 	// ErrMissingTagOrDigest returned when image reference does not include a tag or digest
 	//
 	// Deprecated: replace with [errs.ErrMissingTagOrDigest].
+	//go:fix inline
 	ErrMissingTagOrDigest = errs.ErrMissingTagOrDigest
 	// ErrMismatch returned when a comparison detects a difference
 	//
 	// Deprecated: replace with [errs.ErrMismatch].
+	//go:fix inline
 	ErrMismatch = errs.ErrMismatch
 	// ErrMountReturnedLocation when a blob mount fails but a location header is received
 	//
 	// Deprecated: replace with [errs.ErrMountReturnedLocation].
+	//go:fix inline
 	ErrMountReturnedLocation = errs.ErrMountReturnedLocation
 	// ErrNoNewChallenge indicates a challenge update did not result in any change
 	//
 	// Deprecated: replace with [errs.ErrNoNewChallenge].
+	//go:fix inline
 	ErrNoNewChallenge = errs.ErrNoNewChallenge
 	// ErrNotFound isn't there, search for your value elsewhere
 	//
 	// Deprecated: replace with [errs.ErrNotFound].
+	//go:fix inline
 	ErrNotFound = errs.ErrNotFound
 	// ErrNotImplemented returned when method has not been implemented yet
 	//
 	// Deprecated: replace with [errs.ErrNotImplemented].
+	//go:fix inline
 	ErrNotImplemented = errs.ErrNotImplemented
 	// ErrNotRetryable indicates the process cannot be retried
 	//
 	// Deprecated: replace with [errs.ErrNotRetryable].
+	//go:fix inline
 	ErrNotRetryable = errs.ErrNotRetryable
 	// ErrParsingFailed when a string cannot be parsed
 	//
 	// Deprecated: replace with [errs.ErrParsingFailed].
+	//go:fix inline
 	ErrParsingFailed = errs.ErrParsingFailed
 	// ErrRetryNeeded indicates a request needs to be retried
 	//
 	// Deprecated: replace with [errs.ErrRetryNeeded].
+	//go:fix inline
 	ErrRetryNeeded = errs.ErrRetryNeeded
 	// ErrShortRead if contents are less than expected the size
 	//
 	// Deprecated: replace with [errs.ErrShortRead].
+	//go:fix inline
 	ErrShortRead = errs.ErrShortRead
 	// ErrSizeLimitExceeded if contents exceed the size limit
 	//
 	// Deprecated: replace with [errs.ErrSizeLimitExceeded].
+	//go:fix inline
 	ErrSizeLimitExceeded = errs.ErrSizeLimitExceeded
 	// ErrUnavailable when a requested value is not available
 	//
 	// Deprecated: replace with [errs.ErrUnavailable].
+	//go:fix inline
 	ErrUnavailable = errs.ErrUnavailable
 	// ErrUnsupported indicates the request was unsupported
 	//
 	// Deprecated: replace with [errs.ErrUnsupported].
+	//go:fix inline
 	ErrUnsupported = errs.ErrUnsupported
 	// ErrUnsupportedAPI happens when an API is not supported on a registry
 	//
 	// Deprecated: replace with [errs.ErrUnsupportedAPI].
+	//go:fix inline
 	ErrUnsupportedAPI = errs.ErrUnsupportedAPI
 	// ErrUnsupportedConfigVersion happens when config file version is greater than this command supports
 	//
 	// Deprecated: replace with [errs.ErrUnsupportedConfigVersion].
+	//go:fix inline
 	ErrUnsupportedConfigVersion = errs.ErrUnsupportedConfigVersion
 	// ErrUnsupportedMediaType returned when media type is unknown or unsupported
 	//
 	// Deprecated: replace with [errs.ErrUnsupportedMediaType].
+	//go:fix inline
 	ErrUnsupportedMediaType = errs.ErrUnsupportedMediaType
 	// ErrHTTPRateLimit when requests exceed server rate limit
 	//
 	// Deprecated: replace with [errs.ErrHTTPRateLimit].
+	//go:fix inline
 	ErrHTTPRateLimit = errs.ErrHTTPRateLimit
 	// ErrHTTPUnauthorized when authentication fails
 	//
 	// Deprecated: replace with [errs.ErrHTTPUnauthorized].
+	//go:fix inline
 	ErrHTTPUnauthorized = errs.ErrHTTPUnauthorized
 )

--- a/types/mediatype.go
+++ b/types/mediatype.go
@@ -8,78 +8,97 @@ const (
 	// MediaTypeDocker1Manifest deprecated media type for docker schema1 manifests.
 	//
 	// Deprecated: replace with [mediatype.Docker1Manifest].
+	//go:fix inline
 	MediaTypeDocker1Manifest = mediatype.Docker1Manifest
 	// MediaTypeDocker1ManifestSigned is a deprecated schema1 manifest with jws signing.
 	//
 	// Deprecated: replace with [mediatype.Docker1ManifestSigned].
+	//go:fix inline
 	MediaTypeDocker1ManifestSigned = mediatype.Docker1ManifestSigned
 	// MediaTypeDocker2Manifest is the media type when pulling manifests from a v2 registry.
 	//
 	// Deprecated: replace with [mediatype.Docker2Manifest].
+	//go:fix inline
 	MediaTypeDocker2Manifest = mediatype.Docker2Manifest
 	// MediaTypeDocker2ManifestList is the media type when pulling a manifest list from a v2 registry.
 	//
 	// Deprecated: replace with [mediatype.Docker2ManifestList].
+	//go:fix inline
 	MediaTypeDocker2ManifestList = mediatype.Docker2ManifestList
 	// MediaTypeDocker2ImageConfig is for the configuration json object media type.
 	//
 	// Deprecated: replace with [mediatype.Docker2ImageConfig].
+	//go:fix inline
 	MediaTypeDocker2ImageConfig = mediatype.Docker2ImageConfig
 	// MediaTypeOCI1Artifact EXPERIMENTAL OCI v1 artifact media type.
 	//
 	// Deprecated: replace with [mediatype.OCI1Artifact].
+	//go:fix inline
 	MediaTypeOCI1Artifact = mediatype.OCI1Artifact
 	// MediaTypeOCI1Manifest OCI v1 manifest media type.
 	//
 	// Deprecated: replace with [mediatype.OCI1Manifest].
+	//go:fix inline
 	MediaTypeOCI1Manifest = mediatype.OCI1Manifest
 	// MediaTypeOCI1ManifestList OCI v1 manifest list media type.
 	//
 	// Deprecated: replace with [mediatype.OCI1ManifestList].
+	//go:fix inline
 	MediaTypeOCI1ManifestList = mediatype.OCI1ManifestList
 	// MediaTypeOCI1ImageConfig OCI v1 configuration json object media type.
 	//
 	// Deprecated: replace with [mediatype.OCI1ImageConfig].
+	//go:fix inline
 	MediaTypeOCI1ImageConfig = mediatype.OCI1ImageConfig
 	// MediaTypeDocker2LayerGzip is the default compressed layer for docker schema2.
 	//
 	// Deprecated: replace with [mediatype.Docker2LayerGzip].
+	//go:fix inline
 	MediaTypeDocker2LayerGzip = mediatype.Docker2LayerGzip
 	// MediaTypeDocker2ForeignLayer is the default compressed layer for foreign layers in docker schema2.
 	//
 	// Deprecated: replace with [mediatype.Docker2ForeignLayer].
+	//go:fix inline
 	MediaTypeDocker2ForeignLayer = mediatype.Docker2ForeignLayer
 	// MediaTypeOCI1Layer is the uncompressed layer for OCIv1.
 	//
 	// Deprecated: replace with [mediatype.OCI1Layer].
+	//go:fix inline
 	MediaTypeOCI1Layer = mediatype.OCI1Layer
 	// MediaTypeOCI1LayerGzip is the gzip compressed layer for OCI v1.
 	//
 	// Deprecated: replace with [mediatype.OCI1LayerGzip].
+	//go:fix inline
 	MediaTypeOCI1LayerGzip = mediatype.OCI1LayerGzip
 	// MediaTypeOCI1LayerZstd is the zstd compressed layer for OCI v1.
 	//
 	// Deprecated: replace with [mediatype.OCI1LayerZstd].
+	//go:fix inline
 	MediaTypeOCI1LayerZstd = mediatype.OCI1LayerZstd
 	// MediaTypeOCI1ForeignLayer is the foreign layer for OCI v1.
 	//
 	// Deprecated: replace with [mediatype.OCI1ForeignLayer].
+	//go:fix inline
 	MediaTypeOCI1ForeignLayer = mediatype.OCI1ForeignLayer
 	// MediaTypeOCI1ForeignLayerGzip is the gzip compressed foreign layer for OCI v1.
 	//
 	// Deprecated: replace with [mediatype.OCI1ForeignLayerGzip].
+	//go:fix inline
 	MediaTypeOCI1ForeignLayerGzip = mediatype.OCI1ForeignLayerGzip
 	// MediaTypeOCI1ForeignLayerZstd is the zstd compressed foreign layer for OCI v1.
 	//
 	// Deprecated: replace with [mediatype.OCI1ForeignLayerZstd].
+	//go:fix inline
 	MediaTypeOCI1ForeignLayerZstd = mediatype.OCI1ForeignLayerZstd
 	// MediaTypeOCI1Empty is used for blobs containing the empty JSON data `{}`.
 	//
 	// Deprecated: replace with [mediatype.OCI1Empty].
+	//go:fix inline
 	MediaTypeOCI1Empty = mediatype.OCI1Empty
 	// MediaTypeBuildkitCacheConfig is used by buildkit cache images.
 	//
 	// Deprecated: replace with [mediatype.BuildkitCacheConfig].
+	//go:fix inline
 	MediaTypeBuildkitCacheConfig = mediatype.BuildkitCacheConfig
 )
 
@@ -87,5 +106,6 @@ var (
 	// Base cleans the Content-Type header to return only the lower case base media type.
 	//
 	// Deprecated: replace with [mediatype.Base].
+	//go:fix inline
 	MediaTypeBase = mediatype.Base
 )


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This will help transition to newer methods and variables with the Go tooling. To avoid breakage from transitioning multiple `scheme.With*` calls, a `Merge` method was added to `MatchOp`.

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

IDE's will flag calls to deprecated methods with the new method.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Chore: Add go:fix lines to deprecated code.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
