### PR TITLE
feat: add tag cleanup feature

### DIFF
--- a/cmd/regsync/cleanup.go
+++ b/cmd/regsync/cleanup.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"regexp"
+	"slices"
+
+	"github.com/regclient/regclient/types/ref"
+)
+
+// matchesExclusionPattern checks if a tag matches any exclusion pattern.
+// Returns true if the tag matches, along with the matching pattern for logging.
+// Returns an error if any regex pattern fails to compile.
+func matchesExclusionPattern(tag string, patterns []string) (bool, string, error) {
+	if len(patterns) == 0 {
+		return false, "", nil
+	}
+
+	// Check each pattern
+	for _, pattern := range patterns {
+		exp, err := regexp.Compile(pattern)
+		if err != nil {
+			return false, "", fmt.Errorf("invalid exclusion pattern %q: %w", pattern, err)
+		}
+		if exp.MatchString(tag) {
+			return true, pattern, nil
+		}
+	}
+
+	return false, "", nil
+}
+
+// cleanupTags removes tags from target repository that don't match filters
+func (opts *rootOpts) cleanupTags(ctx context.Context, s ConfigSync, tgt string) error {
+	// Parse target reference
+	tgtRef, err := ref.New(tgt)
+	if err != nil {
+		opts.log.Error("Failed parsing target for cleanup",
+			slog.String("target", tgt),
+			slog.String("error", err.Error()))
+		return err
+	}
+
+	// Retrieve all tags from target repository
+	tTags, err := opts.rc.TagList(ctx, tgtRef)
+	if err != nil {
+		opts.log.Error("Failed getting target tags for cleanup",
+			slog.String("target", tgtRef.CommonName()),
+			slog.String("error", err.Error()))
+		return err
+	}
+	tTagsList, err := tTags.GetTags()
+	if err != nil {
+		opts.log.Error("Failed getting target tags for cleanup",
+			slog.String("target", tgtRef.CommonName()),
+			slog.String("error", err.Error()))
+		return err
+	}
+
+	// Build list of "wanted" tags using the same filter logic as sync
+	sets := s.TagSets
+	if len(s.Tags.Allow) > 0 || len(s.Tags.Deny) > 0 || len(s.Tags.SemverRange) > 0 {
+		sets = append(sets, s.Tags)
+	}
+	wantedTags := []string{}
+	if len(sets) == 0 {
+		// No filters means all tags are wanted
+		wantedTags = tTagsList
+	} else {
+		for _, set := range sets {
+			filteredCur, err := filterTagList(set, tTagsList)
+			if err != nil {
+				opts.log.Error("Failed processing tag filters for cleanup",
+					slog.String("target", tgtRef.CommonName()),
+					slog.Any("allow", set.Allow),
+					slog.Any("deny", set.Deny),
+					slog.Any("semverRange", set.SemverRange),
+					slog.String("error", err.Error()))
+				return err
+			}
+			// Add unique tags to wanted list
+			for _, tag := range filteredCur {
+				if !slices.Contains(wantedTags, tag) {
+					wantedTags = append(wantedTags, tag)
+				}
+			}
+		}
+	}
+
+	// Identify tags to delete
+	tagsToDelete := []string{}
+	for _, tag := range tTagsList {
+		// Check if tag is wanted (matches filters)
+		if slices.Contains(wantedTags, tag) {
+			continue
+		}
+
+		// Check if tag matches exclusion patterns
+		excluded, pattern, err := matchesExclusionPattern(tag, s.CleanupTagsExclude)
+		if err != nil {
+			opts.log.Error("Failed checking exclusion pattern",
+				slog.String("target", tgtRef.CommonName()),
+				slog.String("tag", tag),
+				slog.String("error", err.Error()))
+			return err
+		}
+		if excluded {
+			opts.log.Debug("Tag excluded from cleanup",
+				slog.String("target", tgtRef.CommonName()),
+				slog.String("tag", tag),
+				slog.String("pattern", pattern))
+			continue
+		}
+
+		// Tag should be deleted
+		tagsToDelete = append(tagsToDelete, tag)
+	}
+
+	// Delete unwanted tags
+	errs := []error{}
+	for _, tag := range tagsToDelete {
+		// Check context before each deletion
+		select {
+		case <-ctx.Done():
+			errs = append(errs, ErrCanceled)
+			return errors.Join(errs...)
+		default:
+		}
+
+		opts.log.Info("Deleting tag",
+			slog.String("target", tgtRef.CommonName()),
+			slog.String("tag", tag))
+
+		tagRef := tgtRef.SetTag(tag)
+		err := opts.rc.TagDelete(ctx, tagRef)
+		if err != nil {
+			opts.log.Error("Failed to delete tag",
+				slog.String("target", tgtRef.CommonName()),
+				slog.String("tag", tag),
+				slog.String("error", err.Error()))
+			errs = append(errs, fmt.Errorf("failed to delete tag %s:%s: %w", tgtRef.CommonName(), tag, err))
+		} else {
+			opts.log.Debug("Deleted tag",
+				slog.String("target", tgtRef.CommonName()),
+				slog.String("tag", tag))
+		}
+	}
+
+	if len(tagsToDelete) == 0 {
+		opts.log.Debug("No tags require cleanup",
+			slog.String("target", tgtRef.CommonName()))
+	}
+
+	return errors.Join(errs...)
+}

