### PR TITLE
Fix: URLs passed to ProxyFromEnvironment require a scheme

### DIFF
--- a/internal/regnet/regnet.go
+++ b/internal/regnet/regnet.go
@@ -35,8 +35,8 @@ func AllowRedirect(src, dest url.URL) error {
 }
 
 func IsLocal(hostPort string) bool {
-	// skip check on any requests going through a proxy, ProxyFromEnv assumes http, and localhost is unlikely to have an https cert
-	if u, err := http.ProxyFromEnvironment(&http.Request{URL: &url.URL{Host: hostPort}}); err == nil && u != nil {
+	// skip check on any requests going through a proxy
+	if u, err := http.ProxyFromEnvironment(&http.Request{URL: &url.URL{Scheme: "https", Host: hostPort}}); err == nil && u != nil {
 		return false
 	}
 	// strip trailing port


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

URLs passed to ProxyFromEnvironment require a scheme. I previously misread the Go docs on the function which described that the proxy env variables assume the scheme, not the the passed URL.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

I debugged the specific test for this, moving the test case to be the first in the list so the proxy variables would be set on the first pass. In that scenario, the `ProxyFromEnvironment` check did the quick return.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Fix: URLs passed to ProxyFromEnvironment require a scheme.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation updates are included or not applicable (most documentation should be in the regclient.org repo)
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
- [X] All changes have been human generated or created with a reproducible tool

<!-- markdownlint-disable-file MD041 -->
