### PR TITLE
Sec: Forbid sending auth on redirects

### DIFF
--- a/internal/reghttp/http.go
+++ b/internal/reghttp/http.go
@@ -402,7 +402,8 @@ func (resp *Resp) next() error {
 				}
 				// add auth headers
 				err = hAuth.UpdateRequest(httpReq)
-				if err != nil {
+				// abort on auth errors, but only after the first request has been attempted
+				if err != nil && resp.resp != nil {
 					if errors.Is(err, errs.ErrHTTPUnauthorized) {
 						dropHost = true
 					} else {
@@ -558,7 +559,7 @@ func (resp *Resp) HTTPResponse() *http.Response {
 
 // Read provides a retryable read from the body of the response.
 func (resp *Resp) Read(b []byte) (int, error) {
-	if resp.done {
+	if resp.done || resp.reader == nil {
 		return 0, io.EOF
 	}
 	if resp.resp == nil {
@@ -857,8 +858,13 @@ func (ch *clientHost) AuthCreds() func(h string) auth.Cred {
 		return auth.DefaultCredsFn
 	}
 	return func(h string) auth.Cred {
-		hCred := ch.config.GetCred()
-		return auth.Cred{User: hCred.User, Password: hCred.Password, Token: hCred.Token}
+		// only return credentials to challenges from the registry server, not to any redirects
+		if h == ch.config.Hostname {
+			hCred := ch.config.GetCred()
+			return auth.Cred{User: hCred.User, Password: hCred.Password, Token: hCred.Token}
+		} else {
+			return auth.Cred{}
+		}
 	}
 }
 

--- a/internal/reghttp/http_test.go
+++ b/internal/reghttp/http_test.go
@@ -929,6 +929,11 @@ func TestRegHttp(t *testing.T) {
 				"expectns." + ts2Host,
 			},
 		},
+		"external-host.example.org": {
+			Name:     "external-host.example.org",
+			Hostname: "external-host.example.org",
+			TLS:      config.TLSDisabled,
+		},
 	}
 
 	// create APIs for requests to run
@@ -1215,6 +1220,42 @@ func TestRegHttp(t *testing.T) {
 		err = resp.Close()
 		if err != nil {
 			t.Errorf("error closing request: %v", err)
+		}
+	})
+	// test redirect where auth should not be sent
+	t.Run("redirect-without-auth", func(t *testing.T) {
+		u, err := tsURL.Parse("/v2/project/manifests/tag-auth")
+		if err != nil {
+			t.Fatalf("failed to parse url: %v", err)
+		}
+		authReq := &Req{
+			Host:       "external-host.example.org",
+			Method:     "GET",
+			Repository: "project-redirect",
+			Path:       "manifests/tag-auth",
+			DirectURL:  u,
+			Headers:    headers,
+		}
+		resp, err := hc.Do(ctx, authReq)
+		if !errors.Is(err, errs.ErrHTTPUnauthorized) {
+			t.Errorf("expected Unauthorized, received %v", err)
+		}
+		if resp == nil {
+			t.Errorf("response missing")
+		} else {
+			if resp.HTTPResponse().StatusCode != http.StatusUnauthorized {
+				t.Errorf("invalid status code, expected %d, received %d", http.StatusUnauthorized, resp.HTTPResponse().StatusCode)
+			}
+			body, err := io.ReadAll(resp)
+			if err != nil {
+				t.Fatalf("body read failure: %v", err)
+			} else if bytes.Equal(body, getBody) {
+				t.Errorf("body received without auth")
+			}
+			err = resp.Close()
+			if err != nil {
+				t.Errorf("error closing request: %v", err)
+			}
 		}
 	})
 	// test repoauth

--- a/scheme/reg/blob.go
+++ b/scheme/reg/blob.go
@@ -533,6 +533,9 @@ func (reg *Reg) blobPutUploadChunked(ctx context.Context, r ref.Ref, d descripto
 				resp.HTTPResponse().Header.Get("Location") != "" &&
 				resp.HTTPResponse().Header.Get("Range") != "" {
 				retryCur++
+				if retryCur > retryLimit {
+					return d, fmt.Errorf("failed to send blob (chunk), ref %s: http status: %w", r.CommonName(), reghttp.HTTPError(resp.HTTPResponse().StatusCode))
+				}
 				reg.slog.Debug("Recoverable chunk upload error",
 					slog.String("ref", r.CommonName()),
 					slog.Int64("chunkStart", chunkStart),

--- a/scheme/reg/blob_test.go
+++ b/scheme/reg/blob_test.go
@@ -222,6 +222,8 @@ func TestBlobGet(t *testing.T) {
 			Name:     tsHost,
 			Hostname: tsHost,
 			TLS:      config.TLSDisabled,
+			User:     "username",
+			Pass:     "secret",
 		},
 	}
 	log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
@@ -361,6 +363,32 @@ func TestBlobGet(t *testing.T) {
 		}
 	})
 
+	t.Run("Detect external credential leak", func(t *testing.T) {
+		extServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			auth := r.Header.Get("Authorization")
+			if auth != "" {
+				t.Errorf("credential leak detected: %s", auth)
+				w.WriteHeader(http.StatusOK)
+				w.Write(blob1)
+			} else {
+				w.Header().Add("WWW-Authenticate", "Basic realm=\"External Blob Host\"")
+				w.WriteHeader(http.StatusUnauthorized)
+			}
+		}))
+		defer extServer.Close()
+		r, err := ref.New(tsURL.Host + externalRepo)
+		if err != nil {
+			t.Fatalf("Failed creating ref: %v", err)
+		}
+		br, err := reg.BlobGet(ctx, r, descriptor.Descriptor{Digest: d1, URLs: []string{extServer.URL + "/external/" + d1.String()}})
+		if err == nil {
+			br.Close()
+		}
+		if !errors.Is(err, errs.ErrHTTPUnauthorized) {
+			t.Fatalf("Unauthorized status not received, err received: %v", err)
+		}
+	})
+
 	t.Run("Missing", func(t *testing.T) {
 		r, err := ref.New(tsURL.Host + blobRepo)
 		if err != nil {
@@ -428,6 +456,7 @@ func TestBlobPut(t *testing.T) {
 	blobLen3 := 1000 // blob without a full final chunk
 	blobLen4 := 2048 // must be blobChunk < blobLen <= blobChunk * 2
 	blobLen5 := 500  // single chunk
+	blobLen7 := 1024
 	d1, blob1 := reqresp.NewRandomBlob(blobLen, seed)
 	d2, blob2 := reqresp.NewRandomBlob(blobLen, seed+1)
 	d2Bad := digest.SHA256.FromString("digest 2 bad")
@@ -436,6 +465,7 @@ func TestBlobPut(t *testing.T) {
 	d5, blob5 := reqresp.NewRandomBlob(blobLen5, seed+4)
 	blob6 := []byte{}
 	d6 := digest.SHA256.FromBytes(blob6)
+	d7, blob7 := reqresp.NewRandomBlob(blobLen7, seed+5) // external auth refused blob
 	d1sha512 := digest.SHA512.FromBytes(blob1)
 	d5sha512 := digest.SHA512.FromBytes(blob5)
 	uuid1 := reqresp.NewRandomID(seed + 10)
@@ -445,6 +475,7 @@ func TestBlobPut(t *testing.T) {
 	uuid4 := reqresp.NewRandomID(seed + 14)
 	uuid5 := reqresp.NewRandomID(seed + 15)
 	uuid6 := reqresp.NewRandomID(seed + 16)
+	uuid7 := reqresp.NewRandomID(seed + 17)
 	// dMissing := digest.FromBytes([]byte("missing"))
 	user := "testing"
 	pass := "password"
@@ -462,7 +493,6 @@ func TestBlobPut(t *testing.T) {
 				Headers: http.Header{
 					"Content-Length": {fmt.Sprintf("%d", len(blob1))},
 					"Content-Type":   {"application/octet-stream"},
-					"Authorization":  {fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(user+":"+pass)))},
 				},
 				Body: blob1,
 			},
@@ -477,27 +507,6 @@ func TestBlobPut(t *testing.T) {
 		},
 		{
 			ReqEntry: reqresp.ReqEntry{
-				Name:   "PUT for d1 unauth",
-				Method: "PUT",
-				Path:   "/v2" + blobRepo + "/blobs/uploads/" + uuid1,
-				Query: map[string][]string{
-					"digest": {d1.String()},
-				},
-				Headers: http.Header{
-					"Content-Length": {fmt.Sprintf("%d", len(blob1))},
-					"Content-Type":   {"application/octet-stream"},
-				},
-				Body: blob1,
-			},
-			RespEntry: reqresp.RespEntry{
-				Status: http.StatusUnauthorized,
-				Headers: http.Header{
-					"WWW-Authenticate": {"Basic realm=\"testing\""},
-				},
-			},
-		},
-		{
-			ReqEntry: reqresp.ReqEntry{
 				Name:   "PUT for d1 sha512",
 				Method: "PUT",
 				Path:   "/v2" + blobRepo1sha512 + "/blobs/uploads/" + uuid1,
@@ -507,7 +516,6 @@ func TestBlobPut(t *testing.T) {
 				Headers: http.Header{
 					"Content-Length": {fmt.Sprintf("%d", len(blob1))},
 					"Content-Type":   {"application/octet-stream"},
-					"Authorization":  {fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(user+":"+pass)))},
 				},
 				Body: blob1,
 			},
@@ -522,17 +530,71 @@ func TestBlobPut(t *testing.T) {
 		},
 		{
 			ReqEntry: reqresp.ReqEntry{
-				Name:   "PUT for d1 sha512 unauth",
-				Method: "PUT",
-				Path:   "/v2" + blobRepo1sha512 + "/blobs/uploads/" + uuid1,
+				Name:   "GET for d7 unauth",
+				Method: "GET",
+				Path:   "/v2" + blobRepo + "/blobs/uploads/" + uuid7,
 				Query: map[string][]string{
-					"digest": {d1sha512.String()},
+					"digest": {d7.String()},
+				},
+			},
+			RespEntry: reqresp.RespEntry{
+				Status: http.StatusUnauthorized,
+				Headers: http.Header{
+					"WWW-Authenticate": {"Basic realm=\"testing\""},
+				},
+			},
+		},
+		{
+			ReqEntry: reqresp.ReqEntry{
+				Name:   "DELETE for d7 unauth",
+				Method: "DELETE",
+				Path:   "/v2" + blobRepo + "/blobs/uploads/" + uuid7,
+				Query: map[string][]string{
+					"digest": {d7.String()},
+				},
+			},
+			RespEntry: reqresp.RespEntry{
+				Status: http.StatusUnauthorized,
+				Headers: http.Header{
+					"WWW-Authenticate": {"Basic realm=\"testing\""},
+				},
+			},
+		},
+		{
+			ReqEntry: reqresp.ReqEntry{
+				Name:   "PUT for d7 unauth",
+				Method: "PUT",
+				Path:   "/v2" + blobRepo + "/blobs/uploads/" + uuid7,
+				Query: map[string][]string{
+					"digest": {d7.String()},
 				},
 				Headers: http.Header{
-					"Content-Length": {fmt.Sprintf("%d", len(blob1))},
+					"Content-Length": {fmt.Sprintf("%d", len(blob7))},
 					"Content-Type":   {"application/octet-stream"},
 				},
-				Body: blob1,
+				Body: blob7,
+			},
+			RespEntry: reqresp.RespEntry{
+				Status: http.StatusUnauthorized,
+				Headers: http.Header{
+					"WWW-Authenticate": {"Basic realm=\"testing\""},
+				},
+			},
+		},
+		{
+			ReqEntry: reqresp.ReqEntry{
+				Name:   "PATCH for d7 unauth",
+				Method: "PATCH",
+				Path:   "/v2" + blobRepo + "/blobs/uploads/" + uuid7,
+				Query: map[string][]string{
+					"digest": {d7.String()},
+				},
+				Headers: http.Header{
+					"Content-Length": {fmt.Sprintf("%d", blobChunk)},
+					"Content-Range":  {fmt.Sprintf("0-%d", blobChunk-1)},
+					"Content-Type":   {"application/octet-stream"},
+				},
+				Body: blob7[0:blobChunk],
 			},
 			RespEntry: reqresp.RespEntry{
 				Status: http.StatusUnauthorized,
@@ -1351,6 +1413,44 @@ func TestBlobPut(t *testing.T) {
 				},
 			},
 		},
+		// upload put for d7
+		{
+			ReqEntry: reqresp.ReqEntry{
+				Name:   "POST for d7",
+				Method: "POST",
+				Path:   "/v2" + blobRepo + "/blobs/uploads/",
+				Query: map[string][]string{
+					"mount": {d7.String()},
+				},
+				Headers: http.Header{
+					"Authorization": {fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(user+":"+pass)))},
+				},
+			},
+			RespEntry: reqresp.RespEntry{
+				Status: http.StatusAccepted,
+				Headers: http.Header{
+					"Content-Length": {"0"},
+					"Location":       {fmt.Sprintf("http://%s/v2%s/blobs/uploads/%s", blobHost, blobRepo, uuid7)},
+				},
+			},
+		},
+		{
+			ReqEntry: reqresp.ReqEntry{
+				Name:   "POST for d7 unauth",
+				Method: "POST",
+				Path:   "/v2" + blobRepo + "/blobs/uploads/",
+				Query: map[string][]string{
+					"mount": {d7.String()},
+				},
+			},
+			RespEntry: reqresp.RespEntry{
+				Status: http.StatusUnauthorized,
+				Headers: http.Header{
+					"Content-Length":   {"0"},
+					"WWW-Authenticate": {"Basic realm=\"testing\""},
+				},
+			},
+		},
 	}
 	rrs = append(rrs, reqresp.BaseEntries...)
 	// create a server
@@ -1571,6 +1671,19 @@ func TestBlobPut(t *testing.T) {
 		}
 		if dp.Size != int64(len(blob6)) {
 			t.Errorf("Content length mismatch, expected %d, received %d", len(blob6), dp.Size)
+		}
+	})
+
+	// external blob server should not request auth creds
+	t.Run("External request for auth", func(t *testing.T) {
+		r, err := ref.New(tsURL.Host + blobRepo)
+		if err != nil {
+			t.Fatalf("Failed creating ref: %v", err)
+		}
+		br := bytes.NewReader(blob7)
+		_, err = reg.BlobPut(ctx, r, descriptor.Descriptor{Digest: d7, Size: int64(len(blob7))}, br)
+		if !errors.Is(err, errs.ErrHTTPUnauthorized) {
+			t.Fatalf("BlobPut to external server requesting auth, expected: %v, received: %v", errs.ErrHTTPUnauthorized, err)
 		}
 	})
 


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

https://github.com/regclient/regclient/security/advisories/GHSA-qvqc-4c52-x6qp
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This limits sending credentials to only the original registry server, preventing attacks leveraging external URLs to trigger a credential leak.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
make test
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Sec: Forbid sending auth on redirects.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation updates are included or not applicable (most documentation should be in the regclient.org repo)
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
- [X] All changes have been human generated or created with a reproducible tool

<!-- markdownlint-disable-file MD041 -->
