### PR TITLE
additionalTargets depending on target state

### DIFF
--- a/cmd/regsync/config.go
+++ b/cmd/regsync/config.go
@@ -65,28 +65,29 @@ type ConfigRateLimit struct {
 
 // ConfigSync defines a source/target repository to sync
 type ConfigSync struct {
-	Source          string                 `yaml:"source" json:"source"`
-	Target          string                 `yaml:"target" json:"target"`
-	Type            string                 `yaml:"type" json:"type"`
-	Tags            TagAllowDeny           `yaml:"tags" json:"tags"`
-	TagSets         []TagAllowDeny         `yaml:"tagSets" json:"tagSets"`
-	Repos           RepoAllowDeny          `yaml:"repos" json:"repos"`
-	DigestTags      *bool                  `yaml:"digestTags" json:"digestTags"`
-	Referrers       *bool                  `yaml:"referrers" json:"referrers"`
-	ReferrerFilters []ConfigReferrerFilter `yaml:"referrerFilters" json:"referrerFilters"`
-	ReferrerSrc     string                 `yaml:"referrerSource" json:"referrerSource"`
-	ReferrerTgt     string                 `yaml:"referrerTarget" json:"referrerTarget"`
-	Platform        string                 `yaml:"platform" json:"platform"`
-	Platforms       []string               `yaml:"platforms" json:"platforms"`
-	FastCheck       *bool                  `yaml:"fastCheck" json:"fastCheck"`
-	ForceRecursive  *bool                  `yaml:"forceRecursive" json:"forceRecursive"`
-	IncludeExternal *bool                  `yaml:"includeExternal" json:"includeExternal"`
-	Backup          string                 `yaml:"backup" json:"backup"`
-	Interval        time.Duration          `yaml:"interval" json:"interval"`
-	Schedule        string                 `yaml:"schedule" json:"schedule"`
-	RateLimit       ConfigRateLimit        `yaml:"ratelimit" json:"ratelimit"`
-	MediaTypes      []string               `yaml:"mediaTypes" json:"mediaTypes"`
-	Hooks           ConfigHooks            `yaml:"hooks" json:"hooks"`
+	Source            string                 `yaml:"source" json:"source"`
+	Target            string                 `yaml:"target" json:"target"`
+	AdditionalTargets []string               `yaml:"additionalTargets" json:"additionalTargets"`
+	Type              string                 `yaml:"type" json:"type"`
+	Tags              TagAllowDeny           `yaml:"tags" json:"tags"`
+	TagSets           []TagAllowDeny         `yaml:"tagSets" json:"tagSets"`
+	Repos             RepoAllowDeny          `yaml:"repos" json:"repos"`
+	DigestTags        *bool                  `yaml:"digestTags" json:"digestTags"`
+	Referrers         *bool                  `yaml:"referrers" json:"referrers"`
+	ReferrerFilters   []ConfigReferrerFilter `yaml:"referrerFilters" json:"referrerFilters"`
+	ReferrerSrc       string                 `yaml:"referrerSource" json:"referrerSource"`
+	ReferrerTgt       string                 `yaml:"referrerTarget" json:"referrerTarget"`
+	Platform          string                 `yaml:"platform" json:"platform"`
+	Platforms         []string               `yaml:"platforms" json:"platforms"`
+	FastCheck         *bool                  `yaml:"fastCheck" json:"fastCheck"`
+	ForceRecursive    *bool                  `yaml:"forceRecursive" json:"forceRecursive"`
+	IncludeExternal   *bool                  `yaml:"includeExternal" json:"includeExternal"`
+	Backup            string                 `yaml:"backup" json:"backup"`
+	Interval          time.Duration          `yaml:"interval" json:"interval"`
+	Schedule          string                 `yaml:"schedule" json:"schedule"`
+	RateLimit         ConfigRateLimit        `yaml:"ratelimit" json:"ratelimit"`
+	MediaTypes        []string               `yaml:"mediaTypes" json:"mediaTypes"`
+	Hooks             ConfigHooks            `yaml:"hooks" json:"hooks"`
 }
 
 // RepoAllowDeny is an allow and deny list of regex strings for repository names
@@ -237,6 +238,13 @@ func configExpandTemplates(c *Config) error {
 			return err
 		}
 		c.Sync[i].Target = val
+		for j, additionalTgt := range c.Sync[i].AdditionalTargets {
+			val, err = template.String(additionalTgt, dataSync)
+			if err != nil {
+				return err
+			}
+			c.Sync[i].AdditionalTargets[j] = val
+		}
 		val, err = template.String(c.Sync[i].ReferrerTgt, dataSync)
 		if err != nil {
 			return err

--- a/cmd/regsync/regsync_test.go
+++ b/cmd/regsync/regsync_test.go
@@ -938,7 +938,7 @@ func TestProcessRef(t *testing.T) {
 			}
 			src = src.SetTag(tc.src)
 			tgt = tgt.SetTag(tc.tgt)
-			err = rootOpts.processRef(ctx, cs, src, tgt, tc.action)
+			_, err = rootOpts.processRef(ctx, cs, src, tgt, tc.action)
 			// validate err
 			if tc.expErr != nil {
 				if err == nil {


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

closes #1012

### Describe the change

If sync[].target needs update it is updated and all targets in sync[].addtionalTargets get synced as well. 
If sync[].target does not need update nothing is updated. 

### How to verify it

```yaml
sync:
  # upstream: inplace updates
  - source: quay.io/skopeo/stable:v1.20.0
    target: someRegistry/skopeo:{{index (split .Sync.Source ":") 1}}-latest
    additionalTargets:
      - someRegistry/skopeo:{{print (index (split .Sync.Source ":") 1) "-" (time.Now.Format "2006-01-02T150405")}}
      - otherRegistry/skopeo:{{print (index (split .Sync.Source ":") 1) "-" (time.Now.Format "2006-01-02T150405")}}
    type: image
```

### Changelog text

Introduces `sync[].additionalTargets` for `type: image` to sync `source` to multiple targets if for `target` "Image sync needed".

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
    - Done later, if maintainers want this feature
- [X] Documentation has been added, updated, or not applicable
    - handled in a different repo: https://github.com/regclient/regclient.org
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