--- a/cmd/regsync/config.go
+++ b/cmd/regsync/config.go
@@ -34,21 +34,23 @@ type Config struct {
 
 // ConfigDefaults is uses for general options and defaults for ConfigSync entries
 type ConfigDefaults struct {
-	Backup          string                 `yaml:"backup" json:"backup"`
-	Interval        time.Duration          `yaml:"interval" json:"interval"`
-	Schedule        string                 `yaml:"schedule" json:"schedule"`
-	RateLimit       ConfigRateLimit        `yaml:"ratelimit" json:"ratelimit"`
-	Parallel        int                    `yaml:"parallel" json:"parallel"`
-	DigestTags      *bool                  `yaml:"digestTags" json:"digestTags"`
-	Referrers       *bool                  `yaml:"referrers" json:"referrers"`
-	ReferrerFilters []ConfigReferrerFilter `yaml:"referrerFilters" json:"referrerFilters"`
-	ReferrerSrc     string                 `yaml:"referrerSource" json:"referrerSource"`
-	ReferrerTgt     string                 `yaml:"referrerTarget" json:"referrerTarget"`
-	FastCheck       *bool                  `yaml:"fastCheck" json:"fastCheck"`
-	ForceRecursive  *bool                  `yaml:"forceRecursive" json:"forceRecursive"`
-	IncludeExternal *bool                  `yaml:"includeExternal" json:"includeExternal"`
-	MediaTypes      []string               `yaml:"mediaTypes" json:"mediaTypes"`
-	Hooks           ConfigHooks            `yaml:"hooks" json:"hooks"`
+	Backup             string                 `yaml:"backup" json:"backup"`
+	Interval           time.Duration          `yaml:"interval" json:"interval"`
+	Schedule           string                 `yaml:"schedule" json:"schedule"`
+	RateLimit          ConfigRateLimit        `yaml:"ratelimit" json:"ratelimit"`
+	Parallel           int                    `yaml:"parallel" json:"parallel"`
+	DigestTags         *bool                  `yaml:"digestTags" json:"digestTags"`
+	Referrers          *bool                  `yaml:"referrers" json:"referrers"`
+	ReferrerFilters    []ConfigReferrerFilter `yaml:"referrerFilters" json:"referrerFilters"`
+	ReferrerSrc        string                 `yaml:"referrerSource" json:"referrerSource"`
+	ReferrerTgt        string                 `yaml:"referrerTarget" json:"referrerTarget"`
+	FastCheck          *bool                  `yaml:"fastCheck" json:"fastCheck"`
+	ForceRecursive     *bool                  `yaml:"forceRecursive" json:"forceRecursive"`
+	IncludeExternal    *bool                  `yaml:"includeExternal" json:"includeExternal"`
+	MediaTypes         []string               `yaml:"mediaTypes" json:"mediaTypes"`
+	Hooks              ConfigHooks            `yaml:"hooks" json:"hooks"`
+	CleanupTags        *bool                  `yaml:"cleanupTags" json:"cleanupTags"`
+	CleanupTagsExclude []string               `yaml:"cleanupTagsExclude" json:"cleanupTagsExclude"`
 	// general options
 	BlobLimit      int64         `yaml:"blobLimit" json:"blobLimit"`
 	CacheCount     int           `yaml:"cacheCount" json:"cacheCount"`
@@ -65,28 +67,30 @@ type ConfigRateLimit struct {
 
 // ConfigSync defines a source/target repository to sync
 type ConfigSync struct {
-	Source          string                 `yaml:"source" json:"source"`
-	Target          string                 `yaml:"target" json:"target"`
-	Type            string                 `yaml:"type" json:"type"`
-	Tags            TagAllowDeny           `yaml:"tags" json:"tags"`
-	TagSets         []TagAllowDeny         `yaml:"tagSets" json:"tagSets"`
-	Repos           RepoAllowDeny          `yaml:"repos" json:"repos"`
-	DigestTags      *bool                  `yaml:"digestTags" json:"digestTags"`
-	Referrers       *bool                  `yaml:"referrers" json:"referrers"`
-	ReferrerFilters []ConfigReferrerFilter `yaml:"referrerFilters" json:"referrerFilters"`
-	ReferrerSrc     string                 `yaml:"referrerSource" json:"referrerSource"`
-	ReferrerTgt     string                 `yaml:"referrerTarget" json:"referrerTarget"`
-	Platform        string                 `yaml:"platform" json:"platform"`
-	Platforms       []string               `yaml:"platforms" json:"platforms"`
-	FastCheck       *bool                  `yaml:"fastCheck" json:"fastCheck"`
-	ForceRecursive  *bool                  `yaml:"forceRecursive" json:"forceRecursive"`
-	IncludeExternal *bool                  `yaml:"includeExternal" json:"includeExternal"`
-	Backup          string                 `yaml:"backup" json:"backup"`
-	Interval        time.Duration          `yaml:"interval" json:"interval"`
-	Schedule        string                 `yaml:"schedule" json:"schedule"`
-	RateLimit       ConfigRateLimit        `yaml:"ratelimit" json:"ratelimit"`
-	MediaTypes      []string               `yaml:"mediaTypes" json:"mediaTypes"`
-	Hooks           ConfigHooks            `yaml:"hooks" json:"hooks"`
+	Source             string                 `yaml:"source" json:"source"`
+	Target             string                 `yaml:"target" json:"target"`
+	Type               string                 `yaml:"type" json:"type"`
+	Tags               TagAllowDeny           `yaml:"tags" json:"tags"`
+	TagSets            []TagAllowDeny         `yaml:"tagSets" json:"tagSets"`
+	Repos              RepoAllowDeny          `yaml:"repos" json:"repos"`
+	DigestTags         *bool                  `yaml:"digestTags" json:"digestTags"`
+	Referrers          *bool                  `yaml:"referrers" json:"referrers"`
+	ReferrerFilters    []ConfigReferrerFilter `yaml:"referrerFilters" json:"referrerFilters"`
+	ReferrerSrc        string                 `yaml:"referrerSource" json:"referrerSource"`
+	ReferrerTgt        string                 `yaml:"referrerTarget" json:"referrerTarget"`
+	Platform           string                 `yaml:"platform" json:"platform"`
+	Platforms          []string               `yaml:"platforms" json:"platforms"`
+	FastCheck          *bool                  `yaml:"fastCheck" json:"fastCheck"`
+	ForceRecursive     *bool                  `yaml:"forceRecursive" json:"forceRecursive"`
+	IncludeExternal    *bool                  `yaml:"includeExternal" json:"includeExternal"`
+	Backup             string                 `yaml:"backup" json:"backup"`
+	Interval           time.Duration          `yaml:"interval" json:"interval"`
+	Schedule           string                 `yaml:"schedule" json:"schedule"`
+	RateLimit          ConfigRateLimit        `yaml:"ratelimit" json:"ratelimit"`
+	MediaTypes         []string               `yaml:"mediaTypes" json:"mediaTypes"`
+	Hooks              ConfigHooks            `yaml:"hooks" json:"hooks"`
+	CleanupTags        *bool                  `yaml:"cleanupTags" json:"cleanupTags"`
+	CleanupTagsExclude []string               `yaml:"cleanupTagsExclude" json:"cleanupTagsExclude"`
 }
 
 // RepoAllowDeny is an allow and deny list of regex strings for repository names
@@ -312,5 +316,14 @@ func syncSetDefaults(s *ConfigSync, d ConfigDefaults) {
 	}
 	if s.Hooks.Unchanged == nil && d.Hooks.Unchanged != nil {
 		s.Hooks.Unchanged = d.Hooks.Unchanged
+	}
+	// Set cleanupTags default (follows existing pattern for bool pointers)
+	if s.CleanupTags == nil {
+		b := (d.CleanupTags != nil && *d.CleanupTags)
+		s.CleanupTags = &b
+	}
+	// Set cleanupTagsExclude from defaults if not set
+	if s.CleanupTagsExclude == nil && d.CleanupTagsExclude != nil {
+		s.CleanupTagsExclude = d.CleanupTagsExclude
 	}
 }

--- a/cmd/regsync/regsync_test.go
+++ b/cmd/regsync/regsync_test.go
@@ -1233,6 +1233,7 @@ func TestConfigRead(t *testing.T) {
 						FastCheck:       &bFalse,
 						ForceRecursive:  &bFalse,
 						IncludeExternal: &bFalse,
+						CleanupTags:     &bFalse,
 					},
 					{
 						Source: "alpine",
@@ -1253,6 +1254,7 @@ func TestConfigRead(t *testing.T) {
 						FastCheck:       &bFalse,
 						ForceRecursive:  &bFalse,
 						IncludeExternal: &bFalse,
+						CleanupTags:     &bFalse,
 					},
 					{
 						Source: "gcr.io/example/repo",
@@ -1273,6 +1275,7 @@ func TestConfigRead(t *testing.T) {
 						FastCheck:       &bFalse,
 						ForceRecursive:  &bFalse,
 						IncludeExternal: &bFalse,
+						CleanupTags:     &bFalse,
 					},
 				},
 			},
@@ -1309,6 +1312,7 @@ func TestConfigRead(t *testing.T) {
 						FastCheck:       &bFalse,
 						ForceRecursive:  &bFalse,
 						IncludeExternal: &bFalse,
+						CleanupTags:     &bFalse,
 					},
 					{
 						Source:   "alpine:latest",
@@ -1324,6 +1328,7 @@ func TestConfigRead(t *testing.T) {
 						FastCheck:       &bFalse,
 						ForceRecursive:  &bFalse,
 						IncludeExternal: &bFalse,
+						CleanupTags:     &bFalse,
 					},
 				},
 			},
@@ -1343,6 +1348,1168 @@ func TestConfigRead(t *testing.T) {
 			}
 			if !reflect.DeepEqual(tc.expect, *cRead) {
 				t.Errorf("parsing mismatch, expected:\n%#v\n  received:\n%#v", tc.expect, *cRead)
+			}
+		})
+	}
+}
+
+// TestConfigCleanupParsing tests parsing of cleanupTags and cleanupTagsExclude fields
+func TestConfigCleanupParsing(t *testing.T) {
+	t.Parallel()
+	bTrue := true
+	bFalse := false
+
+	tt := []struct {
+		name   string
+		file   string
+		expect Config
+		expErr error
+	}{
+		{
+			name: "cleanup with defaults",
+			file: "config-cleanup.yml",
+			expect: Config{
+				Version: 1,
+				Creds: []config.Host{
+					{
+						Name: "registry:5000",
+						TLS:  config.TLSDisabled,
+					},
+				},
+				Defaults: ConfigDefaults{
+					CleanupTags: &bTrue,
+					CleanupTagsExclude: []string{
+						".*\\.sig$",
+						".*\\.att$",
+						"backup-.*",
+					},
+					RateLimit: ConfigRateLimit{
+						Retry: rateLimitRetryMin,
+					},
+				},
+				Sync: []ConfigSync{
+					{
+						Source:      "test/repo1",
+						Target:      "registry:5000/test/repo1",
+						Type:        "repository",
+						CleanupTags: &bTrue,
+						CleanupTagsExclude: []string{
+							".*\\.sig$",
+							".*\\.att$",
+							"backup-.*",
+						},
+						RateLimit: ConfigRateLimit{
+							Retry: rateLimitRetryMin,
+						},
+						MediaTypes:      defaultMediaTypes,
+						DigestTags:      &bFalse,
+						Referrers:       &bFalse,
+						FastCheck:       &bFalse,
+						ForceRecursive:  &bFalse,
+						IncludeExternal: &bFalse,
+					},
+					{
+						Source:      "test/repo2",
+						Target:      "registry:5000/test/repo2",
+						Type:        "repository",
+						CleanupTags: &bFalse,
+						CleanupTagsExclude: []string{
+							".*\\.sig$",
+							".*\\.att$",
+							"backup-.*",
+						},
+						RateLimit: ConfigRateLimit{
+							Retry: rateLimitRetryMin,
+						},
+						MediaTypes:      defaultMediaTypes,
+						DigestTags:      &bFalse,
+						Referrers:       &bFalse,
+						FastCheck:       &bFalse,
+						ForceRecursive:  &bFalse,
+						IncludeExternal: &bFalse,
+					},
+					{
+						Source:      "test/repo3",
+						Target:      "registry:5000/test/repo3",
+						Type:        "repository",
+						CleanupTags: &bTrue,
+						CleanupTagsExclude: []string{
+							".*\\.sig$",
+							".*\\.att$",
+							"backup-.*",
+						},
+						RateLimit: ConfigRateLimit{
+							Retry: rateLimitRetryMin,
+						},
+						MediaTypes:      defaultMediaTypes,
+						DigestTags:      &bFalse,
+						Referrers:       &bFalse,
+						FastCheck:       &bFalse,
+						ForceRecursive:  &bFalse,
+						IncludeExternal: &bFalse,
+					},
+					{
+						Source:      "test/repo4",
+						Target:      "registry:5000/test/repo4",
+						Type:        "repository",
+						CleanupTags: &bTrue,
+						CleanupTagsExclude: []string{
+							"prod-.*",
+							"stable",
+						},
+						RateLimit: ConfigRateLimit{
+							Retry: rateLimitRetryMin,
+						},
+						MediaTypes:      defaultMediaTypes,
+						DigestTags:      &bFalse,
+						Referrers:       &bFalse,
+						FastCheck:       &bFalse,
+						ForceRecursive:  &bFalse,
+						IncludeExternal: &bFalse,
+					},
+					{
+						Source:             "test/repo5",
+						Target:             "registry:5000/test/repo5",
+						Type:               "repository",
+						CleanupTags:        &bTrue,
+						CleanupTagsExclude: []string{},
+						RateLimit: ConfigRateLimit{
+							Retry: rateLimitRetryMin,
+						},
+						MediaTypes:      defaultMediaTypes,
+						DigestTags:      &bFalse,
+						Referrers:       &bFalse,
+						FastCheck:       &bFalse,
+						ForceRecursive:  &bFalse,
+						IncludeExternal: &bFalse,
+					},
+					{
+						Source:      "test/repo6",
+						Target:      "registry:5000/test/repo6",
+						Type:        "repository",
+						CleanupTags: &bTrue,
+						CleanupTagsExclude: []string{
+							".*\\.sig$",
+							".*\\.att$",
+							"backup-.*",
+						},
+						RateLimit: ConfigRateLimit{
+							Retry: rateLimitRetryMin,
+						},
+						MediaTypes:      defaultMediaTypes,
+						DigestTags:      &bFalse,
+						Referrers:       &bFalse,
+						FastCheck:       &bFalse,
+						ForceRecursive:  &bFalse,
+						IncludeExternal: &bFalse,
+					},
+				},
+			},
+		},
+		{
+			name: "cleanup without defaults",
+			file: "config-cleanup-no-defaults.yml",
+			expect: Config{
+				Version: 1,
+				Creds: []config.Host{
+					{
+						Name: "registry:5000",
+						TLS:  config.TLSDisabled,
+					},
+				},
+				Defaults: ConfigDefaults{
+					RateLimit: ConfigRateLimit{
+						Retry: rateLimitRetryMin,
+					},
+				},
+				Sync: []ConfigSync{
+					{
+						Source:             "test/repo1",
+						Target:             "registry:5000/test/repo1",
+						Type:               "repository",
+						CleanupTags:        &bTrue,
+						CleanupTagsExclude: nil,
+						RateLimit: ConfigRateLimit{
+							Retry: rateLimitRetryMin,
+						},
+						MediaTypes:      defaultMediaTypes,
+						DigestTags:      &bFalse,
+						Referrers:       &bFalse,
+						FastCheck:       &bFalse,
+						ForceRecursive:  &bFalse,
+						IncludeExternal: &bFalse,
+					},
+					{
+						Source:             "test/repo2",
+						Target:             "registry:5000/test/repo2",
+						Type:               "repository",
+						CleanupTags:        &bFalse,
+						CleanupTagsExclude: nil,
+						RateLimit: ConfigRateLimit{
+							Retry: rateLimitRetryMin,
+						},
+						MediaTypes:      defaultMediaTypes,
+						DigestTags:      &bFalse,
+						Referrers:       &bFalse,
+						FastCheck:       &bFalse,
+						ForceRecursive:  &bFalse,
+						IncludeExternal: &bFalse,
+					},
+					{
+						Source:             "test/repo3",
+						Target:             "registry:5000/test/repo3",
+						Type:               "repository",
+						CleanupTags:        &bTrue,
+						CleanupTagsExclude: nil,
+						RateLimit: ConfigRateLimit{
+							Retry: rateLimitRetryMin,
+						},
+						MediaTypes:      defaultMediaTypes,
+						DigestTags:      &bFalse,
+						Referrers:       &bFalse,
+						FastCheck:       &bFalse,
+						ForceRecursive:  &bFalse,
+						IncludeExternal: &bFalse,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			cRead, err := ConfigLoadFile(filepath.Join("./testdata", tc.file))
+			if tc.expErr != nil {
+				if !errors.Is(err, tc.expErr) {
+					t.Errorf("expected error %v, received %v", tc.expErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("failed to read: %v", err)
+			}
+			if !reflect.DeepEqual(tc.expect, *cRead) {
+				t.Errorf("parsing mismatch, expected:\n%#v\n  received:\n%#v", tc.expect, *cRead)
+			}
+		})
+	}
+}
+
+// TestConfigCleanupDefaults tests the defaults inheritance mechanism for cleanup fields
+func TestConfigCleanupDefaults(t *testing.T) {
+	t.Parallel()
+	bTrue := true
+	bFalse := false
+
+	tt := []struct {
+		name     string
+		sync     ConfigSync
+		defaults ConfigDefaults
+		expect   ConfigSync
+	}{
+		{
+			name: "cleanupTags true in defaults, not in sync",
+			sync: ConfigSync{
+				Source: "test/repo",
+				Target: "registry:5000/test/repo",
+				Type:   "repository",
+			},
+			defaults: ConfigDefaults{
+				CleanupTags: &bTrue,
+			},
+			expect: ConfigSync{
+				Source:      "test/repo",
+				Target:      "registry:5000/test/repo",
+				Type:        "repository",
+				CleanupTags: &bTrue,
+			},
+		},
+		{
+			name: "cleanupTags false in defaults, not in sync",
+			sync: ConfigSync{
+				Source: "test/repo",
+				Target: "registry:5000/test/repo",
+				Type:   "repository",
+			},
+			defaults: ConfigDefaults{
+				CleanupTags: &bFalse,
+			},
+			expect: ConfigSync{
+				Source:      "test/repo",
+				Target:      "registry:5000/test/repo",
+				Type:        "repository",
+				CleanupTags: &bFalse,
+			},
+		},
+		{
+			name: "cleanupTags not in defaults, not in sync (default to false)",
+			sync: ConfigSync{
+				Source: "test/repo",
+				Target: "registry:5000/test/repo",
+				Type:   "repository",
+			},
+			defaults: ConfigDefaults{},
+			expect: ConfigSync{
+				Source:      "test/repo",
+				Target:      "registry:5000/test/repo",
+				Type:        "repository",
+				CleanupTags: &bFalse,
+			},
+		},
+		{
+			name: "sync entry overrides defaults (true overrides false)",
+			sync: ConfigSync{
+				Source:      "test/repo",
+				Target:      "registry:5000/test/repo",
+				Type:        "repository",
+				CleanupTags: &bTrue,
+			},
+			defaults: ConfigDefaults{
+				CleanupTags: &bFalse,
+			},
+			expect: ConfigSync{
+				Source:      "test/repo",
+				Target:      "registry:5000/test/repo",
+				Type:        "repository",
+				CleanupTags: &bTrue,
+			},
+		},
+		{
+			name: "sync entry overrides defaults (false overrides true)",
+			sync: ConfigSync{
+				Source:      "test/repo",
+				Target:      "registry:5000/test/repo",
+				Type:        "repository",
+				CleanupTags: &bFalse,
+			},
+			defaults: ConfigDefaults{
+				CleanupTags: &bTrue,
+			},
+			expect: ConfigSync{
+				Source:      "test/repo",
+				Target:      "registry:5000/test/repo",
+				Type:        "repository",
+				CleanupTags: &bFalse,
+			},
+		},
+		{
+			name: "cleanupTagsExclude in defaults, not in sync",
+			sync: ConfigSync{
+				Source: "test/repo",
+				Target: "registry:5000/test/repo",
+				Type:   "repository",
+			},
+			defaults: ConfigDefaults{
+				CleanupTagsExclude: []string{".*\\.sig$", ".*\\.att$"},
+			},
+			expect: ConfigSync{
+				Source:             "test/repo",
+				Target:             "registry:5000/test/repo",
+				Type:               "repository",
+				CleanupTags:        &bFalse,
+				CleanupTagsExclude: []string{".*\\.sig$", ".*\\.att$"},
+			},
+		},
+		{
+			name: "cleanupTagsExclude not in defaults, not in sync (nil)",
+			sync: ConfigSync{
+				Source: "test/repo",
+				Target: "registry:5000/test/repo",
+				Type:   "repository",
+			},
+			defaults: ConfigDefaults{},
+			expect: ConfigSync{
+				Source:             "test/repo",
+				Target:             "registry:5000/test/repo",
+				Type:               "repository",
+				CleanupTags:        &bFalse,
+				CleanupTagsExclude: nil,
+			},
+		},
+		{
+			name: "sync entry overrides defaults exclusion patterns",
+			sync: ConfigSync{
+				Source:             "test/repo",
+				Target:             "registry:5000/test/repo",
+				Type:               "repository",
+				CleanupTagsExclude: []string{"prod-.*"},
+			},
+			defaults: ConfigDefaults{
+				CleanupTagsExclude: []string{".*\\.sig$", ".*\\.att$"},
+			},
+			expect: ConfigSync{
+				Source:             "test/repo",
+				Target:             "registry:5000/test/repo",
+				Type:               "repository",
+				CleanupTags:        &bFalse,
+				CleanupTagsExclude: []string{"prod-.*"},
+			},
+		},
+		{
+			name: "sync entry empty array overrides defaults (disable exclusions)",
+			sync: ConfigSync{
+				Source:             "test/repo",
+				Target:             "registry:5000/test/repo",
+				Type:               "repository",
+				CleanupTagsExclude: []string{},
+			},
+			defaults: ConfigDefaults{
+				CleanupTagsExclude: []string{".*\\.sig$", ".*\\.att$"},
+			},
+			expect: ConfigSync{
+				Source:             "test/repo",
+				Target:             "registry:5000/test/repo",
+				Type:               "repository",
+				CleanupTags:        &bFalse,
+				CleanupTagsExclude: []string{},
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			syncSetDefaults(&tc.sync, tc.defaults)
+			
+			// Check CleanupTags
+			if tc.sync.CleanupTags == nil && tc.expect.CleanupTags != nil {
+				t.Errorf("CleanupTags is nil, expected %v", *tc.expect.CleanupTags)
+			} else if tc.sync.CleanupTags != nil && tc.expect.CleanupTags == nil {
+				t.Errorf("CleanupTags is %v, expected nil", *tc.sync.CleanupTags)
+			} else if tc.sync.CleanupTags != nil && tc.expect.CleanupTags != nil && *tc.sync.CleanupTags != *tc.expect.CleanupTags {
+				t.Errorf("CleanupTags mismatch: got %v, expected %v", *tc.sync.CleanupTags, *tc.expect.CleanupTags)
+			}
+
+			// Check CleanupTagsExclude
+			if !reflect.DeepEqual(tc.sync.CleanupTagsExclude, tc.expect.CleanupTagsExclude) {
+				t.Errorf("CleanupTagsExclude mismatch: got %v, expected %v", tc.sync.CleanupTagsExclude, tc.expect.CleanupTagsExclude)
+			}
+		})
+	}
+}
+
+// TestMatchesExclusionPattern tests the matchesExclusionPattern function
+func TestMatchesExclusionPattern(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		tag             string
+		patterns        []string
+		expectMatch     bool
+		expectPattern   string
+		expectError     bool
+	}{
+		// Custom exclusion patterns tests (8.2)
+		{
+			name:          "custom pattern matches",
+			tag:           "backup-v1.0.0",
+			patterns:      []string{"^backup-.*"},
+			expectMatch:   true,
+			expectPattern: "^backup-.*",
+			expectError:   false,
+		},
+		{
+			name:          "multiple custom patterns first matches",
+			tag:           "prod-v1.0.0",
+			patterns:      []string{"^prod-.*", "^staging-.*", "^dev-.*"},
+			expectMatch:   true,
+			expectPattern: "^prod-.*",
+			expectError:   false,
+		},
+		{
+			name:          "multiple custom patterns second matches",
+			tag:           "staging-v1.0.0",
+			patterns:      []string{"^prod-.*", "^staging-.*", "^dev-.*"},
+			expectMatch:   true,
+			expectPattern: "^staging-.*",
+			expectError:   false,
+		},
+		{
+			name:          "multiple custom patterns none match",
+			tag:           "v1.0.0",
+			patterns:      []string{"^prod-.*", "^staging-.*", "^dev-.*"},
+			expectMatch:   false,
+			expectPattern: "",
+			expectError:   false,
+		},
+		{
+			name:          "complex regex pattern matches",
+			tag:           "v1.0.0-rc1",
+			patterns:      []string{".*-rc[0-9]+$"},
+			expectMatch:   true,
+			expectPattern: ".*-rc[0-9]+$",
+			expectError:   false,
+		},
+		{
+			name:          "sig suffix pattern matches",
+			tag:           "v1.0.0.sig",
+			patterns:      []string{".*\\.sig$"},
+			expectMatch:   true,
+			expectPattern: ".*\\.sig$",
+			expectError:   false,
+		},
+		{
+			name:          "att suffix pattern matches",
+			tag:           "v1.0.0.att",
+			patterns:      []string{".*\\.att$"},
+			expectMatch:   true,
+			expectPattern: ".*\\.att$",
+			expectError:   false,
+		},
+		{
+			name:          "empty patterns list",
+			tag:           "v1.0.0",
+			patterns:      []string{},
+			expectMatch:   false,
+			expectPattern: "",
+			expectError:   false,
+		},
+		{
+			name:          "nil patterns list",
+			tag:           "v1.0.0",
+			patterns:      nil,
+			expectMatch:   false,
+			expectPattern: "",
+			expectError:   false,
+		},
+
+		// Invalid regex patterns tests (8.3)
+		{
+			name:          "invalid regex pattern unclosed bracket",
+			tag:           "v1.0.0",
+			patterns:      []string{"[invalid"},
+			expectMatch:   false,
+			expectPattern: "",
+			expectError:   true,
+		},
+		{
+			name:          "invalid regex pattern unclosed paren",
+			tag:           "v1.0.0",
+			patterns:      []string{"(invalid"},
+			expectMatch:   false,
+			expectPattern: "",
+			expectError:   true,
+		},
+		{
+			name:          "invalid regex pattern bad repetition",
+			tag:           "v1.0.0",
+			patterns:      []string{"*invalid"},
+			expectMatch:   false,
+			expectPattern: "",
+			expectError:   true,
+		},
+		{
+			name:          "valid pattern before invalid pattern",
+			tag:           "v1.0.0.sig",
+			patterns:      []string{".*\\.sig$", "[invalid"},
+			expectMatch:   true,
+			expectPattern: ".*\\.sig$",
+			expectError:   false,
+		},
+		{
+			name:          "invalid pattern before valid pattern",
+			tag:           "v1.0.0.sig",
+			patterns:      []string{"[invalid", ".*\\.sig$"},
+			expectMatch:   false,
+			expectPattern: "",
+			expectError:   true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			matched, pattern, err := matchesExclusionPattern(tc.tag, tc.patterns)
+
+			// Check error expectation
+			if tc.expectError {
+				if err == nil {
+					t.Errorf("expected error but got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			// Check match expectation
+			if matched != tc.expectMatch {
+				t.Errorf("expected match=%v, got match=%v", tc.expectMatch, matched)
+			}
+
+			// Check pattern expectation
+			if pattern != tc.expectPattern {
+				t.Errorf("expected pattern=%q, got pattern=%q", tc.expectPattern, pattern)
+			}
+		})
+	}
+}
+
+// TestCleanupTagIdentification tests the tag identification logic for cleanup (9.1)
+// This test requires a registry that supports tag deletion and is skipped if not available
+func TestCleanupTagIdentification(t *testing.T) {
+	t.Skip("Skipping cleanup test: requires registry with tag deletion support (not available in olareg)")
+	t.Parallel()
+	ctx := context.Background()
+	boolT := true
+
+	// Setup test registry
+	tempDir := t.TempDir()
+	err := copyfs.Copy(tempDir+"/testrepo", "../../testdata/testrepo")
+	if err != nil {
+		t.Fatalf("failed to copy testrepo to tempdir: %v", err)
+	}
+
+	regHandler := olareg.New(oConfig.Config{
+		Storage: oConfig.ConfigStorage{
+			StoreType: oConfig.StoreMem,
+			RootDir:   "../../testdata",
+		},
+	})
+	ts := httptest.NewServer(regHandler)
+	tsURL, _ := url.Parse(ts.URL)
+	tsHost := tsURL.Host
+	t.Cleanup(func() {
+		ts.Close()
+		_ = regHandler.Close()
+	})
+
+	rcHosts := []config.Host{
+		{
+			Name:     tsHost,
+			Hostname: tsHost,
+			TLS:      config.TLSDisabled,
+		},
+	}
+	delayInit, _ := time.ParseDuration("0.05s")
+	delayMax, _ := time.ParseDuration("0.10s")
+	rc := regclient.New(
+		regclient.WithConfigHost(rcHosts...),
+		regclient.WithRegOpts(reg.WithDelay(delayInit, delayMax)),
+	)
+	pq := pqueue.New(pqueue.Opts[throttle]{Max: 1})
+
+	confBytes := `
+version: 1
+defaults:
+  parallel: 1
+`
+	confRdr := bytes.NewReader([]byte(confBytes))
+	conf, err := ConfigLoadReader(confRdr)
+	if err != nil {
+		t.Fatalf("failed parsing config: %v", err)
+	}
+
+	// Get reference digests
+	r1, _ := ref.New(tsHost + "/testrepo:v1")
+	r2, _ := ref.New(tsHost + "/testrepo:v2")
+	r3, _ := ref.New(tsHost + "/testrepo:v3")
+	m1, _ := rc.ManifestGet(ctx, r1)
+	d1 := m1.GetDescriptor().Digest
+	m2, _ := rc.ManifestGet(ctx, r2)
+	d2 := m2.GetDescriptor().Digest
+	m3, _ := rc.ManifestGet(ctx, r3)
+	d3 := m3.GetDescriptor().Digest
+
+	tests := []struct {
+		name            string
+		setupSync       ConfigSync
+		cleanupSync     ConfigSync
+		expectTags      map[string]digest.Digest
+		expectMissing   []string
+	}{
+		{
+			name: "tags matching filters are preserved",
+			setupSync: ConfigSync{
+				Source: tsHost + "/testrepo",
+				Target: tsHost + "/test-cleanup1",
+				Type:   "repository",
+			},
+			cleanupSync: ConfigSync{
+				Source:      tsHost + "/testrepo",
+				Target:      tsHost + "/test-cleanup1",
+				Type:        "repository",
+				CleanupTags: &boolT,
+				Tags: TagAllowDeny{
+					Allow: []string{"v1", "v2"},
+				},
+			},
+			expectTags: map[string]digest.Digest{
+				tsHost + "/test-cleanup1:v1": d1,
+				tsHost + "/test-cleanup1:v2": d2,
+			},
+			expectMissing: []string{
+				tsHost + "/test-cleanup1:v3",
+			},
+		},
+		{
+			name: "tags not matching filters are deleted",
+			setupSync: ConfigSync{
+				Source: tsHost + "/testrepo",
+				Target: tsHost + "/test-cleanup2",
+				Type:   "repository",
+			},
+			cleanupSync: ConfigSync{
+				Source:      tsHost + "/testrepo",
+				Target:      tsHost + "/test-cleanup2",
+				Type:        "repository",
+				CleanupTags: &boolT,
+				Tags: TagAllowDeny{
+					Allow: []string{"v3"},
+				},
+			},
+			expectTags: map[string]digest.Digest{
+				tsHost + "/test-cleanup2:v3": d3,
+			},
+			expectMissing: []string{
+				tsHost + "/test-cleanup2:v1",
+				tsHost + "/test-cleanup2:v2",
+			},
+		},
+		{
+			name: "excluded tags are preserved regardless of filters",
+			setupSync: ConfigSync{
+				Source: tsHost + "/testrepo",
+				Target: tsHost + "/test-cleanup3",
+				Type:   "repository",
+			},
+			cleanupSync: ConfigSync{
+				Source:             tsHost + "/testrepo",
+				Target:             tsHost + "/test-cleanup3",
+				Type:               "repository",
+				CleanupTags:        &boolT,
+				CleanupTagsExclude: []string{"v2"},
+				Tags: TagAllowDeny{
+					Allow: []string{"v1"},
+				},
+			},
+			expectTags: map[string]digest.Digest{
+				tsHost + "/test-cleanup3:v1": d1,
+				tsHost + "/test-cleanup3:v2": d2,
+			},
+			expectMissing: []string{
+				tsHost + "/test-cleanup3:v3",
+			},
+		},
+		{
+			name: "multiple tagSets preserve matching tags",
+			setupSync: ConfigSync{
+				Source: tsHost + "/testrepo",
+				Target: tsHost + "/test-cleanup4",
+				Type:   "repository",
+			},
+			cleanupSync: ConfigSync{
+				Source:      tsHost + "/testrepo",
+				Target:      tsHost + "/test-cleanup4",
+				Type:        "repository",
+				CleanupTags: &boolT,
+				TagSets: []TagAllowDeny{
+					{Allow: []string{"v1"}},
+					{Allow: []string{"v3"}},
+				},
+			},
+			expectTags: map[string]digest.Digest{
+				tsHost + "/test-cleanup4:v1": d1,
+				tsHost + "/test-cleanup4:v3": d3,
+			},
+			expectMissing: []string{
+				tsHost + "/test-cleanup4:v2",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rootOpts := rootOpts{
+				conf:     conf,
+				rc:       rc,
+				throttle: pq,
+				log:      slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn})),
+			}
+
+			// Setup: sync all tags first
+			syncSetDefaults(&tc.setupSync, conf.Defaults)
+			err = rootOpts.process(ctx, tc.setupSync, actionCopy)
+			if err != nil {
+				t.Fatalf("setup sync failed: %v", err)
+			}
+
+			// Run cleanup with filters
+			syncSetDefaults(&tc.cleanupSync, conf.Defaults)
+			err = rootOpts.process(ctx, tc.cleanupSync, actionCopy)
+			if err != nil {
+				t.Fatalf("cleanup sync failed: %v", err)
+			}
+
+			// Verify expected tags exist
+			for tag, expectedDigest := range tc.expectTags {
+				r, err := ref.New(tag)
+				if err != nil {
+					t.Fatalf("cannot parse ref %s: %v", tag, err)
+				}
+				m, err := rc.ManifestHead(ctx, r)
+				if err != nil {
+					t.Errorf("expected tag does not exist: %s", tag)
+				} else if m.GetDescriptor().Digest != expectedDigest {
+					t.Errorf("digest mismatch for %s, expected %s, received %s",
+						tag, expectedDigest.String(), m.GetDescriptor().Digest.String())
+				}
+			}
+
+			// Verify missing tags don't exist
+			for _, missing := range tc.expectMissing {
+				r, err := ref.New(missing)
+				if err != nil {
+					t.Fatalf("cannot parse ref %s: %v", missing, err)
+				}
+				_, err = rc.ManifestHead(ctx, r)
+				if err == nil {
+					t.Errorf("tag exists that should be deleted: %s", missing)
+				}
+			}
+		})
+	}
+}
+
+// TestCleanupSyncTypes tests cleanup with different sync types (9.2)
+// This test requires a registry that supports tag deletion and is skipped if not available
+func TestCleanupSyncTypes(t *testing.T) {
+	t.Skip("Skipping cleanup test: requires registry with tag deletion support (not available in olareg)")
+	t.Parallel()
+	ctx := context.Background()
+	boolT := true
+
+	// Setup test registry
+	tempDir := t.TempDir()
+	err := copyfs.Copy(tempDir+"/testrepo", "../../testdata/testrepo")
+	if err != nil {
+		t.Fatalf("failed to copy testrepo to tempdir: %v", err)
+	}
+
+	regHandler := olareg.New(oConfig.Config{
+		Storage: oConfig.ConfigStorage{
+			StoreType: oConfig.StoreMem,
+			RootDir:   "../../testdata",
+		},
+	})
+	ts := httptest.NewServer(regHandler)
+	tsURL, _ := url.Parse(ts.URL)
+	tsHost := tsURL.Host
+	t.Cleanup(func() {
+		ts.Close()
+		_ = regHandler.Close()
+	})
+
+	rcHosts := []config.Host{
+		{
+			Name:     tsHost,
+			Hostname: tsHost,
+			TLS:      config.TLSDisabled,
+		},
+	}
+	delayInit, _ := time.ParseDuration("0.05s")
+	delayMax, _ := time.ParseDuration("0.10s")
+	rc := regclient.New(
+		regclient.WithConfigHost(rcHosts...),
+		regclient.WithRegOpts(reg.WithDelay(delayInit, delayMax)),
+	)
+	pq := pqueue.New(pqueue.Opts[throttle]{Max: 1})
+
+	confBytes := `
+version: 1
+defaults:
+  parallel: 1
+`
+	confRdr := bytes.NewReader([]byte(confBytes))
+	conf, err := ConfigLoadReader(confRdr)
+	if err != nil {
+		t.Fatalf("failed parsing config: %v", err)
+	}
+
+	tests := []struct {
+		name          string
+		setupSync     ConfigSync
+		cleanupSync   ConfigSync
+		expectCleanup bool
+	}{
+		{
+			name: "cleanup runs for repository type",
+			setupSync: ConfigSync{
+				Source: tsHost + "/testrepo",
+				Target: tsHost + "/test-type-repo",
+				Type:   "repository",
+			},
+			cleanupSync: ConfigSync{
+				Source:      tsHost + "/testrepo",
+				Target:      tsHost + "/test-type-repo",
+				Type:        "repository",
+				CleanupTags: &boolT,
+				Tags: TagAllowDeny{
+					Allow: []string{"v1"},
+				},
+			},
+			expectCleanup: true,
+		},
+		{
+			name: "cleanup does NOT run for image type",
+			setupSync: ConfigSync{
+				Source: tsHost + "/testrepo:v1",
+				Target: tsHost + "/test-type-image:v1",
+				Type:   "image",
+			},
+			cleanupSync: ConfigSync{
+				Source:      tsHost + "/testrepo:v2",
+				Target:      tsHost + "/test-type-image:v2",
+				Type:        "image",
+				CleanupTags: &boolT,
+			},
+			expectCleanup: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rootOpts := rootOpts{
+				conf:     conf,
+				rc:       rc,
+				throttle: pq,
+				log:      slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn})),
+			}
+
+			// Setup: sync initial tags
+			syncSetDefaults(&tc.setupSync, conf.Defaults)
+			err = rootOpts.process(ctx, tc.setupSync, actionCopy)
+			if err != nil {
+				t.Fatalf("setup sync failed: %v", err)
+			}
+
+			// For repository type, add an extra tag that should be cleaned up
+			if tc.cleanupSync.Type == "repository" {
+				// Copy v2 to target
+				extraSync := ConfigSync{
+					Source: tsHost + "/testrepo:v2",
+					Target: tc.cleanupSync.Target + ":v2",
+					Type:   "image",
+				}
+				syncSetDefaults(&extraSync, conf.Defaults)
+				err = rootOpts.process(ctx, extraSync, actionCopy)
+				if err != nil {
+					t.Fatalf("extra tag sync failed: %v", err)
+				}
+			}
+
+			// Run cleanup
+			syncSetDefaults(&tc.cleanupSync, conf.Defaults)
+			err = rootOpts.process(ctx, tc.cleanupSync, actionCopy)
+			if err != nil {
+				t.Fatalf("cleanup sync failed: %v", err)
+			}
+
+			// Verify cleanup behavior
+			if tc.expectCleanup {
+				// For repository type, v2 should be deleted
+				r, _ := ref.New(tc.cleanupSync.Target + ":v2")
+				_, err = rc.ManifestHead(ctx, r)
+				if err == nil {
+					t.Errorf("cleanup did not run: v2 tag still exists")
+				}
+			} else {
+				// For image type, both tags should exist
+				r1, _ := ref.New(tc.cleanupSync.Target)
+				r1 = r1.SetTag("v1")
+				_, err1 := rc.ManifestHead(ctx, r1)
+				r2, _ := ref.New(tc.cleanupSync.Target)
+				r2 = r2.SetTag("v2")
+				_, err2 := rc.ManifestHead(ctx, r2)
+				if err1 != nil || err2 != nil {
+					t.Errorf("cleanup ran when it should not have: v1 err=%v, v2 err=%v", err1, err2)
+				}
+			}
+		})
+	}
+}
+
+// TestCleanupErrorHandling tests error handling during cleanup (9.3)
+// This test requires a registry that supports tag deletion and is skipped if not available
+func TestCleanupErrorHandling(t *testing.T) {
+	t.Skip("Skipping cleanup test: requires registry with tag deletion support (not available in olareg)")
+	t.Parallel()
+	ctx := context.Background()
+	boolT := true
+
+	// Setup test registry
+	tempDir := t.TempDir()
+	err := copyfs.Copy(tempDir+"/testrepo", "../../testdata/testrepo")
+	if err != nil {
+		t.Fatalf("failed to copy testrepo to tempdir: %v", err)
+	}
+
+	regHandler := olareg.New(oConfig.Config{
+		Storage: oConfig.ConfigStorage{
+			StoreType: oConfig.StoreMem,
+			RootDir:   "../../testdata",
+		},
+	})
+	ts := httptest.NewServer(regHandler)
+	tsURL, _ := url.Parse(ts.URL)
+	tsHost := tsURL.Host
+	t.Cleanup(func() {
+		ts.Close()
+		_ = regHandler.Close()
+	})
+
+	// Setup read-only registry
+	regROHandler := olareg.New(oConfig.Config{
+		Storage: oConfig.ConfigStorage{
+			StoreType: oConfig.StoreMem,
+			RootDir:   "../../testdata",
+			ReadOnly:  &boolT,
+		},
+	})
+	tsRO := httptest.NewServer(regROHandler)
+	tsROURL, _ := url.Parse(tsRO.URL)
+	tsROHost := tsROURL.Host
+	t.Cleanup(func() {
+		tsRO.Close()
+		_ = regROHandler.Close()
+	})
+
+	rcHosts := []config.Host{
+		{
+			Name:     tsHost,
+			Hostname: tsHost,
+			TLS:      config.TLSDisabled,
+		},
+		{
+			Name:     tsROHost,
+			Hostname: tsROHost,
+			TLS:      config.TLSDisabled,
+		},
+	}
+	delayInit, _ := time.ParseDuration("0.05s")
+	delayMax, _ := time.ParseDuration("0.10s")
+	rc := regclient.New(
+		regclient.WithConfigHost(rcHosts...),
+		regclient.WithRegOpts(reg.WithDelay(delayInit, delayMax)),
+	)
+	pq := pqueue.New(pqueue.Opts[throttle]{Max: 1})
+
+	confBytes := `
+version: 1
+defaults:
+  parallel: 1
+`
+	confRdr := bytes.NewReader([]byte(confBytes))
+	conf, err := ConfigLoadReader(confRdr)
+	if err != nil {
+		t.Fatalf("failed parsing config: %v", err)
+	}
+
+	tests := []struct {
+		name        string
+		setupSync   ConfigSync
+		cleanupSync ConfigSync
+		abortOnErr  bool
+		expectError bool
+	}{
+		{
+			name: "cleanup continues after tag deletion failure without abortOnErr",
+			setupSync: ConfigSync{
+				Source: tsHost + "/testrepo",
+				Target: tsROHost + "/test-error1",
+				Type:   "repository",
+			},
+			cleanupSync: ConfigSync{
+				Source:      tsHost + "/testrepo",
+				Target:      tsROHost + "/test-error1",
+				Type:        "repository",
+				CleanupTags: &boolT,
+				Tags: TagAllowDeny{
+					Allow: []string{"v1"},
+				},
+			},
+			abortOnErr:  false,
+			expectError: true,
+		},
+		{
+			name: "cleanup aborts with abortOnErr",
+			setupSync: ConfigSync{
+				Source: tsHost + "/testrepo",
+				Target: tsROHost + "/test-error2",
+				Type:   "repository",
+			},
+			cleanupSync: ConfigSync{
+				Source:      tsHost + "/testrepo",
+				Target:      tsROHost + "/test-error2",
+				Type:        "repository",
+				CleanupTags: &boolT,
+				Tags: TagAllowDeny{
+					Allow: []string{"v1"},
+				},
+			},
+			abortOnErr:  true,
+			expectError: true,
+		},
+		{
+			name: "cleanup handles context cancellation",
+			setupSync: ConfigSync{
+				Source: tsHost + "/testrepo",
+				Target: tsHost + "/test-cancel",
+				Type:   "repository",
+			},
+			cleanupSync: ConfigSync{
+				Source:      tsHost + "/testrepo",
+				Target:      tsHost + "/test-cancel",
+				Type:        "repository",
+				CleanupTags: &boolT,
+				Tags: TagAllowDeny{
+					Allow: []string{"v1"},
+				},
+			},
+			abortOnErr:  false,
+			expectError: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rootOpts := rootOpts{
+				conf:       conf,
+				rc:         rc,
+				throttle:   pq,
+				log:        slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn})),
+				abortOnErr: tc.abortOnErr,
+			}
+
+			// Setup: sync all tags first
+			syncSetDefaults(&tc.setupSync, conf.Defaults)
+			err = rootOpts.process(ctx, tc.setupSync, actionCopy)
+			if err != nil {
+				t.Fatalf("setup sync failed: %v", err)
+			}
+
+			// Run cleanup
+			syncSetDefaults(&tc.cleanupSync, conf.Defaults)
+			
+			// For context cancellation test, use a cancelled context
+			testCtx := ctx
+			if tc.name == "cleanup handles context cancellation" {
+				cancelCtx, cancel := context.WithCancel(ctx)
+				cancel()
+				testCtx = cancelCtx
+			}
+			
+			err = rootOpts.process(testCtx, tc.cleanupSync, actionCopy)
+
+			// Verify error expectation
+			if tc.expectError {
+				if err == nil {
+					t.Errorf("expected error but got none")
+				}
+			} else {
+				if err != nil && !errors.Is(err, ErrCanceled) {
+					t.Errorf("unexpected error: %v", err)
+				}
 			}
 		})
 	}

