### PR TITLE
Fix: Skip local check on requests going through a proxy

### DIFF
--- a/internal/regnet/regnet.go
+++ b/internal/regnet/regnet.go
@@ -4,6 +4,7 @@ package regnet
 import (
 	"fmt"
 	"net"
+	"net/http"
 	"net/url"
 
 	"github.com/regclient/regclient/types/errs"
@@ -20,6 +21,10 @@ func AllowRedirect(src, dest url.URL) error {
 }
 
 func IsLocal(hostPort string) bool {
+	// skip check on any requests going through a proxy, ProxyFromEnv assumes http, and localhost is unlikely to have an https cert
+	if u, err := http.ProxyFromEnvironment(&http.Request{URL: &url.URL{Host: hostPort}}); err == nil && u != nil {
+		return false
+	}
 	// strip trailing port
 	host, _, err := net.SplitHostPort(hostPort)
 	if err != nil {

--- a/internal/regnet/regnet_test.go
+++ b/internal/regnet/regnet_test.go
@@ -59,6 +59,7 @@ func urlMustParse(t *testing.T, s string) url.URL {
 func TestIsLocal(t *testing.T) {
 	tt := []struct {
 		host   string
+		proxy  bool
 		expect bool
 	}{
 		{
@@ -89,9 +90,26 @@ func TestIsLocal(t *testing.T) {
 			host:   "regclient.org",
 			expect: false,
 		},
+		{
+			host:   "regclient.org",
+			expect: false,
+			proxy:  true,
+		},
 	}
 	for _, tc := range tt {
 		t.Run(tc.host, func(t *testing.T) {
+			// caution, proxy variables are only read once on startup, resulting in false positive and negatives from this test
+			if tc.proxy {
+				t.Setenv("HTTP_PROXY", "http://proxy.example.org:5555")
+				t.Setenv("HTTPS_PROXY", "http://proxy.example.org:5555")
+				t.Setenv("NO_PROXY", ".internal.example.org")
+			} else {
+				t.Setenv("HTTP_PROXY", "")
+				t.Setenv("http_proxy", "")
+				t.Setenv("HTTPS_PROXY", "")
+				t.Setenv("https_proxy", "")
+				t.Setenv("NO_PROXY", "")
+			}
 			result := IsLocal(tc.host)
 			if result != tc.expect {
 				t.Errorf("expected %t, received %t", tc.expect, result)


### PR DESCRIPTION

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Fixes #1097.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Skip local check on requests going through a proxy. Requests going through a proxy aren't local, and this can result in unnecessary DNS lookups.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
make test
```

Unfortunately since proxy environment variables are only parsed once, tests that change these values do not have the desired effect.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Fix: Skip local check on requests going through a proxy.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation updates are included or not applicable (most documentation should be in the regclient.org repo)
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
- [X] All changes have been human generated or created with a reproducible tool

<!-- markdownlint-disable-file MD041 -->
