### PR TITLE
Fix: Add limits and controls to ReadAll

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -897,14 +897,12 @@ func (j *jwtHubHandler) ProcessChallenge(c challenge) error {
 		return err
 	}
 	defer resp.Body.Close()
-	body, _ := io.ReadAll(resp.Body)
-
 	if resp.StatusCode != 200 || resp.StatusCode >= 300 {
 		return errs.ErrHTTPUnauthorized
 	}
 
 	var bodyParsed jwtHubResp
-	err = json.Unmarshal(body, &bodyParsed)
+	err = json.NewDecoder(resp.Body).Decode(&bodyParsed)
 	if err != nil {
 		return err
 	}

--- a/internal/reghttp/http.go
+++ b/internal/reghttp/http.go
@@ -44,8 +44,9 @@ var (
 )
 
 const (
-	DefaultRetryLimit = 5 // number of times a request will be retried
-	backoffResetCount = 5 // number of successful requests needed to reduce the backoff
+	DefaultRetryLimit = 5               // number of times a request will be retried
+	backoffResetCount = 5               // number of successful requests needed to reduce the backoff
+	ReadBodyLimit     = 8 * 1024 * 1024 // limit for reading the body for errors
 )
 
 // Client is an HTTP client wrapper.
@@ -482,7 +483,7 @@ func (resp *Resp) next() error {
 					dropHost = true
 				}
 				errHTTP := HTTPError(resp.resp.StatusCode)
-				errBody, _ := io.ReadAll(resp.resp.Body)
+				errBody, _ := io.ReadAll(&io.LimitedReader{R: resp.resp.Body, N: ReadBodyLimit})
 				_ = resp.resp.Body.Close()
 				return fmt.Errorf("request failed: %w: %s", errHTTP, errBody)
 			}

--- a/regclient.go
+++ b/regclient.go
@@ -31,6 +31,7 @@ const (
 type RegClient struct {
 	hosts       map[string]*config.Host
 	hostDefault *config.Host
+	ocidirOpts  []ocidir.Opts
 	regOpts     []reg.Opts
 	schemes     map[string]scheme.API
 	slog        *slog.Logger
@@ -76,12 +77,14 @@ func New(opts ...Opt) *RegClient {
 		reg.WithSlog(rc.slog),
 		reg.WithUserAgent(rc.userAgent),
 	)
+	rc.ocidirOpts = append(
+		rc.ocidirOpts,
+		ocidir.WithSlog(rc.slog),
+	)
 
 	// setup scheme's
 	rc.schemes["reg"] = reg.New(rc.regOpts...)
-	rc.schemes["ocidir"] = ocidir.New(
-		ocidir.WithSlog(rc.slog),
-	)
+	rc.schemes["ocidir"] = ocidir.New(rc.ocidirOpts...)
 
 	rc.slog.Debug("regclient initialized",
 		slog.String("VCSRef", info.VCSRef),
@@ -170,6 +173,16 @@ func WithDockerCredsFile(fname string) Opt {
 			return
 		}
 		rc.hostLoad("docker-file", configHosts)
+	}
+}
+
+// WithOCIDirOpts passes through opts to the ocidir scheme.
+func WithOCIDirOpts(opts ...ocidir.Opts) Opt {
+	return func(rc *RegClient) {
+		if len(opts) == 0 {
+			return
+		}
+		rc.ocidirOpts = append(rc.ocidirOpts, opts...)
 	}
 }
 

--- a/scheme/ocidir/manifest.go
+++ b/scheme/ocidir/manifest.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/opencontainers/go-digest"
 
+	"github.com/regclient/regclient/internal/limitread"
 	"github.com/regclient/regclient/scheme"
 	"github.com/regclient/regclient/types"
 	"github.com/regclient/regclient/types/errs"
@@ -116,6 +117,9 @@ func (o *OCIDir) manifestGet(_ context.Context, r ref.Ref) (manifest.Manifest, e
 			return nil, err
 		}
 	}
+	if desc.Size > o.manifestMaxPull {
+		return nil, fmt.Errorf("manifest exceeds size limit, ref: %s, limit: %d, size: %d%.0w", r.CommonName(), o.manifestMaxPull, desc.Size, errs.ErrSizeLimitExceeded)
+	}
 	if desc.Digest == "" {
 		return nil, errs.ErrNotFound
 	}
@@ -129,7 +133,11 @@ func (o *OCIDir) manifestGet(_ context.Context, r ref.Ref) (manifest.Manifest, e
 		return nil, fmt.Errorf("failed to open manifest: %w", err)
 	}
 	defer fd.Close()
-	mb, err := io.ReadAll(fd)
+	limit := desc.Size
+	if desc.Size == 0 {
+		limit = o.manifestMaxPull
+	}
+	mb, err := io.ReadAll(&limitread.LimitRead{Reader: fd, Limit: limit})
 	if err != nil {
 		return nil, fmt.Errorf("failed to read manifest: %w", err)
 	}

--- a/scheme/ocidir/manifest_test.go
+++ b/scheme/ocidir/manifest_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"os"
 	"path"