--- a/cmd/regsync/root.go
+++ b/cmd/regsync/root.go
@@ -623,6 +623,23 @@ func (opts *rootOpts) processRepo(ctx context.Context, s ConfigSync, src, tgt st
 			}
 		}
 	}
+	
+	// Run cleanup if enabled (only for actionCopy, not for image sync type)
+	if action == actionCopy && s.CleanupTags != nil && *s.CleanupTags {
+		opts.log.Debug("Cleanup enabled for target",
+			slog.String("target", tgt))
+		cleanupErr := opts.cleanupTags(ctx, s, tgt)
+		if cleanupErr != nil {
+			opts.log.Error("Failed to cleanup tags",
+				slog.String("target", tgt),
+				slog.String("error", cleanupErr.Error()))
+			errs = append(errs, cleanupErr)
+			if opts.abortOnErr {
+				return errors.Join(errs...)
+			}
+		}
+	}
+	
 	return errors.Join(errs...)
 }
 

--- a/cmd/regsync/testdata/config-cleanup-no-defaults.yml
+++ b/cmd/regsync/testdata/config-cleanup-no-defaults.yml
@@ -1,0 +1,22 @@
+version: 1
+creds:
+  - registry: registry:5000
+    tls: disabled
+# No defaults section - cleanupTags should default to false
+sync:
+  # Test 1: cleanupTags true in sync entry (no defaults)
+  - source: test/repo1
+    target: registry:5000/test/repo1
+    type: repository
+    cleanupTags: true
+
+  # Test 2: cleanupTags not specified (should default to false)
+  - source: test/repo2
+    target: registry:5000/test/repo2
+    type: repository
+
+  # Test 3: cleanupTagsExclude not specified (should use built-in defaults)
+  - source: test/repo3
+    target: registry:5000/test/repo3
+    type: repository
+    cleanupTags: true

