### PR TITLE
Feat: Add support for cosign v3 bundles

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -122,14 +122,14 @@ jobs:
       if: github.event_name != 'pull_request' && github.repository_owner == 'regclient'
       uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
       with:
-        cosign-release: "v2.6.1"
+        cosign-release: "v3.0.2"
     
     - name: Install syft
       if: github.event_name != 'pull_request' && github.repository_owner == 'regclient'
-      uses: anchore/sbom-action/download-syft@8e94d75ddd33f69f691467e42275782e4bfefe84 # v0.20.9
+      uses: anchore/sbom-action/download-syft@fbfd9c6c189226748411491745178e0c2017392d # v0.20.10
       id: syft
       with:
-        syft-version: "v1.37.0"
+        syft-version: "v1.38.0"
     
     # Dogfooding, use regctl to modify regclient images to improve reproducibility
     - name: Install regctl
@@ -209,6 +209,8 @@ jobs:
           else
             echo "Pushing ${tag}"
             regctl image copy --referrers "ocidir://output/${{matrix.image}}:${{matrix.type}}@${digest}" "${tag}"
-            cosign sign -y -r "${tag}@${digest}"
+            # sign both with and without the bundle to support older clients
+            cosign sign -y -r --new-bundle-format=false -use-signing-config=false "${tag}@${digest}"
+            cosign sign -y -r --new-bundle-format=true  -use-signing-config=true  "${tag}@${digest}"
           fi
         done

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -60,10 +60,10 @@ jobs:
 
     - name: Install syft
       if: startsWith( github.ref, 'refs/tags/v' ) || github.ref == 'refs/heads/main'
-      uses: anchore/sbom-action/download-syft@8e94d75ddd33f69f691467e42275782e4bfefe84 # v0.20.9
+      uses: anchore/sbom-action/download-syft@fbfd9c6c189226748411491745178e0c2017392d # v0.20.10
       id: syft
       with:
-        syft-version: "v1.37.0"
+        syft-version: "v1.38.0"
 
     - name: Build artifacts
       if: startsWith( github.ref, 'refs/tags/v' ) || github.ref == 'refs/heads/main'
@@ -73,7 +73,7 @@ jobs:
       if: ( startsWith( github.ref, 'refs/tags/v' ) || github.ref == 'refs/heads/main' ) && matrix.gover == env.RELEASE_GO_VER
       uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
       with:
-        cosign-release: "v2.6.1"
+        cosign-release: "v3.0.2"
 
     - name: Package artifacts
       if: ( startsWith( github.ref, 'refs/tags/v' ) || github.ref == 'refs/heads/main' ) && matrix.gover == env.RELEASE_GO_VER
@@ -108,7 +108,9 @@ jobs:
             regsync-linux-riscv64 \
             regsync-windows-amd64.exe \
           ; do
-          cosign sign-blob -y --output-signature "${artifact%.exe}.sig" --output-certificate "${artifact%.exe}.pem" "${artifact}"
+          # sign content with and without the bundle to simplify client migrations
+          cosign sign-blob -y --new-bundle-format=false --use-signing-config=false --output-signature "${artifact%.exe}.sig" --output-certificate "${artifact%.exe}.pem" "${artifact}"
+          cosign sign-blob -y --new-bundle-format=true  --use-signing-config=true  --bundle "${artifact%.exe}.sigstore.json" "${artifact}"
         done
         tar -cvzf metadata.tgz *.sig *.pem *.json
 

--- a/.version-bump.lock
+++ b/.version-bump.lock
@@ -9,15 +9,15 @@
 {"name":"gha-alpine-digest","key":"docker.io/library/alpine:3.22.2","version":"sha256:4b7ce07002c69e8f3d704a9c5d6fd3053be500b7f1c69fc0d80990c2ad8dd412"}
 {"name":"gha-alpine-tag-base","key":"docker.io/library/alpine","version":"3"}
 {"name":"gha-alpine-tag-comment","key":"docker.io/library/alpine","version":"3.22.2"}
