### PR TITLE
feat: add ipAddr host option to override the dialed IP

### DIFF
--- a/cmd/regctl/registry.go
+++ b/cmd/regctl/registry.go
@@ -28,6 +28,7 @@ type registryOpts struct {
 	passStdin            bool
 	credHelper           string
 	hostname, pathPrefix string
+	ipAddr               string
 	cacert, tls          string // set opts
 	clientCert           string
 	clientKey            string
@@ -178,6 +179,8 @@ regctl registry set quay.io --req-per-sec 10`,
 	cmd.Flags().StringVar(&opts.credHelper, "cred-helper", "", "Credential helper (full binary name, including docker-credential- prefix)")
 	cmd.Flags().StringVar(&opts.hostname, "hostname", "", "Hostname or ip with port")
 	_ = cmd.RegisterFlagCompletionFunc("hostname", completeArgNone)
+	cmd.Flags().StringVar(&opts.ipAddr, "ip", "", "Override IP to dial, hostname is still used for TLS SNI, Host header, and cert validation")
+	_ = cmd.RegisterFlagCompletionFunc("ip", completeArgNone)
 	cmd.Flags().StringArrayVar(&opts.mirrors, "mirror", nil, "List of mirrors (registry names)")
 	_ = cmd.RegisterFlagCompletionFunc("mirror", completeArgNone)
 	cmd.Flags().StringVar(&opts.pathPrefix, "path-prefix", "", "Prefix to all repositories")
@@ -463,6 +466,9 @@ func (opts *registryOpts) runRegistrySet(cmd *cobra.Command, args []string) erro
 	}
 	if flagChanged(cmd, "hostname") {
 		h.Hostname = opts.hostname
+	}
+	if flagChanged(cmd, "ip") {
+		h.IPAddr = opts.ipAddr
 	}
 	if flagChanged(cmd, "path-prefix") {
 		h.PathPrefix = opts.pathPrefix

--- a/cmd/regctl/registry_test.go
+++ b/cmd/regctl/registry_test.go
@@ -44,6 +44,7 @@ func TestRegistry(t *testing.T) {
 		_ = regHandler.Close()
 	})
 	tsExampleHost := "registry.example.org"
+	tsIPHost := "ipoverride.example.org"
 	tempDir := t.TempDir()
 	t.Setenv(ConfigEnv, filepath.Join(tempDir, "config.json"))
 	tt := []struct {
@@ -88,6 +89,24 @@ func TestRegistry(t *testing.T) {
 			args:        []string{"registry", "set", tsExampleHost, "--cred-helper", "", "--skip-check"},
 			expectOut:   "",
 			outContains: false,
+		},
+		// set and query an IP override
+		{
+			name:        "set ip override",
+			args:        []string{"registry", "set", tsIPHost, "--ip", "10.0.0.1:443", "--skip-check"},
+			expectOut:   "",
+			outContains: false,
+		},
+		{
+			name:        "query ip override",
+			args:        []string{"registry", "config", tsIPHost},
+			expectOut:   `"ipAddr": "10.0.0.1:443",`,
+			outContains: true,
+		},
+		{
+			name:      "query ip override format",
+			args:      []string{"registry", "config", tsIPHost, "--format", "{{.IPAddr}}"},
+			expectOut: `10.0.0.1:443`,
 		},
 		// query the config change
 		{

--- a/cmd/regctl/root.go
+++ b/cmd/regctl/root.go
@@ -200,9 +200,11 @@ func (opts *rootOpts) newRegClient() *regclient.RegClient {
 				slog.String("err", err.Error()))
 		}
 		host := config.Host{
-			Name: hKV["reg"],
-			User: hKV["user"],
-			Pass: hKV["pass"],
+			Name:     hKV["reg"],
+			Hostname: hKV["hostname"],
+			IPAddr:   hKV["ip"],
+			User:     hKV["user"],
+			Pass:     hKV["pass"],
 		}
 		if hKV["tls"] != "" {
 			var hostTLS config.TLSConf

--- a/config/host.go
+++ b/config/host.go
@@ -106,6 +106,7 @@ type Host struct {
 	ClientCert    string            `json:"clientCert,omitempty" yaml:"clientCert"`       // public pem cert for client (mTLS)
 	ClientKey     string            `json:"clientKey,omitempty" yaml:"clientKey"`         //#nosec G117 private pem cert for client (mTLS)
 	Hostname      string            `json:"hostname,omitempty" yaml:"hostname"`           // hostname of registry, default is the registry name
+	IPAddr        string            `json:"ipAddr,omitempty" yaml:"ipAddr"`               // override IP to dial, hostname is still used for TLS SNI, Host header, and cert validation
 	User          string            `json:"user,omitempty" yaml:"user"`                   // username, not used with credHelper
 	Pass          string            `json:"pass,omitempty" yaml:"pass"`                   //#nosec G117 password, not used with credHelper
 	Token         string            `json:"token,omitempty" yaml:"token"`                 // token, experimental for specific APIs
@@ -238,6 +239,7 @@ func (host Host) IsZero() bool {
 		host.ClientCert != "" ||
 		host.ClientKey != "" ||
 		(host.Hostname != "" && host.Hostname != host.Name) ||
+		host.IPAddr != "" ||
 		host.User != "" ||
 		host.Pass != "" ||
 		host.Token != "" ||
@@ -391,6 +393,16 @@ func (host *Host) Merge(newHost Host, log *slog.Logger) error {
 				slog.String("host", name))
 		}
 		host.Hostname = newHost.Hostname
+	}
+
+	if newHost.IPAddr != "" {
+		if host.IPAddr != "" && host.IPAddr != newHost.IPAddr {
+			log.Warn("Changing IP address settings for registry",
+				slog.String("orig", host.IPAddr),
+				slog.String("new", newHost.IPAddr),
+				slog.String("host", name))
+		}
+		host.IPAddr = newHost.IPAddr
 	}
 
 	if newHost.PathPrefix != "" {

--- a/config/host_test.go
+++ b/config/host_test.go
@@ -126,6 +126,7 @@ func TestConfig(t *testing.T) {
 	{
 	  "tls": "disabled",
 		"hostname": "host2.example.com",
+		"ipAddr": "192.0.2.10:443",
 		"user": "user-ex3",
 		"pass": "secret3",
 		"regcert": "` + strings.ReplaceAll(caCert, "\n", "\\n") + `",
@@ -288,6 +289,7 @@ func TestConfig(t *testing.T) {
 			hostExpect: Host{
 				TLS:        TLSDisabled,
 				Hostname:   "host2.example.com",
+				IPAddr:     "192.0.2.10:443",
 				User:       "user-ex3",
 				Pass:       "secret3",
 				RegCert:    caCert,
@@ -346,6 +348,7 @@ func TestConfig(t *testing.T) {
 			hostExpect: Host{
 				TLS:        TLSDisabled,
 				Hostname:   "host2.example.com",
+				IPAddr:     "192.0.2.10:443",
 				User:       "user-ex3",
 				Pass:       "secret3",
 				RegCert:    caCert,
@@ -442,6 +445,9 @@ func TestConfig(t *testing.T) {
 			}
 			if tc.host.Hostname != tc.hostExpect.Hostname {
 				t.Errorf("hostname field mismatch, expected %s, found %s", tc.hostExpect.Hostname, tc.host.Hostname)
+			}
+			if tc.host.IPAddr != tc.hostExpect.IPAddr {
+				t.Errorf("ipAddr field mismatch, expected %s, found %s", tc.hostExpect.IPAddr, tc.host.IPAddr)
 			}
 			if tc.host.User != tc.hostExpect.User {
 				t.Errorf("user field mismatch, expected %s, found %s", tc.hostExpect.User, tc.host.User)

--- a/internal/reghttp/http.go
+++ b/internal/reghttp/http.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -755,6 +756,28 @@ func (c *Client) getHost(host string) *clientHost {
 	h.httpClient = &hc
 	if h.httpClient.Transport == nil {
 		h.httpClient.Transport = http.DefaultTransport.(*http.Transport).Clone()
+	}
+	// override the dialed IP while leaving the hostname (TLS SNI, Host header, and cert validation) unchanged
+	if h.config.IPAddr != "" {
+		if t, ok := h.httpClient.Transport.(*http.Transport); ok {
+			t = t.Clone()
+			ipAddr := h.config.IPAddr
+			origDial := t.DialContext
+			if origDial == nil {
+				origDial = (&net.Dialer{}).DialContext
+			}
+			t.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+				if _, port, err := net.SplitHostPort(addr); err == nil {
+					if _, _, errIP := net.SplitHostPort(ipAddr); errIP == nil {
+						addr = ipAddr // override includes its own port
+					} else {
+						addr = net.JoinHostPort(ipAddr, port)
+					}
+				}
+				return origDial(ctx, network, addr)
+			}
+			h.httpClient.Transport = t
+		}
 	}
 	// configure transport for insecure requests and root certs
 	if h.config.TLS == config.TLSInsecure || len(c.rootCAPool) > 0 || len(c.rootCADirs) > 0 || h.config.RegCert != "" || (h.config.ClientCert != "" && h.config.ClientKey != "") {

--- a/internal/reghttp/http_test.go
+++ b/internal/reghttp/http_test.go
@@ -934,6 +934,12 @@ func TestRegHttp(t *testing.T) {
 			Hostname: "external-host.example.org",
 			TLS:      config.TLSDisabled,
 		},
+		"ipaddr." + tsHost: {
+			Name:     "ipaddr." + tsHost,
+			Hostname: "ipaddr-unresolvable.example.org",
+			IPAddr:   tsHost,
+			TLS:      config.TLSDisabled,
+		},
 	}
 
 	// create APIs for requests to run
@@ -965,6 +971,33 @@ func TestRegHttp(t *testing.T) {
 	t.Run("Get", func(t *testing.T) {
 		getReq := &Req{
 			Host:       tsHost,
+			Method:     "GET",
+			Repository: "project",
+			Path:       "manifests/tag-get",
+			Headers:    headers,
+		}
+		resp, err := hc.Do(ctx, getReq)
+		if err != nil {
+			t.Fatalf("failed to run get: %v", err)
+		}
+		if resp.HTTPResponse().StatusCode != 200 {
+			t.Errorf("invalid status code, expected 200, received %d", resp.HTTPResponse().StatusCode)
+		}
+		body, err := io.ReadAll(resp)
+		if err != nil {
+			t.Fatalf("body read failure: %v", err)
+		} else if !bytes.Equal(body, getBody) {
+			t.Errorf("body read mismatch, expected %s, received %s", getBody, body)
+		}
+		err = resp.Close()
+		if err != nil {
+			t.Errorf("error closing request: %v", err)
+		}
+	})
+	// test IPAddr override: hostname is unresolvable but the dialed IP points to the test server
+	t.Run("IPAddr", func(t *testing.T) {
+		getReq := &Req{
+			Host:       "ipaddr." + tsHost,
 			Method:     "GET",
 			Repository: "project",
 			Path:       "manifests/tag-get",


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

N/A — new feature.

### Describe the change

Type of change: **new feature**.

Adds a per-host `ipAddr` configuration option that overrides the IP address regclient dials, while leaving the hostname unchanged for TLS SNI, the `Host` header, and certificate validation.

This solves the case where a registry's DNS name resolves to different IPs depending on region (or where you otherwise need to pin a specific endpoint) without resorting to `/etc/hosts` edits. The existing `hostname` override is unsuitable for this because it changes the request URL host, which makes Go derive the TLS SNI from that value — and for an IP literal Go omits SNI entirely, breaking SNI-routed registries (e.g. Azure Container Registry).

`ipAddr` only rewrites the TCP dial target via a custom `DialContext`; the URL host (and therefore SNI, `Host` header, and cert verification) stays the registry name.

Implementation:
- `config`: new `Host.IPAddr` field (`ipAddr` in JSON/YAML), wired through `Merge` and `IsZero`.
- `internal/reghttp`: when `IPAddr` is set, clone the transport and wrap `DialContext` to rewrite the dial address to the configured IP (keeps the original port when the override omits one).
- `regctl`: new `--ip` flag on `registry set`, and an `ip=` key for the inline `--host` flag.

### How to verify it

```
# persisted
regctl registry set registry.example.com --ip 10.1.2.3:443

# one-off, no config/etc-hosts changes
regctl --host "reg=registry.example.com,ip=10.1.2.3:443,tls=enabled" \
  manifest get registry.example.com/repo:tag
```

Automated tests:
- `config`: `TestConfig` extended to cover the `IPAddr` field through parse/merge/compare.
- `internal/reghttp`: new `IPAddr` subtest — an unresolvable hostname with `IPAddr` pointed at the test server confirms the dial override is applied.
- `regctl`: `TestRegistry` cases for `registry set --ip`, `registry config` output, and `--format {{.IPAddr}}`.

### Changelog text

Add `ipAddr` host option to override the dialed IP without changing the hostname used for TLS SNI, `Host` header, and certificate validation.

### Please verify and check that the pull request fulfills the following requirements

- [x] Tests have been added or not applicable
- [ ] Documentation updates are included or not applicable (most documentation should be in the regclient.org repo)
- [x] Changes have been rebased to main
- [x] Multiple commits to the same code have been squashed
- [x] All changes have been human generated or created with a reproducible tool

<!-- markdownlint-disable-file MD041 -->