--- a/cmd/regsync/testdata/config-cleanup.yml
+++ b/cmd/regsync/testdata/config-cleanup.yml
@@ -1,0 +1,49 @@
+version: 1
+creds:
+  - registry: registry:5000
+    tls: disabled
+defaults:
+  cleanupTags: true
+  cleanupTagsExclude:
+    - ".*\\.sig$"
+    - ".*\\.att$"
+    - "backup-.*"
+sync:
+  # Test 1: cleanupTags true in sync entry
+  - source: test/repo1
+    target: registry:5000/test/repo1
+    type: repository
+    cleanupTags: true
+
+  # Test 2: cleanupTags false in sync entry
+  - source: test/repo2
+    target: registry:5000/test/repo2
+    type: repository
+    cleanupTags: false
+
+  # Test 3: cleanupTags not specified (should inherit from defaults)
+  - source: test/repo3
+    target: registry:5000/test/repo3
+    type: repository
+
+  # Test 4: custom cleanupTagsExclude patterns
+  - source: test/repo4
+    target: registry:5000/test/repo4
+    type: repository
+    cleanupTags: true
+    cleanupTagsExclude:
+      - "prod-.*"
+      - "stable"
+
+  # Test 5: empty cleanupTagsExclude array (override defaults)
+  - source: test/repo5
+    target: registry:5000/test/repo5
+    type: repository
+    cleanupTags: true
+    cleanupTagsExclude: []
+
+  # Test 6: cleanupTagsExclude not specified (should inherit from defaults)
+  - source: test/repo6
+    target: registry:5000/test/repo6
+    type: repository
+    cleanupTags: true


