### PR TITLE
Feat: Add regbot manifest.descriptor to the sandbox

### DIFF
--- a/cmd/regbot/sandbox/blob.go
+++ b/cmd/regbot/sandbox/blob.go
@@ -45,59 +45,6 @@ func setupBlob(s *Sandbox) {
 	)
 }
 
-// func (s *Sandbox) checkBlob(ls *lua.LState, i int, head bool) *sbBlob {
-// 	var b *sbBlob
-// 	switch ls.Get(i).Type() {
-// 	case lua.LTString:
-// 		r, err := ref.New(ls.CheckString(1))
-// 		if err != nil {
-// 			ls.RaiseError("reference parsing failed: %v", err)
-// 		}
-// 		if head {
-// 			rcB, err := s.rc.BlobHead(s.ctx, r, digest.Digest(r.Digest))
-// 			if err != nil {
-// 				ls.RaiseError("Failed retrieving \"%s\" blob: %v", r.CommonName(), err)
-// 			}
-// 			b = &sbBlob{b: rcB, r: r, d: digest.Digest(r.Digest)}
-// 		} else {
-// 			rcB, err := s.rc.BlobGet(s.ctx, r, digest.Digest(r.Digest))
-// 			if err != nil {
-// 				ls.RaiseError("Blob pull failed: %v", err)
-// 			}
-// 			b = &sbBlob{b: rcB, r: r, d: digest.Digest(r.Digest)}
-// 		}
-// 	case lua.LTUserData:
-// 		ud := ls.CheckUserData(i)
-// 		switch ud.Value.(type) {
-// 		case *sbBlob:
-// 			b = ud.Value.(*sbBlob)
-// 		case *config:
-// 			c := ud.Value.(*config)
-// 			b = &sbBlob{b: c.conf, r: c.r, d: digest.Digest(c.r.Digest)}
-// 		case *reference:
-// 			r := ud.Value.(*reference).r
-// 			if head {
-// 				rcB, err := s.rc.BlobHead(s.ctx, r, digest.Digest(r.Digest))
-// 				if err != nil {
-// 					ls.RaiseError("Failed retrieving \"%s\" blob: %v", r.CommonName(), err)
-// 				}
-// 				b = &sbBlob{b: rcB, r: r, d: digest.Digest(r.Digest)}
-// 			} else {
-// 				rcB, err := s.rc.BlobGet(s.ctx, r, digest.Digest(r.Digest))
-// 				if err != nil {
-// 					ls.RaiseError("Blob pull failed: %v", err)
-// 				}
-// 				b = &sbBlob{b: rcB, r: r, d: digest.Digest(r.Digest)}
-// 			}
-// 		default:
-// 			ls.ArgError(i, "blob expected")
-// 		}
-// 	default:
-// 		ls.ArgError(i, "blob expected")
-// 	}
-// 	return b
-// }
-
 func (s *Sandbox) blobGet(ls *lua.LState) int {
 	err := s.ctx.Err()
 	if err != nil {

--- a/cmd/regbot/sandbox/manifest.go
+++ b/cmd/regbot/sandbox/manifest.go
@@ -24,6 +24,7 @@ func setupManifest(s *Sandbox) {
 		luaManifestName,
 		map[string]lua.LGFunction{
 			"__tostring": s.manifestJSON,
+			"descriptor": s.manifestDescriptor,
 			"get":        s.manifestGet,
 			"getList":    s.manifestGetList,
 			"head":       s.manifestHead,
@@ -33,6 +34,7 @@ func setupManifest(s *Sandbox) {
 			"__index": {
 				"config":        s.configGet,
 				"delete":        s.manifestDelete,
+				"descriptor":    s.manifestDescriptor,
 				"export":        s.manifestExport,
 				"get":           s.manifestGet,
 				"head":          s.manifestHead,
@@ -48,12 +50,12 @@ func (s *Sandbox) checkManifest(ls *lua.LState, i int, list bool, head bool) *sb
 	var m *sbManifest
 	switch ls.Get(i).Type() {
 	case lua.LTString:
-		r, err := ref.New(ls.CheckString(1))
+		r, err := ref.New(ls.CheckString(i))
 		if err != nil {
 			ls.RaiseError("reference parsing failed: %v", err)
 		}
 		if head {
-			rcM, err := s.rc.ManifestHead(s.ctx, r)
+			rcM, err := s.rc.ManifestHead(s.ctx, r, regclient.WithManifestRequireDigest())
 			if err != nil {
 				ls.RaiseError("Failed retrieving \"%s\" manifest: %v", r.CommonName(), err)
 			}
@@ -76,7 +78,7 @@ func (s *Sandbox) checkManifest(ls *lua.LState, i int, list bool, head bool) *sb
 		case *reference:
 			r := ud.Value.(*reference)
 			if head {
-				rcM, err := s.rc.ManifestHead(s.ctx, r.r)
+				rcM, err := s.rc.ManifestHead(s.ctx, r.r, regclient.WithManifestRequireDigest())
 				if err != nil {
 					ls.RaiseError("Failed retrieving \"%s\" manifest: %v", r.r.CommonName(), err)
 				}
@@ -125,6 +127,17 @@ func (s *Sandbox) manifestDelete(ls *lua.LState) int {
 	return 0
 }
 
+func (s *Sandbox) manifestDescriptor(ls *lua.LState) int {
+	m := s.checkManifest(ls, 1, true, true)
+	if m == nil || m.m == nil {
+		ls.RaiseError("Failed retrieving manifest")
+	}
+	desc := m.m.GetDescriptor()
+	ud := go2lua.Export(ls, desc)
+	ls.Push(ud)
+	return 1
+}
+
 func (s *Sandbox) manifestExport(ls *lua.LState) int {
 	var newM *sbManifest
 	i := 1
@@ -153,7 +166,6 @@ func (s *Sandbox) manifestExport(ls *lua.LState) int {
 		}
 		// save image to a new manifest
 		rcM, err := manifest.New(manifest.WithOrig(reflect.ValueOf(newMMP).Elem().Interface())) // reflect is needed again to deref the pointer now
-		// rcM, err := manifest.FromOrig(newMM)
 		if err != nil {
 			ls.RaiseError("Failed exporting manifest (from orig): %v", err)
 		}
@@ -220,7 +232,7 @@ func (s *Sandbox) manifestHead(ls *lua.LState) int {
 		slog.String("script", s.name),
 		slog.String("image", r.r.CommonName()))
 
-	m, err := s.rc.ManifestHead(s.ctx, r.r)
+	m, err := s.rc.ManifestHead(s.ctx, r.r, regclient.WithManifestRequireDigest())
 	if err != nil {
 		ls.RaiseError("Failed retrieving \"%s\" manifest: %v", r.r.CommonName(), err)
 	}

--- a/cmd/regbot/sandbox/reference.go
+++ b/cmd/regbot/sandbox/reference.go
@@ -85,17 +85,6 @@ func (s *Sandbox) checkReference(ls *lua.LState, i int) *reference {
 	return r
 }
 
-// func isReference(ls *lua.LState, i int) bool {
-// 	if ls.Get(i).Type() != lua.LTUserData {
-// 		return false
-// 	}
-// 	ud := ls.CheckUserData(i)
-// 	if _, ok := ud.Value.(*reference); ok {
-// 		return true
-// 	}
-// 	return false
-// }
-
 // referenceString converts a reference back to a common name
 func (s *Sandbox) referenceString(ls *lua.LState) int {
 	r := s.checkReference(ls, 1)

--- a/cmd/regbot/sandbox/sandbox.go
+++ b/cmd/regbot/sandbox/sandbox.go
@@ -121,6 +121,7 @@ func WithThrottle(pq *pqueue.Queue[struct{}]) Opt {
 	}
 }
 
+// setupMod configures a namespace, attaches various functions, and attaches tables of metamethods
 func (s *Sandbox) setupMod(name string, funcs map[string]lua.LGFunction, tables map[string]map[string]lua.LGFunction) {
 	mt := s.ls.NewTypeMetatable(name)
 	s.ls.SetGlobal(name, mt)

--- a/cmd/regbot/sandbox/sandbox_test.go
+++ b/cmd/regbot/sandbox/sandbox_test.go
@@ -1,0 +1,133 @@
+package sandbox
+
+import (
+	"errors"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/olareg/olareg"
+	oConfig "github.com/olareg/olareg/config"
+
+	"github.com/regclient/regclient"
+	rcConfig "github.com/regclient/regclient/config"
+)
+
+func TestSandbox(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	boolT := true
+	regHandler := olareg.New(oConfig.Config{
+		Storage: oConfig.ConfigStorage{
+			StoreType: oConfig.StoreMem,
+			RootDir:   "../../../testdata",
+		},
+		API: oConfig.ConfigAPI{
+			DeleteEnabled: &boolT,
+		},
+	})
+	ts := httptest.NewServer(regHandler)
+	tsURL, _ := url.Parse(ts.URL)
+	tsHost := tsURL.Host
+	t.Cleanup(func() {
+		ts.Close()
+		_ = regHandler.Close()
+	})
+	rcHosts := []rcConfig.Host{
+		{
+			Name:     tsHost,
+			Hostname: tsHost,
+			TLS:      rcConfig.TLSDisabled,
+		},
+		{
+			Name:     "registry.example.org",
+			Hostname: tsHost,
+			TLS:      rcConfig.TLSDisabled,
+		},
+	}
+	// replace regclient with one configured for test hosts
+	rc := regclient.New(
+		regclient.WithConfigHost(rcHosts...),
+	)
+	s := New("test", WithContext(ctx), WithRegClient(rc))
+
+	tt := []struct {
+		name      string
+		script    string
+		expectErr error
+	}{
+		{
+			name:   "Empty",
+			script: "",
+		},
+		{
+			name: "List tags",
+			script: `
+				tags = tag.ls("registry.example.org/testrepo")
+				for k, t in pairs(tags) do
+					if t == "v2" then
+						return
+					end
+				end
+				error("v2 tag was seen in the listing")
+			`,
+		},
+		{
+			name: "Find duplicate digest to mirror tag",
+			script: `
+				target = manifest.descriptor("registry.example.org/testrepo:mirror").Digest
+				tags = tag.ls("registry.example.org/testrepo")
+				for k, t in pairs(tags) do
+					if t ~= "mirror" and target == manifest.descriptor("registry.example.org/testrepo:" .. t).Digest then
+						log("found matching tag to mirror: " .. t)
+						return
+					end
+				end
+				error("did not find matching tag to mirror tag")
+			`,
+		},
+		{
+			name: "Manifest descriptor",
+			script: `
+				m = manifest.getList("registry.example.org/testrepo:v1")
+				if m:descriptor().MediaType ~= "application/vnd.oci.image.index.v1+json" then
+					error("v1 media type is " .. m:descriptor().MediaType)
+				end
+				if not string.match(m:descriptor().Digest, "^sha256:") then
+					error("v1 digest is " .. m:descriptor().Digest)
+				end
+				-- get the descriptor directly
+				desc = manifest.descriptor("registry.example.org/testrepo:v2")
+				if desc.MediaType ~= "application/vnd.oci.image.index.v1+json" then
+					error("v2 media type is " .. desc.MediaType)
+				end
+			`,
+		},
+		{
+			name: "Get config",
+			script: `
+				m = manifest.get("registry.example.org/testrepo:v1", "linux/amd64")
+				ic = image.config(m)
+				if ic.Config.Labels["version"] ~= "1" then
+					error("version label missing/invalid: " .. ic.Config.Labels["version"])
+				end`,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			err := s.RunScript(tc.script)
+			if tc.expectErr != nil {
+				if err == nil {
+					t.Errorf("process did not fail")
+				} else if !errors.Is(err, tc.expectErr) && err.Error() != tc.expectErr.Error() {
+					t.Errorf("unexpected error on process: %v, expected %v", err, tc.expectErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error on process: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Fixes #1088.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Add regbot manifest.descriptor to sandbox. This allows querying the digest. This also updates calls to manifest head to require the digest.

This also cleans up some other leftover cruft in the regbot code.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```
-- get descriptor from a manifest that was pulled
m = manifest.getList("registry.example.org/testrepo:v1")
if m:descriptor().MediaType ~= "application/vnd.oci.image.index.v1+json" then
	error("v1 media type is " .. m:descriptor().MediaType)
end
if not string.match(m:descriptor().Digest, "^sha256:") then
	error("v1 digest is " .. m:descriptor().Digest)
end
-- get the descriptor directly
desc = manifest.descriptor("registry.example.org/testrepo:v2")
if desc.MediaType ~= "application/vnd.oci.image.index.v1+json" then
	error("v2 media type is " .. desc.MediaType)
end
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Feat: Add regbot `manifest.descriptor` to the sandbox.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [x] Documentation updates are included or not applicable (most documentation should be in the regclient.org repo)
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
- [X] All changes have been human generated or created with a reproducible tool

<!-- markdownlint-disable-file MD041 -->
