### PR TITLE
Fix: Avoid a panic if http.DefaultTransport is altered

### DIFF
--- a/internal/reghttp/http.go
+++ b/internal/reghttp/http.go
@@ -768,12 +768,15 @@ func (c *Client) getHost(host string) *clientHost {
 	hc := *c.httpClient
 	h.httpClient = &hc
 	if h.httpClient.Transport == nil {
-		h.httpClient.Transport = http.DefaultTransport.(*http.Transport).Clone()
+		if t, ok := http.DefaultTransport.(*http.Transport); ok {
+			h.httpClient.Transport = t.Clone()
+		} else {
+			h.httpClient.Transport = http.DefaultTransport
+		}
 	}
 	// configure transport for insecure requests and root certs
 	if h.config.TLS == config.TLSInsecure || len(c.rootCAPool) > 0 || len(c.rootCADirs) > 0 || h.config.RegCert != "" || (h.config.ClientCert != "" && h.config.ClientKey != "") {
-		t, ok := h.httpClient.Transport.(*http.Transport)
-		if ok {
+		if t, ok := h.httpClient.Transport.(*http.Transport); ok {
 			var tlsc *tls.Config
 			if t.TLSClientConfig != nil {
 				tlsc = t.TLSClientConfig.Clone()


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Fix untested for #1108.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This avoids panicking if the `http.DefaultTransport` has been altered.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

See linked issue. Tests were not added since they would be rather complicated (implementing the RoundTripper interface) for an unusual use case.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Fix: Avoid a panic if http.DefaultTransport is altered.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [ ] Tests have been added or not applicable
- [X] Documentation updates are included or not applicable (most documentation should be in the regclient.org repo)
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
- [X] All changes have been human generated or created with a reproducible tool

<!-- markdownlint-disable-file MD041 -->