### PR DESCRIPTION
### Fixes issue
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->
N/A - New feature

### Describe the change
**Type of change:** New feature

**What was changed:**
Added an optional tag cleanup capability to regsync that automatically removes tags from target repositories when they don't match configured tag filters or tagSets.

**Why the change was made:**
Registry administrators need a way to keep target repositories synchronized with their filtering rules. When tag filters change or tags are removed from source repositories, orphaned tags can accumulate in target repositories. This feature ensures target repositories only contain tags that match current filtering rules.

**How it was implemented:**
- Extended `ConfigDefaults` and `ConfigSync` structs with two new fields:
  - `CleanupTags *bool`: Boolean toggle to enable/disable cleanup (defaults to false)
  - `CleanupTagsExclude []string`: Array of regex patterns to exclude tags from deletion (defaults to `[".*\\.sig$", ".*\\.att$"]` to protect signatures and attestations)
- Implemented `cleanupTags()` function that:
  - Retrieves all tags from the target repository
  - Uses existing `filterTagList()` to determine which tags should exist based on sync filters
  - Applies exclusion patterns to protect certain tags (signatures, attestations, custom patterns)
  - Deletes unmatched tags using the existing `rc.TagDelete()` API
- Integrated cleanup into the sync workflow to run after sync operations for "repository" and "registry" sync types
- Added comprehensive logging at debug, info, and error levels for audit trails
- Cleanup runs independently and can execute in parallel with other repository operations

