### PR TITLE
Sec: Validate server URL in token auth

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/url"
 	"slices"
@@ -638,6 +639,18 @@ func (b *bearerHandler) UpdateRequest(req *http.Request) error {
 			return err
 		}
 		b.tokenURL = u
+	}
+	// verify tokenURL is allowed for request URL
+	if req.URL.Scheme == "https" && b.tokenURL.Scheme != "https" {
+		return fmt.Errorf("downgrading to an http token server from an https registry is not allowed%.0w", errs.ErrHTTPUnauthorized)
+	}
+	hostToken := b.tokenURL.Hostname()
+	hostReq := req.URL.Hostname()
+	ipToken := net.ParseIP(hostToken)
+	ipReq := net.ParseIP(hostReq)
+	if ipToken != nil && (ipToken.IsLoopback() || ipToken.IsLinkLocalUnicast() || ipToken.IsLinkLocalMulticast()) &&
+		(ipReq == nil || !(ipReq.IsLoopback() || ipReq.IsLinkLocalUnicast() || ipReq.IsLinkLocalMulticast())) {
+		return fmt.Errorf("requesting a local token server from a non-local registry is not allowed%.0w", errs.ErrHTTPUnauthorized)
 	}
 	// if unexpired token already exists, return it
 	if b.token.Token != "" && !b.isExpired() {

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -216,6 +216,9 @@ func TestAuth(t *testing.T) {
 	defer ts.Close()
 	tsURL, _ := url.Parse(ts.URL)
 	tsHost := tsURL.Host
+	tsHTTPS := *tsURL
+	tsHTTPS.Scheme = "https"
+	externURL, _ := url.Parse("http://registry.example.org/v2/project/manifests/latest")
 
 	tests := []struct {
 		name           string
@@ -310,6 +313,50 @@ func TestAuth(t *testing.T) {
 				Header: http.Header{},
 			},
 			wantAuthHeader: "Bearer token2",
+		},
+		{
+			name: "reject redirect to loopback",
+			auth: NewAuth(
+				WithClientID(clientID),
+				WithCreds(credsFn),
+			),
+			handleResponse: &http.Response{
+				Request: &http.Request{
+					URL: externURL,
+				},
+				StatusCode: http.StatusUnauthorized,
+				Header: http.Header{
+					http.CanonicalHeaderKey("WWW-Authenticate"): []string{
+						`Bearer realm="http://127.0.0.1/token",service="example.registry.org",scope="repository:reponame:pull"`,
+					},
+				},
+			},
+			handleRequest: &http.Request{
+				URL: externURL,
+			},
+			wantErrReq: errs.ErrHTTPUnauthorized,
+		},
+		{
+			name: "reject http downgrade",
+			auth: NewAuth(
+				WithClientID(clientID),
+				WithCreds(credsFn),
+			),
+			handleResponse: &http.Response{
+				Request: &http.Request{
+					URL: &tsHTTPS,
+				},
+				StatusCode: http.StatusUnauthorized,
+				Header: http.Header{
+					http.CanonicalHeaderKey("WWW-Authenticate"): []string{
+						`Bearer realm="` + tsURL.String() + `/token",service="` + tsHost + `",scope="repository:reponame:pull"`,
+					},
+				},
+			},
+			handleRequest: &http.Request{
+				URL: &tsHTTPS,
+			},
+			wantErrReq: errs.ErrHTTPUnauthorized,
 		},
 	}
 
@@ -765,7 +812,7 @@ func TestBearerToken(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed on response to token: %v", err)
 	}
-	req, err := http.NewRequest("GET", "http://localhost:5000", nil)
+	req, err := http.NewRequest("GET", tsURL.String()+"/v2/project/manifests/latest", nil)
 	if err != nil {
 		t.Fatalf("failed to generate new request: %v", err)
 	}


### PR DESCRIPTION
Disallow downgrade from https to http, and disallow a redirect from an external registry to a loopback address.

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Validate server URL in token auth. This will disallow a downgrade from https to http, and disallow a redirect from an external registry to a loopback address.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
make test
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Sec: Validate server URL in token auth.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation updates are included or not applicable (most documentation should be in the regclient.org repo)
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
- [X] All changes have been human generated or created with a reproducible tool

<!-- markdownlint-disable-file MD041 -->
