### PR TITLE
Fix: Remove default values from regctl config

### DIFF
--- a/cmd/regctl/config.go
+++ b/cmd/regctl/config.go
@@ -192,21 +192,9 @@ func ConfigLoadConfFile(cf *conffile.File) (*Config, error) {
 		if c.Hosts[h].Name == "" {
 			c.Hosts[h].Name = h
 		}
-		if c.Hosts[h].Hostname == "" {
-			c.Hosts[h].Hostname = h
-		}
-		if c.Hosts[h].TLS == config.TLSUndefined {
-			c.Hosts[h].TLS = config.TLSEnabled
-		}
 		if h == config.DockerRegistryDNS || h == config.DockerRegistry || h == config.DockerRegistryAuth {
 			// Docker Hub
 			c.Hosts[h].Name = config.DockerRegistry
-			if c.Hosts[h].Hostname == h {
-				c.Hosts[h].Hostname = config.DockerRegistryDNS
-			}
-			if c.Hosts[h].CredHost == h {
-				c.Hosts[h].CredHost = config.DockerRegistryAuth
-			}
 		}
 		// ensure key matches Name
 		if c.Hosts[h].Name != h {

--- a/cmd/regctl/registry_test.go
+++ b/cmd/regctl/registry_test.go
@@ -43,6 +43,7 @@ func TestRegistry(t *testing.T) {
 		tsUnauth.Close()
 		_ = regHandler.Close()
 	})
+	tsExampleHost := "registry.example.org"
 	tempDir := t.TempDir()
 	t.Setenv(ConfigEnv, filepath.Join(tempDir, "config.json"))
 	tt := []struct {
@@ -75,6 +76,19 @@ func TestRegistry(t *testing.T) {
 			expectOut:   "",
 			outContains: false,
 		},
+		// set and unset config on example
+		{
+			name:        "set example",
+			args:        []string{"registry", "set", tsExampleHost, "--cred-helper", "docker-credential-example", "--skip-check"},
+			expectOut:   "",
+			outContains: false,
+		},
+		{
+			name:        "set example",
+			args:        []string{"registry", "set", tsExampleHost, "--cred-helper", "", "--skip-check"},
+			expectOut:   "",
+			outContains: false,
+		},
 		// query the config change
 		{
 			name:        "query good host",
@@ -99,6 +113,12 @@ func TestRegistry(t *testing.T) {
 			expectOut:   `"tls": "disabled",`,
 			outContains: true,
 		},
+		{
+			name:        "query example",
+			args:        []string{"registry", "config", tsExampleHost},
+			expectOut:   "No configuration found for registry",
+			outContains: true,
+		},
 		// login
 		{
 			name:        "login good host",
@@ -114,6 +134,12 @@ func TestRegistry(t *testing.T) {
 		{
 			name:        "login bad host",
 			args:        []string{"registry", "login", tsBadHost, "-u", "testbaduser", "-p", "testpass", "--skip-check"},
+			expectOut:   "",
+			outContains: false,
+		},
+		{
+			name:        "login example",
+			args:        []string{"registry", "login", tsExampleHost, "-u", "testexample", "-p", "testpass", "--skip-check"},
 			expectOut:   "",
 			outContains: false,
 		},
@@ -157,6 +183,12 @@ func TestRegistry(t *testing.T) {
 			expectOut:   "",
 			outContains: false,
 		},
+		{
+			name:        "logout example",
+			args:        []string{"registry", "logout", tsExampleHost},
+			expectOut:   "",
+			outContains: false,
+		},
 		// verify logout
 		{
 			name:      "check logout on good host",
@@ -177,6 +209,12 @@ func TestRegistry(t *testing.T) {
 			name:      "check logout on bad host",
 			args:      []string{"registry", "config", tsBadHost, "--format", "{{.User}}"},
 			expectOut: ``,
+		},
+		{
+			name:        "check logout on example",
+			args:        []string{"registry", "config", tsExampleHost},
+			expectOut:   "No configuration found for registry",
+			outContains: true,
 		},
 	}
 	for _, tc := range tt {

--- a/config/host.go
+++ b/config/host.go
@@ -235,12 +235,11 @@ func (host *Host) refreshHelper() {
 
 // IsZero returns true if the struct is set to the zero value or the result of [HostNew].
 func (host Host) IsZero() bool {
-	if host.Name != "" ||
-		(host.TLS != TLSUndefined && host.TLS != TLSEnabled) ||
+	if (host.TLS != TLSUndefined && host.TLS != TLSEnabled) ||
 		host.RegCert != "" ||
 		host.ClientCert != "" ||
 		host.ClientKey != "" ||
-		host.Hostname != "" ||
+		(host.Hostname != "" && host.Hostname != host.Name) ||
 		host.User != "" ||
 		host.Pass != "" ||
 		host.Token != "" ||

--- a/config/host_test.go
+++ b/config/host_test.go
@@ -217,21 +217,25 @@ func TestConfig(t *testing.T) {
 			name: "new-name",
 			host: *newHostNameP,
 			hostExpect: Host{
+				Name:     "host.example.org",
 				TLS:      TLSEnabled,
 				Hostname: "host.example.org",
 				APIOpts:  map[string]string{},
 			},
 			credExpect: Cred{},
+			isZero:     true,
 		},
 		{
 			name: "new-default-nil",
 			host: *newHostDefNil,
 			hostExpect: Host{
+				Name:     "host.example.org",
 				TLS:      TLSEnabled,
 				Hostname: "host.example.org",
 				APIOpts:  map[string]string{},
 			},
 			credExpect: Cred{},
+			isZero:     true,
 		},
 		{
 			name: "new-default-mirror",


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Configs loaded from regctl get merged with a default host entry in regclient. So the default values for various settings can be excluded from the regctl `config.json` file.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Fix: Remove default values from regctl config.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation updates are included or not applicable (most documentation should be in the regclient.org repo)
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
- [X] All changes have been human generated or created with a reproducible tool

<!-- markdownlint-disable-file MD041 -->
