### PR TITLE
Fix: Correct selection of previous tag for releases

### DIFF
--- a/.github/release.sh
+++ b/.github/release.sh
@@ -96,7 +96,7 @@ get_pr_user() {
 
 # prompt with last tag, asking for next tag, defaulting to patch update
 if [ -z "$prev_tag" ]; then
-  prev_tag="$(git tag -l | tail -1)"
+  prev_tag="$(git tag --sort=version:refname -l | tail -1)"
 fi
 # for dry-run, output the change list from the prev_tag to main and stop
 # TODO: add a dry-run func to echo vs exec commands that would change things


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

When running a release, the wrong previous version is selected due to `git tag` defaulting to a lexical sort.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Change the sort of git tags to semver sorting.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Fix: Correct selection of previous tag for releases.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation updates are included or not applicable (most documentation should be in the regclient.org repo)
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
- [X] All changes have been human generated or created with a reproducible tool

<!-- markdownlint-disable-file MD041 -->
