### PR TITLE
Fix: Handle OCI-Tag headers with comma separators

### DIFF
--- a/scheme/reg/manifest.go
+++ b/scheme/reg/manifest.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"slices"
 	"strconv"
+	"strings"
 
 	"github.com/opencontainers/go-digest"
 
@@ -290,7 +291,12 @@ func (reg *Reg) ManifestPut(ctx context.Context, r ref.Ref, m manifest.Manifest,
 	}
 
 	// if pushing tags by digest fails, fall back to pushing individual tags
-	respTags := resp.HTTPResponse().Header.Values("OCI-Tag")
+	respTags := []string{}
+	for _, hv := range resp.HTTPResponse().Header.Values("OCI-Tag") {
+		for sv := range strings.SplitSeq(hv, ",") {
+			respTags = append(respTags, strings.TrimSpace(sv))
+		}
+	}
 	for _, t := range expectTags {
 		if slices.Contains(respTags, t) {
 			continue


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

If the `OCI-Tag` header in the response contained commas, this would incorrectly assume the tag had not been pushed. It's currently not possible to trigger this since only a single tag can be pushed.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Handle OCI-Tag headers with comma separators.

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

This cannot be verified until pushing multiple tags is supported. Improved tests for this will be added then.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Fix: Handle OCI-Tag headers with comma separators.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [ ] Tests have been added or not applicable
- [X] Documentation updates are included or not applicable (most documentation should be in the regclient.org repo)
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
- [X] All changes have been human generated or created with a reproducible tool

<!-- markdownlint-disable-file MD041 -->
