### PR TITLE
Fix: Make sure ContentLength is correctly set in the request

### DIFF
--- a/internal/reqresp/reqresp.go
+++ b/internal/reqresp/reqresp.go
@@ -4,6 +4,7 @@ package reqresp
 import (
 	"bytes"
 	"encoding/base64"
+	"fmt"
 	"io"
 	"math/rand"
 	"net/http"
@@ -93,6 +94,7 @@ func (r *rrHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 			(reqMatch.Path != "" && reqMatch.Path != req.URL.Path) ||
 			!strMapMatch(reqMatch.Query, req.URL.Query()) ||
 			!strMapMatch(reqMatch.Headers, req.Header) ||
+			(reqMatch.Headers != nil && reqMatch.Headers.Get("Content-Length") != "" && reqMatch.Headers.Get("Content-Length") != fmt.Sprintf("%d", req.ContentLength)) ||
 			(len(reqMatch.Body) > 0 && !bytes.Equal(reqMatch.Body, reqBody)) {
 			// skip if any field does not match
 			continue


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

It's possible for request.ContentLength to have a different value than the Content-Length header set on the request, and Go will only send the value defined on the request struct. This hardens the test to ensure the request struct is always correctly set.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Fix: Make sure ContentLength is correctly set in the request.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation updates are included or not applicable (most documentation should be in the regclient.org repo)
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
- [X] All changes have been human generated or created with a reproducible tool

<!-- markdownlint-disable-file MD041 -->