-{"name":"gha-cosign-version","key":"https://github.com/sigstore/cosign.git","version":"v2.6.1"}
+{"name":"gha-cosign-version","key":"https://github.com/sigstore/cosign.git","version":"v3.0.2"}
 {"name":"gha-golang-matrix","key":"golang-matrix","version":"[\"1.24\", \"1.25\"]"}
 {"name":"gha-golang-release","key":"golang-latest","version":"1.25"}
-{"name":"gha-syft-version","key":"docker.io/anchore/syft","version":"v1.37.0"}
+{"name":"gha-syft-version","key":"docker.io/anchore/syft","version":"v1.38.0"}
 {"name":"gha-uses-commit","key":"https://github.com/actions/checkout.git:v5.0.1","version":"93cb6efe18208431cddfb8368fd83d5badbf9bfd"}
 {"name":"gha-uses-commit","key":"https://github.com/actions/setup-go.git:v6.0.0","version":"44694675825211faa026b3c33043df3e48a5fa00"}
 {"name":"gha-uses-commit","key":"https://github.com/actions/stale.git:v10.1.0","version":"5f858e3efba33a5ca4407a664cc011ad407f2008"}
 {"name":"gha-uses-commit","key":"https://github.com/actions/upload-artifact.git:v5.0.0","version":"330a01c490aca151604b8cf639adc76d48f6c5d4"}
-{"name":"gha-uses-commit","key":"https://github.com/anchore/sbom-action.git:v0.20.9","version":"8e94d75ddd33f69f691467e42275782e4bfefe84"}
+{"name":"gha-uses-commit","key":"https://github.com/anchore/sbom-action.git:v0.20.10","version":"fbfd9c6c189226748411491745178e0c2017392d"}
 {"name":"gha-uses-commit","key":"https://github.com/docker/build-push-action.git:v6.18.0","version":"263435318d21b8e681c14492fe198d362a7d2c83"}
 {"name":"gha-uses-commit","key":"https://github.com/docker/login-action.git:v3.6.0","version":"5e57cd118135c172c3672efd75eb46360885c0ef"}
 {"name":"gha-uses-commit","key":"https://github.com/docker/setup-buildx-action.git:v3.11.1","version":"e468171a9de216ec08956ac3ada2f0791b6bd435"}
@@ -28,7 +28,7 @@
 {"name":"gha-uses-semver","key":"https://github.com/actions/setup-go.git","version":"v6.0.0"}
 {"name":"gha-uses-semver","key":"https://github.com/actions/stale.git","version":"v10.1.0"}
 {"name":"gha-uses-semver","key":"https://github.com/actions/upload-artifact.git","version":"v5.0.0"}
-{"name":"gha-uses-semver","key":"https://github.com/anchore/sbom-action.git","version":"v0.20.9"}
+{"name":"gha-uses-semver","key":"https://github.com/anchore/sbom-action.git","version":"v0.20.10"}
 {"name":"gha-uses-semver","key":"https://github.com/docker/build-push-action.git","version":"v6.18.0"}
 {"name":"gha-uses-semver","key":"https://github.com/docker/login-action.git","version":"v3.6.0"}
 {"name":"gha-uses-semver","key":"https://github.com/docker/setup-buildx-action.git","version":"v3.11.1"}
@@ -42,11 +42,11 @@
 {"name":"makefile-gomajor","key":"https://github.com/icholy/gomajor.git","version":"v0.15.0"}
 {"name":"makefile-gosec","key":"https://github.com/securego/gosec.git","version":"v2.22.10"}
 {"name":"makefile-markdown-lint","key":"docker.io/davidanson/markdownlint-cli2","version":"v0.19.0"}
