### PR TITLE
Fix: Handle docker schema v1  with ocidir

### DIFF
--- a/cmd/regctl/image.go
+++ b/cmd/regctl/image.go
@@ -1323,7 +1323,10 @@ func (ip *imageProgress) display(final bool) {
 				if len(pre) > 15 {
 					pre = pre[:14] + " "
 				}
-				pct := float64(e.cur) / float64(e.total)
+				var pct float64
+				if e.total > 0 {
+					pct = float64(e.cur) / float64(e.total)
+				}
 				post := fmt.Sprintf(" %4.2f%% %s/%s", pct*100, units.HumanSize(float64(e.cur)), units.HumanSize(float64(e.total)))
 				ip.asciiOut.Add(ip.bar.Generate(pct, pre, post))
 			}

--- a/internal/ascii/progress.go
+++ b/internal/ascii/progress.go
@@ -53,16 +53,11 @@ func NewProgressBar(w io.Writer) *ProgressBar {
 }
 
 func (p *ProgressBar) Generate(pct float64, pre, post string) []byte {
-	if pct < 0 {
-		pct = 0
-	} else if pct > 1 {
-		pct = 1
-	}
 	curWidth := p.Width - (len(pre) + len(post) + 2)
 	curWidth = min(max(curWidth, p.Min), p.Max)
 	buf := make([]byte, curWidth)
 
-	doneLen := int(float64(curWidth) * pct)
+	doneLen := min(max(int(float64(curWidth)*pct), 0), curWidth)
 	for i := range doneLen {
 		buf[i] = p.Done
 	}

--- a/scheme/ocidir/manifest.go
+++ b/scheme/ocidir/manifest.go
@@ -148,7 +148,7 @@ func (o *OCIDir) manifestGet(_ context.Context, r ref.Ref) (manifest.Manifest, e
 	}
 	defer fd.Close()
 	limit := desc.Size
-	if desc.Size == 0 {
+	if desc.Size <= 0 || desc.MediaType == mediatype.Docker1Manifest || desc.MediaType == mediatype.Docker1ManifestSigned {
 		limit = o.manifestMaxPull
 	}
 	mb, err := io.ReadAll(&limitread.LimitRead{Reader: fd, Limit: limit})


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

```shell
$ regctl image copy debian:6 ocidir://examples:debian-6-schema-v1
panic: runtime error: index out of range [-9223372036854775808]

goroutine 11 [running]:
github.com/regclient/regclient/internal/ascii.(*ProgressBar).Generate(0x354ee30fe60, 0xe?, {0x354ee0be240, 0xf}, {0x354ee3a60c0, 0x14})
        github.com/regclient/regclient/internal/ascii/progress.go:70 +0x245
main.(*imageProgress).display(0x354edf75a00, 0x0)
        github.com/regclient/regclient/cmd/regctl/image.go:1328 +0x6d2
main.(*imageOpts).runImageCopy.func1()
        github.com/regclient/regclient/cmd/regctl/image.go:1209 +0x3b
created by main.(*imageOpts).runImageCopy in goroutine 1
        github.com/regclient/regclient/cmd/regctl/image.go:1202 +0x16d9

$ regctl manifest get ocidir://examples:debian-6-schema-v1
failed to read manifest: read limit exceeded
```

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Some features don't work when the descriptor size is 0 or the descriptor size value does not match the underlying byte size. This adds a couple exceptions needed for schema v1, but it does not add tests since those would require creating a schema v1 image in the testdata, which is no longer supported by build tools.

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
regctl image copy debian:6 ocidir://examples:debian-6-schema-v1
regctl manifest get ocidir://examples:debian-6-schema-v1
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Fix: Handle docker schema v1  with ocidir.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [ ] Tests have been added or not applicable
- [X] Documentation updates are included or not applicable (most documentation should be in the regclient.org repo)
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
- [X] All changes have been human generated or created with a reproducible tool

<!-- markdownlint-disable-file MD041 -->
