### PR TITLE
Add `manifest.descriptor` and `manifest:descriptor` lua functions to regbot

### DIFF
--- a/cmd/regbot/sandbox/descriptor.go
+++ b/cmd/regbot/sandbox/descriptor.go
@@ -1,0 +1,80 @@
+package sandbox
+
+import (
+	"encoding/json"
+
+	lua "github.com/yuin/gopher-lua"
+
+	"github.com/regclient/regclient"
+	"github.com/regclient/regclient/types/descriptor"
+	"github.com/regclient/regclient/types/ref"
+)
+
+func setupDescriptor(s *Sandbox) {
+	s.setupMod(
+		luaDescriptorName,
+		map[string]lua.LGFunction{
+			"__tostring": s.descriptorJSON,
+		},
+		map[string]map[string]lua.LGFunction{
+			"__index": {},
+		},
+	)
+}
+
+type sbDescriptor struct {
+	d descriptor.Descriptor
+	r ref.Ref
+}
+
+func (s *Sandbox) checkDescriptor(ls *lua.LState, i int) *sbDescriptor {
+	fetchDescriptor := func(r ref.Ref) *sbDescriptor {
+		rcM, err := s.rc.ManifestHead(s.ctx, r, regclient.WithManifestRequireDigest())
+		if err != nil {
+			ls.RaiseError("Failed retrieving \"%s\" manifest: %v", r.CommonName(), err)
+		}
+		return &sbDescriptor{d: rcM.GetDescriptor(), r: r}
+	}
+
+	var d *sbDescriptor
+	switch ls.Get(i).Type() {
+	case lua.LTString:
+		r, err := ref.New(ls.CheckString(1))
+		if err != nil {
+			ls.RaiseError("reference parsing failed: %v", err)
+		}
+		d = fetchDescriptor(r)
+	case lua.LTUserData:
+		ud := ls.CheckUserData(i)
+		switch ud.Value.(type) {
+		case *sbDescriptor:
+			d = ud.Value.(*sbDescriptor)
+		case *sbManifest:
+			m := ud.Value.(*sbManifest)
+			d = &sbDescriptor{d: m.m.GetDescriptor(), r: m.r}
+		case *config:
+			c := ud.Value.(*config)
+			m := &sbManifest{r: c.r, m: c.m}
+			d = &sbDescriptor{d: m.m.GetDescriptor(), r: m.r}
+		case *reference:
+			r := ud.Value.(*reference)
+			d = fetchDescriptor(r.r)
+		default:
+			ls.ArgError(i, "descriptor expected")
+		}
+	default:
+		ls.ArgError(i, "descriptor expected")
+	}
+	return d
+}
+
+func (s *Sandbox) descriptorJSON(ls *lua.LState) int {
+	d := s.checkDescriptor(ls, 1)
+
+	mJSON, err := json.MarshalIndent(d.d, "", "  ")
+	if err != nil {
+		ls.RaiseError("Failed outputing descriptor: %v", err)
+	}
+	ls.Push(lua.LString(string(mJSON)))
+	return 1
+}

