### PR TITLE
Feat: Add tagSets to regsync

### DIFF
--- a/cmd/regsync/config.go
+++ b/cmd/regsync/config.go
@@ -69,6 +69,7 @@ type ConfigSync struct {
 	Target          string                 `yaml:"target" json:"target"`
 	Type            string                 `yaml:"type" json:"type"`
 	Tags            TagAllowDeny           `yaml:"tags" json:"tags"`
+	TagSets         []TagAllowDeny         `yaml:"tagSets" json:"tagSets"`
 	Repos           RepoAllowDeny          `yaml:"repos" json:"repos"`
 	DigestTags      *bool                  `yaml:"digestTags" json:"digestTags"`
 	Referrers       *bool                  `yaml:"referrers" json:"referrers"`


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This adds a `tagSets` feature described in https://github.com/regclient/regclient/pull/1005#discussion_r2475949405
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

In the regsync.yaml, include a `tagSets` that is a slice of filters in the `tags` syntax.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Feat: Add `tagSets` to regsync.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->
Docs will be added to regclient.org separately.

- [X] Tests have been added or not applicable
- [ ] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
