### PR TITLE
Build artifacts for riscv64

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -108,7 +108,7 @@ jobs:
       with:
         context: .
         file: ./build/Dockerfile.${{ matrix.image }}.buildkit
-        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/ppc64le,linux/s390x
+        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/ppc64le,linux/s390x,linux/riscv64
         target: release-${{ matrix.type }}
         outputs: type=oci,oci-artifact=true,dest=output/${{matrix.image}}-${{matrix.type}}.tar
         provenance: version=v1,mode=max

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -86,6 +86,7 @@ jobs:
             regbot-linux-arm64 \
             regbot-linux-ppc64le \
             regbot-linux-s390x \
+            regbot-linux-riscv64 \
             regbot-windows-amd64.exe \
             regctl-darwin-amd64 \
             regctl-darwin-arm64 \
@@ -93,6 +94,7 @@ jobs:
             regctl-linux-arm64 \
             regctl-linux-ppc64le \
             regctl-linux-s390x \
+            regctl-linux-riscv64 \
             regctl-windows-amd64.exe \
             regsync-darwin-amd64 \
             regsync-darwin-arm64 \
@@ -100,6 +102,7 @@ jobs:
             regsync-linux-arm64 \
             regsync-linux-ppc64le \
             regsync-linux-s390x \
+            regsync-linux-riscv64 \
             regsync-windows-amd64.exe \
           ; do
           cosign sign-blob -y --output-signature "${artifact%.exe}.sig" --output-certificate "${artifact%.exe}.pem" "${artifact}"
@@ -136,6 +139,7 @@ jobs:
           ./artifacts/regbot-linux-arm64
           ./artifacts/regbot-linux-ppc64le
           ./artifacts/regbot-linux-s390x
+          ./artifacts/regbot-linux-riscv64
           ./artifacts/regbot-windows-amd64.exe
           ./artifacts/regctl-darwin-amd64
           ./artifacts/regctl-darwin-arm64
@@ -143,6 +147,7 @@ jobs:
           ./artifacts/regctl-linux-arm64
           ./artifacts/regctl-linux-ppc64le
           ./artifacts/regctl-linux-s390x
+          ./artifacts/regctl-linux-riscv64
           ./artifacts/regctl-windows-amd64.exe
           ./artifacts/regsync-darwin-amd64
           ./artifacts/regsync-darwin-arm64
@@ -150,6 +155,7 @@ jobs:
           ./artifacts/regsync-linux-arm64
           ./artifacts/regsync-linux-ppc64le
           ./artifacts/regsync-linux-s390x
+          ./artifacts/regsync-linux-riscv64
           ./artifacts/regsync-windows-amd64.exe
           ./artifacts/metadata.tgz
 

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 COMMANDS?=regctl regsync regbot
 BINARIES?=$(addprefix bin/,$(COMMANDS))
 IMAGES?=$(addprefix docker-,$(COMMANDS))
-ARTIFACT_PLATFORMS?=linux-amd64 linux-arm64 linux-ppc64le linux-s390x darwin-amd64 darwin-arm64 windows-amd64.exe
+ARTIFACT_PLATFORMS?=linux-amd64 linux-arm64 linux-ppc64le linux-s390x linux-riscv64 darwin-amd64 darwin-arm64 windows-amd64.exe
 ARTIFACTS?=$(foreach cmd,$(addprefix artifacts/,$(COMMANDS)),$(addprefix $(cmd)-,$(ARTIFACT_PLATFORMS)))
-TEST_PLATFORMS?=linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/ppc64le,linux/s390x
+TEST_PLATFORMS?=linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/ppc64le,linux/s390x,linux/riscv64
 VCS_REPO?="https://github.com/regclient/regclient.git"
 VCS_REF?=$(shell git rev-list -1 HEAD)
 ifneq ($(shell git status --porcelain 2>/dev/null),)

--- a/build/oci-image.sh
+++ b/build/oci-image.sh
@@ -2,7 +2,7 @@
 
 set -e
 image="regctl"
-platforms="linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/ppc64le,linux/s390x"
+platforms="linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/ppc64le,linux/s390x,linux/riscv64"
 base_name=""
 release="scratch"
 push_tags=""


### PR DESCRIPTION


<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue
None
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Recently, riscv64 has gained widespread adoption, and a considerable number of images for riscv64 have appeared on Docker Hub. For example, Debian, Ubuntu, and Alpine all have relevant support, so we can consider building artifacts for riscv64.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

I ran the CI in my fork, and the results show everything is working well, as follows:

1. [CI - Registry](https://github.com/ffgan/regclient/actions/runs/19331031825)
2. [Docker](https://github.com/ffgan/regclient/actions/runs/19331031824)
3. [Go](https://github.com/ffgan/regclient/actions/runs/19331031813)


If you have any questions about this PR, feel free to @ me directly anytime. I'm happy to answer all related questions.

<!-- Include steps that can be taken to verify the change -->

### Changelog text

Build artifacts for riscv64
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [ ] Tests have been added or not applicable
- [ ] Documentation has been added, updated, or not applicable
- [x] Changes have been rebased to main
- [x] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->


---
**Other Info**
Co-authored by: nijincheng@iscas.ac.cn;
