### PR TITLE
Doc: Add REGCTL_CONFIG to regctl help messages

### DIFF
--- a/cmd/regctl/config.go
+++ b/cmd/regctl/config.go
@@ -47,7 +47,11 @@ type configOpts struct {
 func NewConfigCmd(rOpts *rootOpts) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "config <cmd>",
-		Short: "read/set configuration options",
+		Short: "get/set configuration options",
+		Long: fmt.Sprintf(`Retrieve or update a configuration option.
+By default, the configuration is loaded from $HOME/%s/%s.
+This location can be overridden with the %s environment variable.
+Note that these commands do not include logins imported from Docker or values injected with --host.`, ConfigDir, ConfigFilename, ConfigEnv),
 	}
 	cmd.AddCommand(newConfigGetCmd(rOpts))
 	cmd.AddCommand(newConfigSetCmd(rOpts))

--- a/cmd/regctl/registry.go
+++ b/cmd/regctl/registry.go
@@ -46,6 +46,10 @@ func NewRegistryCmd(rOpts *rootOpts) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "registry <cmd>",
 		Short: "manage registries",
+		Long: fmt.Sprintf(`Retrieve or update registry configurations.
+By default, the configuration is loaded from $HOME/%s/%s.
+This location can be overridden with the %s environment variable.
+Note that these commands do not include logins imported from Docker or values injected with --host.`, ConfigDir, ConfigFilename, ConfigEnv),
 	}
 	cmd.AddCommand(newRegistryConfigCmd(rOpts))
 	cmd.AddCommand(newRegistryLoginCmd(rOpts))

--- a/cmd/regctl/root.go
+++ b/cmd/regctl/root.go
@@ -45,7 +45,7 @@ func NewRootCmd() (*cobra.Command, *rootOpts) {
 		Use:   "regctl <cmd>",
 		Short: "Utility for accessing docker registries",
 		Long: `Utility for accessing docker registries
-More details at <https://github.com/regclient/regclient>`,
+More details at <https://regclient.org>`,
 		Example: `
 # login to ghcr.io
 regctl registry login ghcr.io


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Related to #1036 
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Updates the `--help` text on `regctl registry` and `regctl config` to document the `REGCTL_CONFIG` variable.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
regctl config --help
regctl registry --help
```

<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Doc: Add `REGCTL_CONFIG` to `regctl` help messages.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation updates are included or not applicable (most documentation should be in the regclient.org repo)
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
- [X] All changes have been human generated or created with a reproducible tool

<!-- markdownlint-disable-file MD041 -->
