### PR TITLE
Feat: Add created timestamp in OCI Layout entries

### DIFF
--- a/internal/reproducible/reproducible.go
+++ b/internal/reproducible/reproducible.go
@@ -1,0 +1,3 @@
+// Package reproducible is used for reproducibility.
+// See <https://reproducible-builds.org/docs/> for more information of the issues being solved.
+package reproducible

--- a/internal/reproducible/time.go
+++ b/internal/reproducible/time.go
@@ -1,0 +1,35 @@
+package reproducible
+
+import (
+	"errors"
+	"os"
+	"strconv"
+	"time"
+)
+
+const EpocEnv = "SOURCE_DATE_EPOC"
+
+var errInvalidEpoc = errors.New("invalid epoc var")
+
+// TimeNow returns the current time or SOURCE_DATE_EPOC if that is set.
+func TimeNow() time.Time {
+	now, err := TimeEpocEnv()
+	if err == nil {
+		return now
+	}
+	return time.Now().UTC()
+}
+
+// TimeEpocEnv returns the time parsed by SOURCE_DATE_EPOC.
+// This should be used to override any timestamps that should be reproducible.
+func TimeEpocEnv() (time.Time, error) {
+	sec := os.Getenv(EpocEnv)
+	if sec == "" {
+		return time.Time{}, errInvalidEpoc
+	}
+	secI, err := strconv.ParseInt(sec, 10, 64)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return time.Unix(secI, 0).UTC(), nil
+}

