### PR TITLE
Allow pagination parameters on tag listing

### DIFF
--- a/cmd/regbot/sandbox/tag.go
+++ b/cmd/regbot/sandbox/tag.go
@@ -1,9 +1,13 @@
 package sandbox
 
 import (
+	"fmt"
 	"log/slog"
 
 	lua "github.com/yuin/gopher-lua"
+
+	"github.com/regclient/regclient/cmd/regbot/internal/go2lua"
+	"github.com/regclient/regclient/scheme"
 )
 
 func setupTag(s *Sandbox) {
@@ -45,16 +49,37 @@ func (s *Sandbox) tagDelete(ls *lua.LState) int {
 	return 0
 }
 
+type tagLsOpts struct {
+	Limit int    `json:"limit"`
+	Last  string `json:"last"`
+}
+
 func (s *Sandbox) tagLs(ls *lua.LState) int {
 	err := s.ctx.Err()
 	if err != nil {
 		ls.RaiseError("Context error: %v", err)
 	}
 	r := s.checkReference(ls, 1)
+	opts := tagLsOpts{}
+	optsArgs := []scheme.TagOpts{}
+	if ls.GetTop() > 1 {
+		tab := ls.CheckTable(2)
+		err := go2lua.Import(ls, tab, &opts, nil)
+		if err != nil {
+			ls.ArgError(2, fmt.Sprintf("Failed to parse options: %v", err))
+		}
+		if opts.Limit > 0 {
+			optsArgs = append(optsArgs, scheme.WithTagLimit(opts.Limit))
+		}
+		if opts.Last != "" {
+			optsArgs = append(optsArgs, scheme.WithTagLast(opts.Last))
+		}
+	}
 	s.log.Debug("Listing tags",
 		slog.String("script", s.name),
-		slog.String("repo", r.r.CommonName()))
-	tl, err := s.rc.TagList(s.ctx, r.r)
+		slog.String("repo", r.r.CommonName()),
+		slog.Any("opts", opts))
+	tl, err := s.rc.TagList(s.ctx, r.r, optsArgs...)
 	if err != nil {
 		ls.RaiseError("Failed retrieving tag list: %v", err)
 	}


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

Closes #1085

### Describe the change

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->
New feature
Adds pagination parameters to the `tag.ls` implementation of regbot lua scripts.
I've simply copied the implementation from `repo.ls`. If you want to consolidate that somehow, feel free to use this as a basis (or close and re-implement differently).

### How to verify it

<!-- Include steps that can be taken to verify the change -->

Run `tag.ls` against a repository with more than 1000 tags.


### Changelog text

<!-- If the release changelog should have an entry for this, include it here -->

Feat: `tag.ls` now accepts the same pagination parameters as `repo.ls`.

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [ ]  Tests have been added or not applicable
- [x] Documentation updates are included or not applicable (most documentation should be in the regclient.org repo)
- [x] Changes have been rebased to main
- [x] Multiple commits to the same code have been squashed
- [x] All changes have been human generated or created with a reproducible tool

<!-- markdownlint-disable-file MD041 -->
