### PR TITLE
Fix: Do not sign released images multiple times

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -60,17 +60,18 @@ jobs:
         fi
         VERSION="$(echo "${VERSION}" | sed -r 's#/+#-#g')"
         TAGS="${HUB_IMAGE}:${VERSION}${EXT},${GHCR_IMAGE}:${VERSION}${EXT}"
+        TAG_COPIES=""
         if [[ $VERSION =~ ^v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
           MINOR="${VERSION%.*}"
           MAJOR="${MINOR%.*}"
-          TAGS="${TAGS},${HUB_IMAGE}:${MINOR}${EXT},${HUB_IMAGE}:${MAJOR}${EXT}"
-          TAGS="${TAGS},${GHCR_IMAGE}:${MINOR}${EXT},${GHCR_IMAGE}:${MAJOR}${EXT}"
+          TAG_COPIES="${HUB_IMAGE}:${MINOR}${EXT},${HUB_IMAGE}:${MAJOR}${EXT}"
+          TAG_COPIES="${GHCR_IMAGE}:${MINOR}${EXT},${GHCR_IMAGE}:${MAJOR}${EXT}"
           if [ "${{ matrix.type }}" == "scratch" ]; then
-            TAGS="${TAGS},${HUB_IMAGE}:latest"
-            TAGS="${TAGS},${GHCR_IMAGE}:latest"
+            TAG_COPIES="${TAG_COPIES},${HUB_IMAGE}:latest"
+            TAG_COPIES="${TAG_COPIES},${GHCR_IMAGE}:latest"
           else
-            TAGS="${TAGS},${HUB_IMAGE}:${{ matrix.type }}"
-            TAGS="${TAGS},${GHCR_IMAGE}:${{ matrix.type }}"
+            TAG_COPIES="${TAG_COPIES},${HUB_IMAGE}:${{ matrix.type }}"
+            TAG_COPIES="${TAG_COPIES},${GHCR_IMAGE}:${{ matrix.type }}"
           fi
         fi
         VCS_SEC="$(git log -1 --format=%ct)"
@@ -80,6 +81,7 @@ jobs:
         echo "image_hub=${HUB_IMAGE}" >>$GITHUB_OUTPUT
         echo "image_ghcr=${GHCR_IMAGE}" >>$GITHUB_OUTPUT
         echo "tags=${TAGS}" >>$GITHUB_OUTPUT
+        echo "tag_copies=${TAG_COPIES}" >>$GITHUB_OUTPUT
         echo "vcs_sec=${VCS_SEC}" >>$GITHUB_OUTPUT
         echo "created=${VCS_DATE}" >>$GITHUB_OUTPUT
         echo "repo_url=${REPO_URL}" >>$GITHUB_OUTPUT
@@ -200,17 +202,21 @@ jobs:
       id: push
       run: |
         # loop over the tags
-        image_hub="${{ steps.prep.outputs.image_hub }}"
         for tag in $(echo ${{ steps.prep.outputs.tags }} | tr , ' '); do
           digest="$(regctl image digest "ocidir://output/${{matrix.image}}:${{matrix.type}}")"
           if [ "${digest}" = "$(regctl image digest "${tag}" 2>/dev/null || true)" ]; then
             # image already pushed, don't add referrers to reproducible builds
-            echo "Skipping ${tag}"
+            echo "Skipping already pushed image ${tag}"
           else
-            echo "Pushing ${tag}"
+            echo "Pushing image to ${tag}"
             regctl image copy --referrers "ocidir://output/${{matrix.image}}:${{matrix.type}}@${digest}" "${tag}"
             # sign both with and without the bundle to support older clients
             cosign sign -y -r --new-bundle-format=false --use-signing-config=false "${tag}@${digest}"
             cosign sign -y -r --new-bundle-format=true  --use-signing-config=true  "${tag}@${digest}"
           fi
+        done
+        # after the first tag is pushed to each registry, remaining tags can skip referrers and cosign
+        for tag in $(echo ${{ steps.prep.outputs.tag_copies }} | tr , ' '); do
+            echo "Pushing tag to ${tag}"
+            regctl image copy "ocidir://output/${{matrix.image}}:${{matrix.type}}@${digest}" "${tag}"
         done


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Released images are getting signed for each tag that is pushed.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Only a single signature per registry is needed since signatures are attached to the image digest. The rest can be treated as minimal copies, retagging an already pushed image.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

GHA logs on the next docker push should show only two runs of cosign per deploy (one classic signing, one with the new bundles).
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Fix: Do not sign released images multiple times.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [ ] Tests have been added or not applicable
- [X] Documentation updates are included or not applicable (most documentation should be in the regclient.org repo)
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
- [X] All changes have been human generated or created with a reproducible tool

<!-- markdownlint-disable-file MD041 -->
