### PR TITLE
Fix docker workflow missing minor/major tags on docker hub push

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -65,7 +65,7 @@ jobs:
           MINOR="${VERSION%.*}"
           MAJOR="${MINOR%.*}"
           TAG_COPIES="${HUB_IMAGE}:${MINOR}${EXT},${HUB_IMAGE}:${MAJOR}${EXT}"
-          TAG_COPIES="${GHCR_IMAGE}:${MINOR}${EXT},${GHCR_IMAGE}:${MAJOR}${EXT}"
+          TAG_COPIES="${TAG_COPIES},${GHCR_IMAGE}:${MINOR}${EXT},${GHCR_IMAGE}:${MAJOR}${EXT}"
           if [ "${{ matrix.type }}" == "scratch" ]; then
             TAG_COPIES="${TAG_COPIES},${HUB_IMAGE}:latest"
             TAG_COPIES="${TAG_COPIES},${GHCR_IMAGE}:latest"


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

n/a

### Describe the change

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

Since af38ac4, the [`docker` workflow](.github/workflows/docker.yml) now longer pushed minor and major tags to Docker hub due to the `TAG_COPIES` variable being overwritten.

### How to verify it

<!-- Include steps that can be taken to verify the change -->

The next release should correctly update the tags on Docker Hub (which are missing since 0.11.1).


### Changelog text

Fix: Push tags for minor and major releases on Docker Hub.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [x] Tests have been added or not applicable
- [x] Documentation updates are included or not applicable (most documentation should be in the regclient.org repo)
- [x] Changes have been rebased to main
- [x] Multiple commits to the same code have been squashed
- [x] All changes have been human generated or created with a reproducible tool

<!-- markdownlint-disable-file MD041 -->
