### PR TITLE
feat: add semver versioning

### DIFF
--- a/cmd/regsync/config.go
+++ b/cmd/regsync/config.go
@@ -68,8 +68,8 @@ type ConfigSync struct {
 	Source          string                 `yaml:"source" json:"source"`
 	Target          string                 `yaml:"target" json:"target"`
 	Type            string                 `yaml:"type" json:"type"`
-	Tags            AllowDeny              `yaml:"tags" json:"tags"`
-	Repos           AllowDeny              `yaml:"repos" json:"repos"`
+	Tags            TagAllowDeny           `yaml:"tags" json:"tags"`
+	Repos           RepoAllowDeny          `yaml:"repos" json:"repos"`
 	DigestTags      *bool                  `yaml:"digestTags" json:"digestTags"`
 	Referrers       *bool                  `yaml:"referrers" json:"referrers"`
 	ReferrerFilters []ConfigReferrerFilter `yaml:"referrerFilters" json:"referrerFilters"`
@@ -88,10 +88,17 @@ type ConfigSync struct {
 	Hooks           ConfigHooks            `yaml:"hooks" json:"hooks"`
 }
 
-// AllowDeny is an allow and deny list of regex strings
-type AllowDeny struct {
+// RepoAllowDeny is an allow and deny list of regex strings for repository names
+type RepoAllowDeny struct {
 	Allow []string `yaml:"allow" json:"allow"`
 	Deny  []string `yaml:"deny" json:"deny"`
+}
+
+// TagAllowDeny is an allow and deny list of regex strings for tags, with optional semver version range support
+type TagAllowDeny struct {
+	Allow       []string `yaml:"allow" json:"allow"`
+	Deny        []string `yaml:"deny" json:"deny"`
+	SemverRange []string `yaml:"semverRange,omitempty" json:"semverRange,omitempty"` // array of semver constraints, e.g., [">=1.0.0 <2.0.0", ">=4.0.0"]
 }
 
 type ConfigReferrerFilter struct {

--- a/cmd/regsync/regsync_test.go
+++ b/cmd/regsync/regsync_test.go
@@ -342,7 +342,7 @@ defaults:
 				Source: tsHost + "/testrepo",
 				Target: tsHost + "/test3",
 				Type:   "repository",
-				Tags: AllowDeny{
+				Tags: TagAllowDeny{
 					Allow: []string{"v1", "v3", "latest"},
 				},
 			},
@@ -364,7 +364,7 @@ defaults:
 				Source: tsHost + "/testrepo",
 				Target: tsHost + "/test4",
 				Type:   "repository",
-				Tags: AllowDeny{
+				Tags: TagAllowDeny{
 					Deny: []string{"v2", "old"},
 				},
 			},
@@ -439,7 +439,7 @@ defaults:
 				Source: tsHost + "/testrepo",
 				Target: tsHost + "/test-missing",
 				Type:   "repository",
-				Tags: AllowDeny{
+				Tags: TagAllowDeny{
 					Allow: []string{"v1", "v2", "v3", "latest"},
 				},
 			},
@@ -893,6 +893,213 @@ func TestProcessRef(t *testing.T) {
 	}
 }
 
+// TestFilterListVersionScheme tests the integration of semver filtering with tag filtering.
+// This focuses on real-world scenarios including:
+// - Tag patterns with suffixes (alpine, scratch, debian, etc.)
+// - Mixed version formats (v1, v1.5, v1.5.0)
+// - Multiple ranges and edge cases specific to container image tags
+// Note: Basic semver constraint tests are in internal/semver/semver_test.go
+func TestFilterListVersionScheme(t *testing.T) {
+	tests := []struct {
+		name        string
+		ad          TagAllowDeny
+		input       []string
+		expected    []string
+		expectError bool
+	}{
+		{
+			name: "semver with multiple ranges and deny",
+			ad: TagAllowDeny{
+				SemverRange: []string{">=1.0.0 <2.0.0", ">=4.0.0"},
+				Deny:        []string{".*-rc.*"},
+			},
+			input:    []string{"1.0.0", "1.5.0-rc1", "2.0.0", "4.0.0", "4.1.0-rc2", "5.0.0"},
+			expected: []string{"1.0.0", "4.0.0", "5.0.0"},
+		},
+		{
+			name: "semver filters non-semver tags",
+			ad: TagAllowDeny{
+				SemverRange: []string{">=1.0.0"},
+			},
+			input:    []string{"latest", "dev", "1.0.0", "1.5.0", "main"},
+			expected: []string{"1.0.0", "1.5.0"},
+		},
+		{
+			name: "semver with allow/deny combination",
+			ad: TagAllowDeny{
+				SemverRange: []string{">=1.0.0 <3.0.0"},
+				Deny:        []string{".*-rc.*"},
+			},
+			input:    []string{"1.0.0", "1.5.0-rc1", "2.0.0", "2.1.0-rc2", "3.0.0"},
+			expected: []string{"1.0.0", "2.0.0"},
+		},
+		{
+			name: "no version range (backward compatibility)",
+			ad: TagAllowDeny{
+				Allow: []string{"v[0-9]+\\.[0-9]+\\.[0-9]+"},
+			},
+			input:    []string{"v1.0.0", "v1.5.0", "latest", "dev"},
+			expected: []string{"v1.0.0", "v1.5.0"},
+		},
+		{
+			name: "empty result when no matches",
+			ad: TagAllowDeny{
+				SemverRange: []string{">=5.0.0"},
+			},
+			input:    []string{"1.0.0", "2.0.0", "3.0.0"},
+			expected: []string{},
+		},
+		{
+			name: "multiple ranges skip middle versions",
+			ad: TagAllowDeny{
+				SemverRange: []string{">=1.0.0 <1.20.0", ">=1.22.0"},
+			},
+			input:    []string{"1.0.0", "1.19.0", "1.20.0", "1.21.0", "1.22.0", "1.23.0"},
+			expected: []string{"1.0.0", "1.19.0", "1.22.0", "1.23.0"},
+		},
+		{
+			name: "version range with allow filter",
+			ad: TagAllowDeny{
+				SemverRange: []string{">=1.0.0"},
+				Allow:       []string{"v.*"},
+			},
+			input:    []string{"1.0.0", "v1.5.0", "v2.0.0", "3.0.0"},
+			expected: []string{"v1.5.0", "v2.0.0"}, // sequential: semver first (all 4), then allow filters by v.*
+		},
+		{
+			name: "empty version range array",
+			ad: TagAllowDeny{
+				SemverRange: []string{},
+			},
+			input:    []string{"1.0.0", "2.0.0"},
+			expected: []string{"1.0.0", "2.0.0"},
+		},
+		{
+			name: "semver with suffix alpine",
+			ad: TagAllowDeny{
+				SemverRange: []string{">=1.0.0 <2.0.0"},
+			},
+			input:    []string{"v1.2.3-alpine3.21", "v1.5.0-alpine3.20", "v2.0.0-alpine3.21", "v0.9.0-alpine3.19"},
+			expected: []string{"v1.2.3-alpine3.21", "v1.5.0-alpine3.20", "v2.0.0-alpine3.21"},
+		},
+		{
+			name: "semver with suffix scratch",
+			ad: TagAllowDeny{
+				SemverRange: []string{">=5.0.0"},
+			},
+			input:    []string{"v5-scratch", "v4-scratch", "v6-scratch", "v5.1-scratch"},
+			expected: []string{"v6-scratch", "v5.1-scratch"},
+		},
+		{
+			name: "semver with suffix mixed",
+			ad: TagAllowDeny{
+				SemverRange: []string{">=1.0.0 <3.0.0"},
+			},
+			input:    []string{"v1.0.0", "v1.5.0-alpine", "v2.0.0-scratch", "v2.5.1-debian", "v3.0.0-alpine"},
+			expected: []string{"v1.0.0", "v1.5.0-alpine", "v2.0.0-scratch", "v2.5.1-debian", "v3.0.0-alpine"},
+		},
+		{
+			name: "semver major version only",
+			ad: TagAllowDeny{
+				SemverRange: []string{">=2 <5"},
+			},
+			input:    []string{"v1", "v2", "v3", "v4", "v5", "v6"},
+			expected: []string{"v2", "v3", "v4"},
+		},
+		{
+			name: "semver major.minor only",
+			ad: TagAllowDeny{
+				SemverRange: []string{">=1.5 <2.0"},
+			},
+			input:    []string{"v1.4", "v1.5", "v1.6", "v1.9", "v2.0", "v2.1"},
+			expected: []string{"v1.5", "v1.6", "v1.9"},
+		},
+		{
+			name: "semver mixed version formats",
+			ad: TagAllowDeny{
+				SemverRange: []string{">=1.0.0 <3.0.0"},
+			},
+			input:    []string{"v1", "v1.5", "v1.5.0", "v2", "v2.0", "v2.0.0", "v3", "v3.0.0"},
+			expected: []string{"v1", "v1.5", "v1.5.0", "v2", "v2.0", "v2.0.0"},
+		},
+		{
+			name: "semver with deny on suffixes",
+			ad: TagAllowDeny{
+				SemverRange: []string{">=1.0.0"},
+				Deny:        []string{".*-alpine.*"},
+			},
+			input:    []string{"v1.0.0", "v1.2.3-alpine3.21", "v2.0.0-scratch", "v2.5.0-alpine3.20"},
+			expected: []string{"v1.0.0", "v2.0.0-scratch"},
+		},
+		{
+			name: "semver + allow adds non-semver tags",
+			ad: TagAllowDeny{
+				SemverRange: []string{">=1.0.0 <2.0.0"},
+				Allow:       []string{"latest", "edge"},
+			},
+			input:    []string{"0.9.0", "1.0.0", "1.5.0", "2.0.0", "latest", "edge", "dev"},
+			expected: []string{}, // sequential: semver filters out non-semver tags, so allow has nothing to match
+		},
+		{
+			name: "semver + allow + deny combines all filters",
+			ad: TagAllowDeny{
+				SemverRange: []string{">=1.0.0"},
+				Allow:       []string{"latest", "stable"},
+				Deny:        []string{".*-rc.*", "latest"},
+			},
+			input:    []string{"1.0.0", "1.5.0-rc1", "2.0.0", "latest", "stable", "dev"},
+			expected: []string{}, // sequential: semver filters out non-semver "latest", "stable", "dev"
+		},
+		{
+			name: "allow without semver still works (backward compatible)",
+			ad: TagAllowDeny{
+				Allow: []string{"v[0-9]+\\.[0-9]+"},
+			},
+			input:    []string{"v1.0", "v1.5", "v2.0", "latest", "edge"},
+			expected: []string{"v1.0", "v1.5", "v2.0"},
+		},
+		{
+			name: "semver + allow with overlapping matches",
+			ad: TagAllowDeny{
+				SemverRange: []string{">=1.0.0"},
+				Allow:       []string{"v[0-9]+\\.[0-9]+\\.[0-9]+"},
+			},
+			input:    []string{"v1.0.0", "v1.5.0", "v2.0.0", "latest"},
+			expected: []string{"v1.0.0", "v1.5.0", "v2.0.0"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := filterTagList(tt.ad, tt.input)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if len(result) != len(tt.expected) {
+				t.Errorf("expected %d results, got %d\nexpected: %v\ngot: %v",
+					len(tt.expected), len(result), tt.expected, result)
+				return
+			}
+
+			for i := range result {
+				if result[i] != tt.expected[i] {
+					t.Errorf("result[%d]: expected %q, got %q", i, tt.expected[i], result[i])
+				}
+			}
+		})
+	}
+}
+
 func TestConfigRead(t *testing.T) {
 	t.Parallel()
 	bFalse := false
@@ -949,7 +1156,7 @@ func TestConfigRead(t *testing.T) {
 						Source: "alpine",
 						Target: "registry:5000/hub/alpine",
 						Type:   "repository",
-						Tags: AllowDeny{
+						Tags: TagAllowDeny{
 							Allow: []string{"3", "3.9", "latest"},
 						},
 						Interval: 60 * time.Minute,
@@ -969,7 +1176,7 @@ func TestConfigRead(t *testing.T) {
 						Source: "gcr.io/example/repo",
 						Target: "registry:5000/gcr/example/repo",
 						Type:   "repository",
-						Tags: AllowDeny{
+						Tags: TagAllowDeny{
 							Allow: []string{"3", "3.9", "latest"},
 						},
 						Interval: 60 * time.Minute,

--- a/cmd/regsync/root.go
+++ b/cmd/regsync/root.go
@@ -24,6 +24,7 @@ import (
 	"github.com/regclient/regclient/config"
 	"github.com/regclient/regclient/internal/cobradoc"
 	"github.com/regclient/regclient/internal/pqueue"
+	"github.com/regclient/regclient/internal/semver"
 	"github.com/regclient/regclient/internal/version"
 	"github.com/regclient/regclient/pkg/template"
 	"github.com/regclient/regclient/scheme"
@@ -480,7 +481,7 @@ func (opts *rootOpts) processRegistry(ctx context.Context, s ConfigSync, src, tg
 		}
 		last = sRepoList[len(sRepoList)-1]
 		// filter repos according to allow/deny rules
-		sRepoList, err = filterList(s.Repos, sRepoList)
+		sRepoList, err = filterRepoList(s.Repos, sRepoList)
 		if err != nil {
 			opts.log.Error("Failed processing repo filters",
 				slog.String("source", src),
@@ -526,7 +527,7 @@ func (opts *rootOpts) processRepo(ctx context.Context, s ConfigSync, src, tgt st
 			slog.String("error", err.Error()))
 		return err
 	}
-	sTagList, err := filterList(s.Tags, sTagsList)
+	sTagList, err := filterTagList(s.Tags, sTagsList)
 	if err != nil {
 		opts.log.Error("Failed processing tag filters",
 			slog.String("source", sRepoRef.CommonName()),
@@ -884,51 +885,131 @@ func (opts *rootOpts) processRef(ctx context.Context, s ConfigSync, src, tgt ref
 	return nil
 }
 
-func filterList(ad AllowDeny, in []string) ([]string, error) {
-	var result []string
-	// apply allow list
+// filterByRegex applies allow/deny regex patterns to a list of strings.
+// filterRegexAllow returns items that match at least one allow pattern.
+// If no patterns are provided, returns all items.
+func filterRegexAllow(patterns []string, in []string) ([]string, error) {
+	if len(patterns) == 0 {
+		return in, nil
+	}
+
+	// Compile all patterns
+	exps := make([]*regexp.Regexp, 0, len(patterns))
+	for _, pattern := range patterns {
+		exp, err := regexp.Compile("^" + pattern + "$")
+		if err != nil {
+			return nil, fmt.Errorf("invalid allow pattern %q: %w", pattern, err)
+		}
+		exps = append(exps, exp)
+	}
+
+	// Keep items matching any pattern
+	result := make([]string, 0, len(in))
+	for _, item := range in {
+		for _, exp := range exps {
+			if exp.MatchString(item) {
+				result = append(result, item)
+				break
+			}
+		}
+	}
+	return result, nil
+}
+
+// filterRegexDeny removes items that match any deny pattern.
+// If no patterns are provided, returns all items unchanged.
+func filterRegexDeny(patterns []string, in []string) ([]string, error) {
+	if len(patterns) == 0 {
+		return in, nil
+	}
+
+	// Compile all patterns
+	exps := make([]*regexp.Regexp, 0, len(patterns))
+	for _, pattern := range patterns {
+		exp, err := regexp.Compile("^" + pattern + "$")
+		if err != nil {
+			return nil, fmt.Errorf("invalid deny pattern %q: %w", pattern, err)
+		}
+		exps = append(exps, exp)
+	}
+
+	// Remove items matching any pattern
+	result := make([]string, 0, len(in))
+	for _, item := range in {
+		denied := false
+		for _, exp := range exps {
+			if exp.MatchString(item) {
+				denied = true
+				break
+			}
+		}
+		if !denied {
+			result = append(result, item)
+		}
+	}
+	return result, nil
+}
+
+func filterRepoList(ad RepoAllowDeny, in []string) ([]string, error) {
+	// Apply allow filter
+	result, err := filterRegexAllow(ad.Allow, in)
+	if err != nil {
+		return nil, err
+	}
+	// Apply deny filter
+	return filterRegexDeny(ad.Deny, result)
+}
+
+func filterTagList(ad TagAllowDeny, in []string) ([]string, error) {
+	result := in
+
+	// Step 1: Apply semverRange filter
+	if len(ad.SemverRange) > 0 {
+		// Parse all constraints
+		constraints := make([]semver.Constraint, 0, len(ad.SemverRange))
+		for _, rangeStr := range ad.SemverRange {
+			if rangeStr == "" {
+				continue
+			}
+			constraint, err := semver.NewConstraint(rangeStr)
+			if err != nil {
+				return nil, fmt.Errorf("invalid semver range %q: %w", rangeStr, err)
+			}
+			constraints = append(constraints, constraint)
+		}
+
+		// Apply version filtering if we have valid constraints
+		if len(constraints) > 0 {
+			filtered := make([]string, 0, len(result))
+			for _, tag := range result {
+				// Try to parse as semver, skip non-semver tags
+				v, err := semver.NewVersion(tag)
+				if err != nil {
+					continue
+				}
+				// Check if version matches any constraint (OR logic)
+				for _, constraint := range constraints {
+					if constraint.Check(v) {
+						filtered = append(filtered, tag)
+						break
+					}
+				}
+			}
+			result = filtered
+		}
+	}
+
+	// Step 2: Apply Allow filter
 	if len(ad.Allow) > 0 {
-		result = make([]string, len(in))
-		for _, filter := range ad.Allow {
-			exp, err := regexp.Compile("^" + filter + "$")
-			if err != nil {
-				return result, err
-			}
-			for i := range in {
-				if result[i] == "" && exp.MatchString(in[i]) {
-					result[i] = in[i]
-				}
-			}
-		}
-	} else {
-		// by default, everything is allowed
-		result = in
-	}
-
-	// apply deny list
-	if len(ad.Deny) > 0 {
-		for _, filter := range ad.Deny {
-			exp, err := regexp.Compile("^" + filter + "$")
-			if err != nil {
-				return result, err
-			}
-			for i := range result {
-				if result[i] != "" && exp.MatchString(result[i]) {
-					result[i] = ""
-				}
-			}
+		var err error
+		result, err = filterRegexAllow(ad.Allow, result)
+		if err != nil {
+			return nil, err
 		}
 	}
 
-	// compress result list, removing empty elements
-	compressed := make([]string, 0, len(in))
-	for i := range result {
-		if result[i] != "" {
-			compressed = append(compressed, result[i])
-		}
-	}
-
-	return compressed, nil
+	// Step 3: Apply Deny filter
+	return filterRegexDeny(ad.Deny, result)
 }
 
 var manifestCache struct {

--- a/internal/semver/semver.go
+++ b/internal/semver/semver.go
@@ -1,0 +1,317 @@
+// Package semver provides semantic version parsing and constraint checking.
+package semver
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Version represents a semantic version
+type Version struct {
+	parts      []int // version parts (major, minor, patch, and any additional components)
+	prerelease string
+	metadata   string
+	original   string
+}
+
+// NewVersion parses a string into a Version
+func NewVersion(v string) (Version, error) {
+	original := v
+	// Strip leading 'v' if present
+	v = strings.TrimPrefix(v, "v")
+
+	// Split on + for metadata
+	parts := strings.SplitN(v, "+", 2)
+	v = parts[0]
+	metadata := ""
+	if len(parts) > 1 {
+		metadata = parts[1]
+	}
+
+	// Split on - for prerelease
+	parts = strings.SplitN(v, "-", 2)
+	v = parts[0]
+	prerelease := ""
+	if len(parts) > 1 {
+		prerelease = parts[1]
+	}
+
+	// Parse version numbers
+	versionParts := strings.Split(v, ".")
+	if len(versionParts) < 1 {
+		return Version{}, fmt.Errorf("invalid version format: %s", original)
+	}
+
+	versionNumbers := make([]int, len(versionParts))
+	for i, part := range versionParts {
+		num, err := strconv.Atoi(part)
+		if err != nil {
+			return Version{}, fmt.Errorf("invalid version part %d: %s", i, original)
+		}
+		versionNumbers[i] = num
+	}
+
+	return Version{
+		parts:      versionNumbers,
+		prerelease: prerelease,
+		metadata:   metadata,
+		original:   original,
+	}, nil
+}
+
+// Compare returns -1 if v < other, 0 if v == other, 1 if v > other
+func (v Version) Compare(other Version) int {
+	// Compare version parts
+	maxLen := len(v.parts)
+	if len(other.parts) > maxLen {
+		maxLen = len(other.parts)
+	}
+
+	for i := 0; i < maxLen; i++ {
+		vPart := 0
+		if i < len(v.parts) {
+			vPart = v.parts[i]
+		}
+		oPart := 0
+		if i < len(other.parts) {
+			oPart = other.parts[i]
+		}
+
+		if vPart != oPart {
+			if vPart < oPart {
+				return -1
+			}
+			return 1
+		}
+	}
+
+	// Handle prerelease comparison
+	// Version without prerelease is greater than version with prerelease
+	if v.prerelease == "" && other.prerelease != "" {
+		return 1
+	}
+	if v.prerelease != "" && other.prerelease == "" {
+		return -1
+	}
+
+	// Both have prerelease, compare them
+	if v.prerelease != other.prerelease {
+		return comparePrereleases(v.prerelease, other.prerelease)
+	}
+
+	return 0
+}
+
+// comparePrereleases compares two prerelease strings according to semver rules
+func comparePrereleases(a, b string) int {
+	aParts := strings.Split(a, ".")
+	bParts := strings.Split(b, ".")
+
+	// Compare each identifier
+	for i := 0; i < len(aParts) && i < len(bParts); i++ {
+		aNum, aIsNum := strconv.Atoi(aParts[i])
+		bNum, bIsNum := strconv.Atoi(bParts[i])
+
+		// Both numeric: compare as integers
+		if aIsNum == nil && bIsNum == nil {
+			if aNum != bNum {
+				if aNum < bNum {
+					return -1
+				}
+				return 1
+			}
+			continue
+		}
+
+		// Numeric has lower precedence than alphanumeric
+		if aIsNum == nil && bIsNum != nil {
+			return -1
+		}
+		if aIsNum != nil && bIsNum == nil {
+			return 1
+		}
+
+		// Both alphanumeric: lexical comparison
+		if aParts[i] != bParts[i] {
+			if aParts[i] < bParts[i] {
+				return -1
+			}
+			return 1
+		}
+	}
+
+	// Fewer parts = lower precedence
+	if len(aParts) < len(bParts) {
+		return -1
+	}
+	if len(aParts) > len(bParts) {
+		return 1
+	}
+
+	return 0
+}
+
+// String returns the original version string
+func (v Version) String() string {
+	return v.original
+}
+
+// Major returns the major version number
+func (v Version) Major() int {
+	if len(v.parts) > 0 {
+		return v.parts[0]
+	}
+	return 0
+}
+
+// Minor returns the minor version number
+func (v Version) Minor() int {
+	if len(v.parts) > 1 {
+		return v.parts[1]
+	}
+	return 0
+}
+
+// Patch returns the patch version number
+func (v Version) Patch() int {
+	if len(v.parts) > 2 {
+		return v.parts[2]
+	}
+	return 0
+}
+
+// Constraint represents a version constraint
+type Constraint struct {
+	constraints []constraint
+}
+
+type constraint struct {
+	operator string
+	version  Version
+}
+
+// NewConstraint parses a constraint string
+// Supports: >=, <=, >, <, =, ^, ~, and ranges like ">=1.0.0 <2.0.0"
+func NewConstraint(c string) (Constraint, error) {
+	c = strings.TrimSpace(c)
+	if c == "" {
+		return Constraint{}, fmt.Errorf("empty constraint")
+	}
+
+	// Split on spaces to handle ranges
+	parts := strings.Fields(c)
+	constraints := []constraint{}
+
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+
+		// Handle caret (^) constraint
+		if strings.HasPrefix(part, "^") {
+			v, err := NewVersion(strings.TrimPrefix(part, "^"))
+			if err != nil {
+				return Constraint{}, fmt.Errorf("invalid caret constraint version: %w", err)
+			}
+			// ^1.2.3 means >=1.2.3 <2.0.0
+			// ^0.2.3 means >=0.2.3 <0.3.0
+			// ^0.0.3 means >=0.0.3 <0.0.4
+			constraints = append(constraints, constraint{operator: ">=", version: v})
+
+			var upperBound Version
+			if v.Major() > 0 {
+				upperBound = Version{parts: []int{v.Major() + 1, 0, 0}}
+			} else if v.Minor() > 0 {
+				upperBound = Version{parts: []int{0, v.Minor() + 1, 0}}
+			} else {
+				upperBound = Version{parts: []int{0, 0, v.Patch() + 1}}
+			}
+			constraints = append(constraints, constraint{operator: "<", version: upperBound})
+			continue
+		}
+
+		// Handle tilde (~) constraint
+		if strings.HasPrefix(part, "~") {
+			v, err := NewVersion(strings.TrimPrefix(part, "~"))
+			if err != nil {
+				return Constraint{}, fmt.Errorf("invalid tilde constraint version: %w", err)
+			}
+			// ~1.2.3 means >=1.2.3 <1.3.0
+			constraints = append(constraints, constraint{operator: ">=", version: v})
+			upperBound := Version{parts: []int{v.Major(), v.Minor() + 1, 0}}
+			constraints = append(constraints, constraint{operator: "<", version: upperBound})
+			continue
+		}
+
+		// Handle comparison operators
+		op := ""
+		vStr := part
+
+		if strings.HasPrefix(part, ">=") {
+			op = ">="
+			vStr = strings.TrimPrefix(part, ">=")
+		} else if strings.HasPrefix(part, "<=") {
+			op = "<="
+			vStr = strings.TrimPrefix(part, "<=")
+		} else if strings.HasPrefix(part, ">") {
+			op = ">"
+			vStr = strings.TrimPrefix(part, ">")
+		} else if strings.HasPrefix(part, "<") {
+			op = "<"
+			vStr = strings.TrimPrefix(part, "<")
+		} else if strings.HasPrefix(part, "=") {
+			op = "="
+			vStr = strings.TrimPrefix(part, "=")
+		} else {
+			// No operator means exact match
+			op = "="
+		}
+
+		v, err := NewVersion(vStr)
+		if err != nil {
+			return Constraint{}, fmt.Errorf("invalid constraint version: %w", err)
+		}
+
+		constraints = append(constraints, constraint{operator: op, version: v})
+	}
+
+	if len(constraints) == 0 {
+		return Constraint{}, fmt.Errorf("no valid constraints found")
+	}
+
+	return Constraint{constraints: constraints}, nil
+}
+
+// Check returns true if the version satisfies all constraints
+func (c Constraint) Check(v Version) bool {
+	for _, con := range c.constraints {
+		cmp := v.Compare(con.version)
+
+		switch con.operator {
+		case "=":
+			if cmp != 0 {
+				return false
+			}
+		case ">":
+			if cmp <= 0 {
+				return false
+			}
+		case ">=":
+			if cmp < 0 {
+				return false
+			}
+		case "<":
+			if cmp >= 0 {
+				return false
+			}
+		case "<=":
+			if cmp > 0 {
+				return false
+			}
+		}
+	}
+
+	return true
+}

--- a/internal/semver/semver_test.go
+++ b/internal/semver/semver_test.go
@@ -1,0 +1,208 @@
+package semver
+
+import (
+	"testing"
+)
+
+func TestNewVersion(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		expectError bool
+		major       int
+		minor       int
+		patch       int
+		prerelease  string
+	}{
+		{name: "simple version", input: "1.2.3", major: 1, minor: 2, patch: 3},
+		{name: "version with v prefix", input: "v1.2.3", major: 1, minor: 2, patch: 3},
+		{name: "version with prerelease", input: "1.2.3-rc1", major: 1, minor: 2, patch: 3, prerelease: "rc1"},
+		{name: "version with v and prerelease", input: "v1.2.3-beta.1", major: 1, minor: 2, patch: 3, prerelease: "beta.1"},
+		{name: "version with metadata", input: "1.2.3+build123", major: 1, minor: 2, patch: 3},
+		{name: "major only", input: "1", major: 1, minor: 0, patch: 0},
+		{name: "major.minor", input: "1.2", major: 1, minor: 2, patch: 0},
+		{name: "zero version", input: "0.0.0", major: 0, minor: 0, patch: 0},
+		{name: "windows version", input: "10.0.17763.2114", major: 10, minor: 0, patch: 17763},
+		{name: "invalid format", input: "abc", expectError: true},
+		{name: "empty string", input: "", expectError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v, err := NewVersion(tt.input)
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error but got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+			if v.Major() != tt.major {
+				t.Errorf("major: expected %d, got %d", tt.major, v.Major())
+			}
+			if v.Minor() != tt.minor {
+				t.Errorf("minor: expected %d, got %d", tt.minor, v.Minor())
+			}
+			if v.Patch() != tt.patch {
+				t.Errorf("patch: expected %d, got %d", tt.patch, v.Patch())
+			}
+			if v.prerelease != tt.prerelease {
+				t.Errorf("prerelease: expected %q, got %q", tt.prerelease, v.prerelease)
+			}
+		})
+	}
+}
+
+func TestVersionCompare(t *testing.T) {
+	tests := []struct {
+		name     string
+		v1       string
+		v2       string
+		expected int
+	}{
+		{name: "equal", v1: "1.2.3", v2: "1.2.3", expected: 0},
+		{name: "major less", v1: "1.2.3", v2: "2.2.3", expected: -1},
+		{name: "major greater", v1: "2.2.3", v2: "1.2.3", expected: 1},
+		{name: "minor less", v1: "1.2.3", v2: "1.3.3", expected: -1},
+		{name: "minor greater", v1: "1.3.3", v2: "1.2.3", expected: 1},
+		{name: "patch less", v1: "1.2.3", v2: "1.2.4", expected: -1},
+		{name: "patch greater", v1: "1.2.4", v2: "1.2.3", expected: 1},
+		{name: "with v prefix", v1: "v1.2.3", v2: "v1.2.3", expected: 0},
+		{name: "prerelease less than release", v1: "1.2.3-rc1", v2: "1.2.3", expected: -1},
+		{name: "release greater than prerelease", v1: "1.2.3", v2: "1.2.3-rc1", expected: 1},
+		{name: "prerelease comparison", v1: "1.2.3-alpha", v2: "1.2.3-beta", expected: -1},
+		{name: "windows version equal", v1: "10.0.17763.2114", v2: "10.0.17763.2114", expected: 0},
+		{name: "windows version less fourth part", v1: "10.0.17763.2114", v2: "10.0.17763.2115", expected: -1},
+		{name: "windows version greater fourth part", v1: "10.0.17763.2115", v2: "10.0.17763.2114", expected: 1},
+		{name: "windows vs semver", v1: "10.0.17763", v2: "10.0.17763.0", expected: 0},
+		{name: "different length shorter less", v1: "1.2.3", v2: "1.2.3.1", expected: -1},
+		{name: "different length longer greater", v1: "1.2.3.1", v2: "1.2.3", expected: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v1, err := NewVersion(tt.v1)
+			if err != nil {
+				t.Fatalf("failed to parse v1: %v", err)
+			}
+			v2, err := NewVersion(tt.v2)
+			if err != nil {
+				t.Fatalf("failed to parse v2: %v", err)
+			}
+			result := v1.Compare(v2)
+			if result != tt.expected {
+				t.Errorf("expected %d, got %d", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestNewConstraint(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		expectError bool
+	}{
+		{name: "simple >=", input: ">=1.0.0", expectError: false},
+		{name: "simple <=", input: "<=2.0.0", expectError: false},
+		{name: "simple >", input: ">1.0.0", expectError: false},
+		{name: "simple <", input: "<2.0.0", expectError: false},
+		{name: "simple =", input: "=1.0.0", expectError: false},
+		{name: "range", input: ">=1.0.0 <2.0.0", expectError: false},
+		{name: "caret", input: "^1.2.3", expectError: false},
+		{name: "tilde", input: "~1.2.3", expectError: false},
+		{name: "empty", input: "", expectError: true},
+		{name: "invalid version", input: ">=abc", expectError: true},
+		{name: "invalid range format", input: "invalid range", expectError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewConstraint(tt.input)
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error but got none")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestConstraintCheck(t *testing.T) {
+	tests := []struct {
+		name       string
+		constraint string
+		version    string
+		expected   bool
+	}{
+		// Basic comparisons
+		{name: ">= pass", constraint: ">=1.0.0", version: "1.0.0", expected: true},
+		{name: ">= pass higher", constraint: ">=1.0.0", version: "1.5.0", expected: true},
+		{name: ">= fail", constraint: ">=1.0.0", version: "0.9.0", expected: false},
+		{name: "<= pass", constraint: "<=2.0.0", version: "2.0.0", expected: true},
+		{name: "<= pass lower", constraint: "<=2.0.0", version: "1.5.0", expected: true},
+		{name: "<= fail", constraint: "<=2.0.0", version: "2.1.0", expected: false},
+		{name: "> pass", constraint: ">1.0.0", version: "1.0.1", expected: true},
+		{name: "> fail equal", constraint: ">1.0.0", version: "1.0.0", expected: false},
+		{name: "< pass", constraint: "<2.0.0", version: "1.9.9", expected: true},
+		{name: "< fail equal", constraint: "<2.0.0", version: "2.0.0", expected: false},
+		{name: "= pass", constraint: "=1.0.0", version: "1.0.0", expected: true},
+		{name: "= fail", constraint: "=1.0.0", version: "1.0.1", expected: false},
+
+		// Ranges
+		{name: "range pass", constraint: ">=1.0.0 <2.0.0", version: "1.5.0", expected: true},
+		{name: "range pass lower bound", constraint: ">=1.0.0 <2.0.0", version: "1.0.0", expected: true},
+		{name: "range fail upper bound", constraint: ">=1.0.0 <2.0.0", version: "2.0.0", expected: false},
+		{name: "range fail lower", constraint: ">=1.0.0 <2.0.0", version: "0.9.0", expected: false},
+		{name: "range fail upper", constraint: ">=1.0.0 <2.0.0", version: "2.1.0", expected: false},
+
+		// Caret constraints
+		{name: "caret pass same", constraint: "^1.2.3", version: "1.2.3", expected: true},
+		{name: "caret pass minor", constraint: "^1.2.3", version: "1.5.0", expected: true},
+		{name: "caret pass patch", constraint: "^1.2.3", version: "1.2.5", expected: true},
+		{name: "caret fail major", constraint: "^1.2.3", version: "2.0.0", expected: false},
+		{name: "caret fail lower", constraint: "^1.2.3", version: "1.2.2", expected: false},
+		{name: "caret 0.x pass", constraint: "^0.2.3", version: "0.2.5", expected: true},
+		{name: "caret 0.x fail minor", constraint: "^0.2.3", version: "0.3.0", expected: false},
+		{name: "caret 0.0.x pass", constraint: "^0.0.3", version: "0.0.3", expected: true},
+		{name: "caret 0.0.x fail patch", constraint: "^0.0.3", version: "0.0.4", expected: false},
+
+		// Tilde constraints
+		{name: "tilde pass same", constraint: "~1.2.3", version: "1.2.3", expected: true},
+		{name: "tilde pass patch", constraint: "~1.2.3", version: "1.2.5", expected: true},
+		{name: "tilde fail minor", constraint: "~1.2.3", version: "1.3.0", expected: false},
+		{name: "tilde fail lower", constraint: "~1.2.3", version: "1.2.2", expected: false},
+
+		// Version with v prefix
+		{name: "v prefix pass", constraint: ">=1.0.0", version: "v1.5.0", expected: true},
+		{name: "v prefix in constraint", constraint: ">=v1.0.0", version: "1.5.0", expected: true},
+
+		// Prerelease versions
+		{name: "prerelease pass", constraint: ">=1.0.0-rc1", version: "1.0.0-rc2", expected: true},
+		{name: "prerelease release higher", constraint: ">=1.0.0-rc1", version: "1.0.0", expected: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, err := NewConstraint(tt.constraint)
+			if err != nil {
+				t.Fatalf("failed to parse constraint: %v", err)
+			}
+			v, err := NewVersion(tt.version)
+			if err != nil {
+				t.Fatalf("failed to parse version: %v", err)
+			}
+			result := c.Check(v)
+			if result != tt.expected {
+				t.Errorf("expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Semantic Version Filtering for Regsync

Regsync now supports semantic versioning (semver) for filtering Docker image tags, similar to Renovate's or python-pips version support. This allows you to sync only specific version ranges instead of relying solely on regex patterns.

#### Features

- **Semantic Versioning (semver)**: Filter tags based on semver constraints
- **Multiple Version Ranges**: Support for multiple version range constraints with OR logic
- **Backward Compatible**: Existing regex-based filtering still works
- **Combined Filtering**: Use version ranges with allow/deny regex patterns
- **Auto-filtering**: Non-semver tags are automatically excluded when using semver

### How to verify it

run the included version_filter_test.go

```
go test -v ./cmd/regsync -run TestFilterListVersionScheme
```

amend the configuration as described in `cmd/regsync/version_filter_test.go` and give it a spin

### Changelog text

- Feat: regsync support for semantic versioning(semver) for matching tags

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