-{"name":"makefile-osv-scanner","key":"https://github.com/google/osv-scanner.git","version":"v2.2.4"}
+{"name":"makefile-osv-scanner","key":"https://github.com/google/osv-scanner.git","version":"v2.3.0"}
 {"name":"makefile-staticcheck","key":"https://github.com/dominikh/go-tools.git","version":"v0.6.1"}
-{"name":"makefile-syft-container-digest","key":"anchore/syft:v1.37.0","version":"sha256:48d679480c6d272c1801cf30460556959c01d4826795be31d4fd8b53750b7d91"}
-{"name":"makefile-syft-container-tag","key":"anchore/syft","version":"v1.37.0"}
-{"name":"makefile-syft-version","key":"docker.io/anchore/syft","version":"v1.37.0"}
+{"name":"makefile-syft-container-digest","key":"anchore/syft:v1.38.0","version":"sha256:825cad3a952c87676a6d07e9a3bb05ac9c401d598360070e970aa46d54c1727e"}
+{"name":"makefile-syft-container-tag","key":"anchore/syft","version":"v1.38.0"}
+{"name":"makefile-syft-version","key":"docker.io/anchore/syft","version":"v1.38.0"}
 {"name":"osv-golang-release","key":"docker.io/library/golang","version":"1.25.4"}
 {"name":"shell-alpine-digest","key":"docker.io/library/alpine:3.22.2","version":"sha256:4b7ce07002c69e8f3d704a9c5d6fd3053be500b7f1c69fc0d80990c2ad8dd412"}
 {"name":"shell-alpine-tag-base","key":"docker.io/library/alpine","version":"3"}

--- a/.version-bump.yml
+++ b/.version-bump.yml
@@ -162,7 +162,7 @@ processors:
     sourceArgs:
       url: "https://github.com/sigstore/cosign.git"
     filter:
-      expr: '^v?2\.\d+\.\d+$' # pin to v2 pending cosign-installer upgrade
+      expr: '^v?3\.\d+\.\d+$' # pin to v3, v4 will remove support for older clients
   gha-golang-matrix:
     <<: *registry-tag-semver
     key: "golang-matrix"

--- a/Makefile
+++ b/Makefile
@@ -40,11 +40,11 @@ GOFUMPT_VER?=v0.9.2
 GOMAJOR_VER?=v0.15.0
 GOSEC_VER?=v2.22.10
 GO_VULNCHECK_VER?=v1.1.4
-OSV_SCANNER_VER?=v2.2.4
+OSV_SCANNER_VER?=v2.3.0
 SYFT?=$(shell command -v syft 2>/dev/null)
 SYFT_CMD_VER:=$(shell [ -x "$(SYFT)" ] && echo "v$$($(SYFT) version | awk '/^Version: / {print $$2}')" || echo "0")
-SYFT_VERSION?=v1.37.0
-SYFT_CONTAINER?=anchore/syft:v1.37.0@sha256:48d679480c6d272c1801cf30460556959c01d4826795be31d4fd8b53750b7d91
+SYFT_VERSION?=v1.38.0
+SYFT_CONTAINER?=anchore/syft:v1.38.0@sha256:825cad3a952c87676a6d07e9a3bb05ac9c401d598360070e970aa46d54c1727e
 ifneq "$(SYFT_CMD_VER)" "$(SYFT_VERSION)"
 	SYFT=docker run --rm \
 		-v "$(shell pwd)/:$(shell pwd)/" -w "$(shell pwd)" \


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Add support for the cosign v3 bundles while still pushing the non-bundle content to support existing clients. Eventually, only bundles will be supported.

Additional version bumps include:
- sigstore/cosign to v3.0.2
- anchore/syft to v1.38.0
- anchore/sbom-action to v0.20.10
- google/osv-scanner to v2.3.0

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Feat: Add support for cosign v3 bundles.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation updates are included or not applicable (most documentation should be in the regclient.org repo)
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
- [X] All changes have been human generated or created with a reproducible tool

<!-- markdownlint-disable-file MD041 -->