--- a/cmd/regbot/sandbox/manifest.go
+++ b/cmd/regbot/sandbox/manifest.go
@@ -24,6 +24,7 @@ func setupManifest(s *Sandbox) {
 		luaManifestName,
 		map[string]lua.LGFunction{
 			"__tostring": s.manifestJSON,
+			"descriptor": s.manifestDescriptor,
 			"get":        s.manifestGet,
 			"getList":    s.manifestGetList,
 			"head":       s.manifestHead,
@@ -33,6 +34,7 @@ func setupManifest(s *Sandbox) {
 			"__index": {
 				"config":        s.configGet,
 				"delete":        s.manifestDelete,
+				"descriptor":    s.manifestDescriptor,
 				"export":        s.manifestExport,
 				"get":           s.manifestGet,
 				"head":          s.manifestHead,
@@ -45,15 +47,10 @@ func setupManifest(s *Sandbox) {
 }
 
 func (s *Sandbox) checkManifest(ls *lua.LState, i int, list bool, head bool) *sbManifest {
-	var m *sbManifest
-	switch ls.Get(i).Type() {
-	case lua.LTString:
-		r, err := ref.New(ls.CheckString(1))
-		if err != nil {
-			ls.RaiseError("reference parsing failed: %v", err)
-		}
+	fetchManifest := func(r ref.Ref) *sbManifest {
+		var m *sbManifest
 		if head {
-			rcM, err := s.rc.ManifestHead(s.ctx, r)
+			rcM, err := s.rc.ManifestHead(s.ctx, r, regclient.WithManifestRequireDigest())
 			if err != nil {
 				ls.RaiseError("Failed retrieving \"%s\" manifest: %v", r.CommonName(), err)
 			}
@@ -65,6 +62,17 @@ func (s *Sandbox) checkManifest(ls *lua.LState, i int, list bool, head bool) *sb
 			}
 			m = &sbManifest{m: rcM, r: r}
 		}
+		return m
+	}
+
+	var m *sbManifest
+	switch ls.Get(i).Type() {
+	case lua.LTString:
+		r, err := ref.New(ls.CheckString(1))
+		if err != nil {
+			ls.RaiseError("reference parsing failed: %v", err)
+		}
+		m = fetchManifest(r)
 	case lua.LTUserData:
 		ud := ls.CheckUserData(i)
 		switch ud.Value.(type) {
@@ -75,19 +83,7 @@ func (s *Sandbox) checkManifest(ls *lua.LState, i int, list bool, head bool) *sb
 			m = &sbManifest{r: c.r, m: c.m}
 		case *reference:
 			r := ud.Value.(*reference)
-			if head {
-				rcM, err := s.rc.ManifestHead(s.ctx, r.r)
-				if err != nil {
-					ls.RaiseError("Failed retrieving \"%s\" manifest: %v", r.r.CommonName(), err)
-				}
-				m = &sbManifest{m: rcM, r: r.r}
-			} else {
-				rcM, err := s.rcManifestGet(r.r, list, "")
-				if err != nil {
-					ls.RaiseError("manifest pull failed: %v", err)
-				}
-				m = &sbManifest{m: rcM, r: r.r}
-			}
+			m = fetchManifest(r.r)
 		default:
 			ls.ArgError(i, "manifest expected")
 		}
@@ -228,6 +224,22 @@ func (s *Sandbox) manifestHead(ls *lua.LState) int {
 	ud, err := wrapUserData(ls, &sbManifest{m: m, r: r.r}, m, luaManifestName)
 	if err != nil {
 		ls.RaiseError("Failed packaging \"%s\" manifest: %v", r.r.CommonName(), err)
+	}
+	ls.Push(ud)
+	return 1
+}
+
+func (s *Sandbox) manifestDescriptor(ls *lua.LState) int {
+	err := s.ctx.Err()
+	if err != nil {
+		ls.RaiseError("Context error: %v", err)
+	}
+
+	d := s.checkDescriptor(ls, 1)
+
+	ud, err := wrapUserData(ls, d, d.d, luaDescriptorName)
+	if err != nil {
+		ls.RaiseError("Failed packaging \"%s\" descriptor: %v", d.r.CommonName(), err)
 	}
 	ls.Push(ud)
 	return 1

--- a/cmd/regbot/sandbox/sandbox.go
+++ b/cmd/regbot/sandbox/sandbox.go
@@ -19,6 +19,7 @@ const (
 	luaReferenceName   = "reference"
 	luaTagName         = "tag"
 	luaManifestName    = "manifest"
+	luaDescriptorName  = "descriptor"
 	luaImageName       = "image"
 	luaImageConfigName = "imageconfig"
 	luaBlobName        = "blob"
@@ -44,6 +45,7 @@ var luaMods = []LuaMod{
 	setupTag,
 	setupImage,
 	setupManifest,
+	setupDescriptor,
 	setupBlob,
 }
 


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

Closes #1088

### Describe the change

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

New Feature

Allows retrieving the descriptor of a manifest (list) from a ref.

### How to verify it

<!-- Include steps that can be taken to verify the change -->

Use `manifest.descriptor(ref)` in a regbot script - `ref` can be either a multi-platform image or a "normal" image.
`manifest:descriptor` does the same for an already existing manifest (e.g. from `manifest.head`).

### Changelog text

<!-- If the release changelog should have an entry for this, include it here -->

Add `manifest.descriptor` / `manifest:descriptor` for retrieving the descriptor of a manifest.

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [x] Tests have been added or not applicable
- [x] Documentation updates are included or not applicable (most documentation should be in the regclient.org repo)
- [x] Changes have been rebased to main
- [x] Multiple commits to the same code have been squashed
- [x] All changes have been human generated or created with a reproducible tool

<!-- markdownlint-disable-file MD041 -->
