### PR TITLE
Feat: Support DOCKER_AUTH_CONFIG variable

### DIFF
--- a/config/testdata/docker-credential-test
+++ b/config/testdata/docker-credential-test
@@ -4,6 +4,7 @@ list='{
   "https://index.docker.io/v1/": "hubuser",
   "http://http.example.com/": "hello",
   "host.example.org": "hello",
+  "testenvhelper.example.com": "hienv",
   "testhost.example.com": "hello",
   "testtoken.example.com": "<token>"
 }'
@@ -24,6 +25,12 @@ registry_host_org='
 { "ServerURL": "host.example.org",
   "Username": "hello",
   "Secret": "world"
+}
+'
+registry_testenvhelper='
+{ "ServerURL": "testenvhelper.example.com",
+  "Username": "hienv",
+  "Secret": "stillworks"
 }
 '
 registry_testhost='
@@ -52,6 +59,10 @@ if [ "$1" = "get" ]; then
       ;;
     host.example.org)
       echo "${registry_host_org}"
+      exit 0
+      ;;
+    testenvhelper.example.com)
+      echo "${registry_testenvhelper}"
       exit 0
       ;;
     testhost.example.com)


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This directly injects the docker config credentials using an environment variable instead of a config file. See https://github.com/docker/cli/pull/6008 for the upstream project change.

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
docker run -e DOCKER_AUTH_CONFIG="$(cat ~/.docker/config.json)" regclient/regctl manifest get $image -v trace
```

Note the registries processed in the debug logs.

<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Feat: Support DOCKER_AUTH_CONFIG variable.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

Documentation additions could be added to the regclient.org site in a separate PR.
<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [ ] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