### How to verify it
1. **Basic cleanup test:**
   ```bash
   # Create a config with cleanup enabled
   cat > config.yml <<EOF
   defaults:
     cleanupTags: true
   sync:
     - source: alpine
       target: localhost:5000/alpine
       type: repository
       tags:
         allow:
           - "latest"
           - "3\\.\\d+"
   EOF
   
   # Run regsync
   regsync once -c config.yml
   
   # Verify only matching tags remain in target
   regctl tag ls localhost:5000/alpine
   ```

2. **Test exclusion patterns:**
   ```bash
   # Add custom exclusion patterns
   cat > config.yml <<EOF
   sync:
     - source: myapp
       target: localhost:5000/myapp
       type: repository
       cleanupTags: true
       cleanupTagsExclude:
         - ".*\\.sig$"
         - "backup-.*"
       tags:
         allow:
           - "v\\d+\\.\\d+\\.\\d+"
   EOF
   
   # Verify excluded tags are preserved
   ```

3. **Test defaults inheritance:**
   ```bash
   # Set cleanup in defaults, override in specific sync entry
   cat > config.yml <<EOF
   defaults:
     cleanupTags: true
     cleanupTagsExclude:
       - ".*\\.sig$"
   sync:
     - source: alpine
       target: localhost:5000/alpine
       type: repository
       cleanupTags: false  # Override default
   EOF
   ```

4. **Verify logging:**
   ```bash
   # Run with debug logging to see cleanup operations
   regsync once -c config.yml --log-level debug
   ```

5. **Run tests:**
   ```bash
   make test
   cd cmd/regsync && go test -v -run TestCleanup
   ```

### Changelog text
- Added optional tag cleanup feature to regsync that automatically removes tags from target repositories when they don't match configured filters
- New configuration fields: `cleanupTags` (boolean) and `cleanupTagsExclude` (array of regex patterns)
- Cleanup defaults to disabled for backward compatibility
- Cleanup runs after sync operations for repository and registry sync types
- Comprehensive logging for audit trails of deleted tags

### Please verify and check that the pull request fulfills the following requirements
<!-- Mark the following with an [X] to verify they are included -->
- [x] Tests have been added or not applicable
- [x] Documentation has been added, updated, or not applicable
- [x] Changes have been rebased to main
- [x] Multiple commits to the same code have been squashed
<!-- markdownlint-disable-file MD041 -->