@@ -13,6 +14,7 @@ import (
 	"github.com/opencontainers/go-digest"
 
 	"github.com/regclient/regclient/internal/copyfs"
+	"github.com/regclient/regclient/types/errs"
 	"github.com/regclient/regclient/types/manifest"
 	"github.com/regclient/regclient/types/mediatype"
 	v1 "github.com/regclient/regclient/types/oci/v1"
@@ -234,5 +236,19 @@ func TestManifest(t *testing.T) {
 	_, err = o.ManifestHead(ctx, r11)
 	if err != nil {
 		t.Errorf("could not query manifest after pushing dup tag")
+	}
+	err = o.Close(ctx, r11)
+	if err != nil {
+		t.Errorf("failed closing: %v", err)
+	}
+	// test manifest limits
+	o = New(WithManifestMax(16, 32))
+	_, err = o.ManifestGet(ctx, r11)
+	if !errors.Is(err, errs.ErrSizeLimitExceeded) {
+		t.Errorf("manifest pull limit expected err: %v, received: %v", errs.ErrSizeLimitExceeded, err)
+	}
+	err = o.Close(ctx, r11)
+	if err != nil {
+		t.Errorf("failed closing: %v", err)
 	}
 }

--- a/scheme/ocidir/ocidir.go
+++ b/scheme/ocidir/ocidir.go
@@ -29,16 +29,22 @@ import (
 const (
 	imageLayoutFile = "oci-layout"
 	defThrottle     = 3
+	// defaultManifestMaxPull limits the largest manifest that will be pulled
+	defaultManifestMaxPull = 1024 * 1024 * 8
+	// defaultManifestMaxPush limits the largest manifest that will be pushed
+	defaultManifestMaxPush = 1024 * 1024 * 4
 )
 
 // OCIDir is used for accessing OCI Image Layouts defined as a directory
 type OCIDir struct {
-	slog        *slog.Logger
-	gc          bool
-	modRefs     map[string]*ociGC
-	throttle    map[string]*pqueue.Queue[reqmeta.Data]
-	throttleDef int
-	mu          sync.Mutex
+	slog            *slog.Logger
+	gc              bool
+	manifestMaxPull int64
+	manifestMaxPush int64
+	modRefs         map[string]*ociGC
+	throttle        map[string]*pqueue.Queue[reqmeta.Data]
+	throttleDef     int
+	mu              sync.Mutex
 }
 
 type ociGC struct {
@@ -47,9 +53,11 @@ type ociGC struct {
 }
 
 type ociConf struct {
-	gc       bool
-	slog     *slog.Logger
-	throttle int
+	gc              bool
+	manifestMaxPull int64
+	manifestMaxPush int64
+	slog            *slog.Logger
+	throttle        int
 }
 
 // Opts are used for passing options to ocidir
@@ -58,19 +66,23 @@ type Opts func(*ociConf)
 // New creates a new OCIDir with options
 func New(opts ...Opts) *OCIDir {
 	conf := ociConf{
-		slog:     slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{})),
-		gc:       true,
-		throttle: defThrottle,
+		slog:            slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{})),
+		gc:              true,
+		manifestMaxPull: defaultManifestMaxPull,
+		manifestMaxPush: defaultManifestMaxPush,
+		throttle:        defThrottle,
 	}
 	for _, opt := range opts {
 		opt(&conf)
 	}
 	return &OCIDir{
-		slog:        conf.slog,
-		gc:          conf.gc,
-		modRefs:     map[string]*ociGC{},
-		throttle:    map[string]*pqueue.Queue[reqmeta.Data]{},
-		throttleDef: conf.throttle,
+		slog:            conf.slog,
+		gc:              conf.gc,
+		manifestMaxPull: conf.manifestMaxPull,
+		manifestMaxPush: conf.manifestMaxPush,
+		modRefs:         map[string]*ociGC{},
+		throttle:        map[string]*pqueue.Queue[reqmeta.Data]{},
+		throttleDef:     conf.throttle,
 	}
 }
 
@@ -79,6 +91,14 @@ func New(opts ...Opts) *OCIDir {
 func WithGC(gc bool) Opts {
 	return func(c *ociConf) {
 		c.gc = gc
+	}
+}
+
+// WithManifestMax sets the push and pull limits for manifests
+func WithManifestMax(push, pull int64) Opts {
+	return func(c *ociConf) {
+		c.manifestMaxPush = push
+		c.manifestMaxPull = pull
 	}
 }
 
@@ -194,11 +214,7 @@ func (o *OCIDir) readIndex(r ref.Ref, locked bool) (v1.Index, error) {
 		return index, fmt.Errorf("%s cannot be open: %w", indexFile, err)
 	}
 	defer fh.Close()
-	ib, err := io.ReadAll(fh)
-	if err != nil {
-		return index, fmt.Errorf("%s cannot be read: %w", indexFile, err)
-	}
-	err = json.Unmarshal(ib, &index)
+	err = json.NewDecoder(fh).Decode(&index)
 	if err != nil {
 		return index, fmt.Errorf("%s cannot be parsed: %w", indexFile, err)
 	}
@@ -304,11 +320,7 @@ func (o *OCIDir) valid(dir string, locked bool) error {
 		return fmt.Errorf("%s cannot be open: %w", imageLayoutFile, err)
 	}
 	defer fh.Close()
-	lb, err := io.ReadAll(fh)
-	if err != nil {
-		return fmt.Errorf("%s cannot be read: %w", imageLayoutFile, err)
-	}
-	err = json.Unmarshal(lb, &layout)
+	err = json.NewDecoder(fh).Decode(&layout)
 	if err != nil {
 		return fmt.Errorf("%s cannot be parsed: %w", imageLayoutFile, err)
 	}


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Some `io.ReadAll` calls can be changed to parse directly into JSON, or they can be limited. This reduces possible memory exhaustion risks. The limits added to the ocidir manifest size match those of the registry manifest size.

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
make test
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Fix: Add limits and controls to ReadAll.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation updates are included or not applicable (most documentation should be in the regclient.org repo)
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
- [X] All changes have been human generated or created with a reproducible tool

<!-- markdownlint-disable-file MD041 -->