--- a/internal/reproducible/time_test.go
+++ b/internal/reproducible/time_test.go
@@ -1,23 +1,15 @@
-package mod
+package reproducible
 
 import (
 	"fmt"
-	"os"
 	"testing"
 	"time"
 )
 
 func TestTimeNow(t *testing.T) {
 	t.Run("NoEnv", func(t *testing.T) {
-		curEnv, envIsSet := os.LookupEnv(epocEnv)
-		if envIsSet {
-			err := os.Unsetenv(epocEnv)
-			if err != nil {
-				t.Fatalf("failed to unset %s", epocEnv)
-			}
-			defer os.Setenv(epocEnv, curEnv)
-		}
-		curTimeNow := timeNow()
+		t.Setenv(EpocEnv, "")
+		curTimeNow := TimeNow()
 		if curTimeNow.After(time.Now()) {
 			t.Error("timeNow reported a time after OS time now")
 		}
@@ -25,8 +17,8 @@ func TestTimeNow(t *testing.T) {
 	t.Run("WithEnv", func(t *testing.T) {
 		timePrev := time.Now().Add(-1 * time.Hour).Round(time.Second)
 		timeSec := fmt.Sprintf("%d", timePrev.Unix())
-		t.Setenv(epocEnv, timeSec)
-		curTimeNow := timeNow()
+		t.Setenv(EpocEnv, timeSec)
+		curTimeNow := TimeNow()
 		if !curTimeNow.Equal(timePrev) {
 			t.Errorf("timeNow did not use the epoc, expected %d, received %d", timePrev.Unix(), curTimeNow.Unix())
 		}

--- a/mod/dag.go
+++ b/mod/dag.go
@@ -13,6 +13,7 @@ import (
 	"github.com/opencontainers/go-digest"
 
 	"github.com/regclient/regclient"
+	"github.com/regclient/regclient/internal/reproducible"
 	"github.com/regclient/regclient/types/blob"
 	"github.com/regclient/regclient/types/descriptor"
 	"github.com/regclient/regclient/types/errs"
@@ -29,6 +30,8 @@ const (
 	replaced
 	deleted
 )
+
+var timeStart = reproducible.TimeNow()
 
 type dagConfig struct {
 	stepsManifest  []func(context.Context, *regclient.RegClient, ref.Ref, ref.Ref, *dagManifest) error

--- a/mod/time.go
+++ b/mod/time.go
@@ -1,38 +1,8 @@
 package mod
 
 import (
-	"errors"
-	"os"
-	"strconv"
 	"time"
 )
-
-const epocEnv = "SOURCE_DATE_EPOC"
-
-var (
-	errInvalidEpoc = errors.New("invalid epoc var")
-	timeStart      = timeNow()
-)
-
-func timeNow() time.Time {
-	now, err := timeEpocEnv()
-	if err == nil {
-		return now
-	}
-	return time.Now().UTC()
-}
-
-func timeEpocEnv() (time.Time, error) {
-	sec := os.Getenv(epocEnv)
-	if sec == "" {
-		return time.Time{}, errInvalidEpoc
-	}
-	secI, err := strconv.ParseInt(sec, 10, 64)
-	if err != nil {
-		return time.Time{}, err
-	}
-	return time.Unix(secI, 0), nil
-}
 
 // timeModOpt adjusts time t according to the opts.
 // The bool indicates if the time was changed.

--- a/scheme/ocidir/manifest.go
+++ b/scheme/ocidir/manifest.go
@@ -19,6 +19,7 @@ import (
 	"github.com/opencontainers/go-digest"
 
 	"github.com/regclient/regclient/scheme"
+	"github.com/regclient/regclient/types"
 	"github.com/regclient/regclient/types/errs"
 	"github.com/regclient/regclient/types/manifest"
 	"github.com/regclient/regclient/types/mediatype"
@@ -241,10 +242,9 @@ func (o *OCIDir) manifestPut(ctx context.Context, r ref.Ref, m manifest.Manifest
 			return fmt.Errorf("failed to rebuilding manifest with ref \"%s\": %w", r.CommonName(), err)
 		}
 	}
+	desc.Annotations = map[string]string{}
 	if r.Tag != "" {
-		desc.Annotations = map[string]string{
-			aOCIRefName: r.Tag,
-		}
+		desc.Annotations[types.AnnotationRefName] = r.Tag
 	}
 	// TODO: if the manifest contains a subject, option to add descriptor details and include entry in the index.json, config.child=false
 	// create manifest CAS file

--- a/scheme/ocidir/ocidir.go
+++ b/scheme/ocidir/ocidir.go
@@ -13,9 +13,12 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/regclient/regclient/internal/pqueue"
+	"github.com/regclient/regclient/internal/reproducible"
 	"github.com/regclient/regclient/internal/reqmeta"
+	"github.com/regclient/regclient/types"
 	"github.com/regclient/regclient/types/descriptor"
 	"github.com/regclient/regclient/types/errs"
 	"github.com/regclient/regclient/types/mediatype"
@@ -25,8 +28,6 @@ import (
 
 const (
 	imageLayoutFile = "oci-layout"
-	aOCIRefName     = "org.opencontainers.image.ref.name"
-	aCtrdImageName  = "io.containerd.image.name"
 	defThrottle     = 3
 )
 
@@ -347,13 +348,13 @@ func indexGet(index v1.Index, r ref.Ref) (descriptor.Descriptor, error) {
 		}
 	} else if r.Tag != "" {
 		for _, im := range index.Manifests {
-			if name, ok := im.Annotations[aOCIRefName]; ok && name == r.Tag {
+			if name, ok := im.Annotations[types.AnnotationRefName]; ok && name == r.Tag {
 				return im, nil
 			}
 		}
 		// fall back to support full image name in annotation
 		for _, im := range index.Manifests {
-			if name, ok := im.Annotations[aOCIRefName]; ok && strings.HasSuffix(name, ":"+r.Tag) {
+			if name, ok := im.Annotations[types.AnnotationRefName]; ok && strings.HasSuffix(name, ":"+r.Tag) {
 				return im, nil
 			}
 		}
@@ -365,11 +366,14 @@ func indexSet(index *v1.Index, r ref.Ref, d descriptor.Descriptor) error {
 	if index == nil {
 		return fmt.Errorf("index is nil")
 	}
+	if d.Annotations == nil {
+		d.Annotations = map[string]string{}
+	}
 	if r.Tag != "" {
-		if d.Annotations == nil {
-			d.Annotations = map[string]string{}
-		}
-		d.Annotations[aOCIRefName] = r.Tag
+		d.Annotations[types.AnnotationRefName] = r.Tag
+	}
+	if _, ok := d.Annotations[types.AnnotationCreated]; !ok {
+		d.Annotations[types.AnnotationCreated] = reproducible.TimeNow().Format(time.RFC3339)
 	}
 	if index.Manifests == nil {
 		index.Manifests = []descriptor.Descriptor{}
@@ -379,10 +383,17 @@ func indexSet(index *v1.Index, r ref.Ref, d descriptor.Descriptor) error {
 	for i := range index.Manifests {
 		var name string
 		if index.Manifests[i].Annotations != nil {
-			name = index.Manifests[i].Annotations[aOCIRefName]
+			name = index.Manifests[i].Annotations[types.AnnotationRefName]
 		}
-		if (name == "" && index.Manifests[i].Digest == d.Digest) || (r.Tag != "" && name == r.Tag) {
-			index.Manifests[i] = d
+		if r.Tag == "" && name == "" && index.Manifests[i].Digest == d.Digest {
+			// untagged entry already exists, no need to replace it
+			pos = i
+			break
+		} else if r.Tag != "" && name == r.Tag {
+			if index.Manifests[i].Digest != d.Digest {
+				// replace the tag with a new digest/descriptor
+				index.Manifests[i] = d
+			}
 			pos = i
 			break
 		}
@@ -392,11 +403,11 @@ func indexSet(index *v1.Index, r ref.Ref, d descriptor.Descriptor) error {
 		for i := len(index.Manifests) - 1; i > pos; i-- {
 			var name string
 			if index.Manifests[i].Annotations != nil {
-				name = index.Manifests[i].Annotations[aOCIRefName]
+				name = index.Manifests[i].Annotations[types.AnnotationRefName]
 			}
-			// prune entries without any tag and a matching digest
+			// prune untagged entries with a matching digest if we didn't push a tag
 			// or entries with a matching tag
-			if (name == "" && index.Manifests[i].Digest == d.Digest) || (r.Tag != "" && name == r.Tag) {
+			if (r.Tag == "" && name == "" && index.Manifests[i].Digest == d.Digest) || (r.Tag != "" && name == r.Tag) {
 				index.Manifests = slices.Delete(index.Manifests, i, i+1)
 			}
 		}

--- a/scheme/ocidir/ocidir_test.go
+++ b/scheme/ocidir/ocidir_test.go
@@ -1,12 +1,16 @@
 package ocidir
 
 import (
+	"encoding/json"
 	"errors"
+	"slices"
 	"testing"
 
 	"github.com/opencontainers/go-digest"
 
+	"github.com/regclient/regclient/internal/reproducible"
 	"github.com/regclient/regclient/scheme"
+	"github.com/regclient/regclient/types"
 	"github.com/regclient/regclient/types/descriptor"
 	"github.com/regclient/regclient/types/errs"
 	"github.com/regclient/regclient/types/mediatype"
@@ -23,7 +27,9 @@ var (
 )
 
 func TestIndex(t *testing.T) {
-	t.Parallel()
+	// t.Parallel() // unable to use parallel when setting env
+	t.Setenv(reproducible.EpocEnv, "0")
+	expectCreated := "1970-01-01T00:00:00Z"
 	// ctx := context.Background()
 	tempDir := t.TempDir()
 	o := New()
@@ -37,49 +43,49 @@ func TestIndex(t *testing.T) {
 	rA := r.SetTag("tag-a")
 	rB := r.SetTag("tag-b")
 	rC := r.SetTag("tag-c")
-	rDig := r.SetDigest(dig1.String())
-	descNoTag := descriptor.Descriptor{
+	rDig1 := r.SetDigest(dig1.String())
+	descDig1 := descriptor.Descriptor{
 		MediaType: mediatype.Docker2Manifest,
 		Size:      1234,
 		Digest:    dig1,
 	}
-	descA := descriptor.Descriptor{
+	descDig2TagA := descriptor.Descriptor{
 		MediaType: mediatype.Docker2Manifest,
 		Size:      1234,
 		Digest:    dig2,
 		Annotations: map[string]string{
-			aOCIRefName: "tag-a",
+			types.AnnotationRefName: "tag-a",
 		},
 	}
-	descB := descriptor.Descriptor{
+	descDig2TagB := descriptor.Descriptor{
 		MediaType: mediatype.Docker2Manifest,
 		Size:      1234,
 		Digest:    dig2,
 		Annotations: map[string]string{
-			aOCIRefName: "tag-b",
+			types.AnnotationRefName: "tag-b",
 		},
 	}
-	descC := descriptor.Descriptor{
+	descDig3TagFullC := descriptor.Descriptor{
 		MediaType: mediatype.Docker2Manifest,
 		Size:      1234,
 		Digest:    dig3,
 		Annotations: map[string]string{
-			aOCIRefName: rC.CommonName(),
+			types.AnnotationRefName: rC.CommonName(),
 		},
 	}
 	tests := []struct {
 		name         string
 		index        v1.Index
-		get          ref.Ref
+		getRef       ref.Ref
 		expectGet    descriptor.Descriptor
 		expectGetErr error
-		set          ref.Ref
+		setRef       ref.Ref
 		setDesc      descriptor.Descriptor
 		expectLen    int
 	}{
 		{
 			name:         "empty",
-			get:          rA,
+			getRef:       rA,
 			expectGetErr: errs.ErrNotFound,
 		},
 		{
@@ -88,13 +94,13 @@ func TestIndex(t *testing.T) {
 				Versioned: v1.IndexSchemaVersion,
 				MediaType: mediatype.OCI1ManifestList,
 				Manifests: []descriptor.Descriptor{
-					descNoTag,
+					descDig1,
 				},
 			},
-			get:       rDig,
-			expectGet: descNoTag,
-			set:       rA,
-			setDesc:   descA,
+			getRef:    rDig1,
+			expectGet: descDig1,
+			setRef:    rA,
+			setDesc:   descDig2TagA,
 			expectLen: 2,
 		},
 		{
@@ -103,15 +109,15 @@ func TestIndex(t *testing.T) {
 				Versioned: v1.IndexSchemaVersion,
 				MediaType: mediatype.OCI1ManifestList,
 				Manifests: []descriptor.Descriptor{
-					descNoTag,
-					descA,
+					descDig1,
+					descDig2TagA,
 				},
 			},
-			get:       rDig,
-			expectGet: descNoTag,
-			set:       rC,
-			setDesc:   descNoTag,
-			expectLen: 2,
+			getRef:    rDig1,
+			expectGet: descDig1,
+			setRef:    rC,
+			setDesc:   descDig1,
+			expectLen: 3,
 		},
 		{
 			name: "tag b",
@@ -119,15 +125,15 @@ func TestIndex(t *testing.T) {
 				Versioned: v1.IndexSchemaVersion,
 				MediaType: mediatype.OCI1ManifestList,
 				Manifests: []descriptor.Descriptor{
-					descNoTag,
-					descB,
+					descDig1,
+					descDig2TagB,
 				},
 			},
-			get:       rB,
-			expectGet: descB,
-			set:       rB,
-			setDesc:   descNoTag,
-			expectLen: 1,
+			getRef:    rB,
+			expectGet: descDig2TagB,
+			setRef:    rB,
+			setDesc:   descDig1,
+			expectLen: 2,
 		},
 		{
 			name: "tag c",
@@ -135,14 +141,14 @@ func TestIndex(t *testing.T) {
 				Versioned: v1.IndexSchemaVersion,
 				MediaType: mediatype.OCI1ManifestList,
 				Manifests: []descriptor.Descriptor{
-					descA,
-					descC,
+					descDig2TagA,
+					descDig3TagFullC,
 				},
 			},
-			get:       rC,
-			expectGet: descC,
-			set:       rA,
-			setDesc:   descNoTag,
+			getRef:    rC,
+			expectGet: descDig3TagFullC,
+			setRef:    rA,
+			setDesc:   descDig1,
 			expectLen: 2,
 		},
 	}
@@ -157,8 +163,8 @@ func TestIndex(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to read index: %v", err)
 			}
-			if !tt.get.IsZero() {
-				d, err := indexGet(index, tt.get)
+			if !tt.getRef.IsZero() {
+				d, err := indexGet(index, tt.getRef)
 				if tt.expectGetErr != nil {
 					if err == nil {
 						t.Errorf("indexGet did not fail")
@@ -173,10 +179,16 @@ func TestIndex(t *testing.T) {
 					}
 				}
 			}
-			if !tt.set.IsZero() {
-				err := indexSet(&index, tt.set, tt.setDesc)
+			if !tt.setRef.IsZero() {
+				err := indexSet(&index, tt.setRef, tt.setDesc)
 				if err != nil {
 					t.Errorf("indexSet failed: %v", err)
+				}
+				if !slices.ContainsFunc(index.Manifests, func(d descriptor.Descriptor) bool {
+					return d.Digest == tt.setDesc.Digest && d.Annotations != nil && d.Annotations[types.AnnotationCreated] == expectCreated
+				}) {
+					b, _ := json.Marshal(index)
+					t.Errorf("indexSet did not configure the timestamp for digest %s:\n%s", tt.setDesc.Digest, string(b))
 				}
 			}
 			if len(index.Manifests) != tt.expectLen {

--- a/scheme/ocidir/tag.go
+++ b/scheme/ocidir/tag.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/regclient/regclient/scheme"
+	"github.com/regclient/regclient/types"
 	"github.com/regclient/regclient/types/errs"
 	"github.com/regclient/regclient/types/mediatype"
 	"github.com/regclient/regclient/types/ref"
@@ -33,7 +34,7 @@ func (o *OCIDir) tagDelete(_ context.Context, r ref.Ref) error {
 	}
 	changed := false
 	for i, desc := range index.Manifests {
-		if t, ok := desc.Annotations[aOCIRefName]; ok && t == r.Tag {
+		if t, ok := desc.Annotations[types.AnnotationRefName]; ok && t == r.Tag {
 			// remove matching entry from index
 			index.Manifests = slices.Delete(index.Manifests, i, i+1)
 			changed = true
@@ -60,7 +61,7 @@ func (o *OCIDir) TagList(ctx context.Context, r ref.Ref, opts ...scheme.TagOpts)
 	}
 	tl := []string{}
 	for _, desc := range index.Manifests {
-		if t, ok := desc.Annotations[aOCIRefName]; ok {
+		if t, ok := desc.Annotations[types.AnnotationRefName]; ok {
 			if i := strings.LastIndex(t, ":"); i >= 0 {
 				t = t[i+1:]
 			}


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Add the created timestamp in OCI Layout entries as an annotation. This improves compatibility with other tools and will be useful when the tag listing API is later enhanced by OCI.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
regctl image copy alpine:latest ocidir://alpine:latest
jq . <alpine/index.json
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Feat: Add created timestamp in OCI Layout entries.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation updates are included or not applicable (most documentation should be in the regclient.org repo)
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
- [X] All changes have been human generated or created with a reproducible tool

<!-- markdownlint-disable-file MD041 -->
